### PR TITLE
Establish archive convention for historical docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,13 @@ implementation cannot quietly disagree about ordering or idempotency.
 The in-memory store is the only backend, so nothing survives a restart. A durable,
 queryable backend is the next piece of work — see the issue tracker.
 
+## Archive
+
+Historical and superseded documentation lives in [`archive/`](archive/). Its
+contents are past decisions, plans, or state — not the current design.
+Don't use anything under `archive/` to understand this project as it is
+today or to guide new work; use this README and the code instead.
+
 ## License
 
 MIT

--- a/archive/README.md
+++ b/archive/README.md
@@ -1,0 +1,14 @@
+# Archive
+
+This folder holds historical and superseded documentation and records for
+run-ledger: notes, plans, and write-ups that described the project at some
+point in the past but no longer reflect how it works or where it's headed.
+
+Nothing in here should be used to understand the current state of the
+project, and nothing in here should guide new work. Content is kept only as
+a record of past decisions, plans, or state — it may be incomplete, wrong
+about the present, or describe approaches that were later abandoned.
+
+Contributors and coding agents: treat everything under `archive/` as
+historical context only, never as current truth. For the current state of
+the project, see the top-level `README.md` and the code itself.


### PR DESCRIPTION
## Summary

Sets up a convention for storing historical/superseded documentation so it doesn't get confused with current project state, as part of a batch rollout across multiple repos.

**(a) Archive location:** `archive/` at the repo root. A top-level `docs/` directory exists but is empty (no markdown docs live there), so per the convention the archive lives at `archive/` rather than `docs/archive/`.

**(b) Docs updated:** Only `README.md` — this repo has no `CLAUDE.md` or `AGENTS.md` at the root, so those were left untouched (not created). Added a short "Archive" section pointing to `archive/` and noting its contents are historical only.

**(c) Files moved into archive:** None. I reviewed the root `README.md` (the only existing documentation file) and found nothing unambiguously historical or superseded — it accurately describes the current design and status of the project. Being conservative, nothing was moved.

**(d) Nothing was moved** — see (c).

## Test plan

- [x] `archive/README.md` explains the folder's purpose and warns against treating its contents as current
- [x] `README.md` links to `archive/` with a clear "historical only" caveat
- [x] No existing files altered in content beyond the new README section

🤖 Generated with [Claude Code](https://claude.com/claude-code)