### PR TITLE
test(store): cover concurrent Record of the same run id

### DIFF
--- a/internal/store/conformance.go
+++ b/internal/store/conformance.go
@@ -3,6 +3,8 @@ package store
 import (
 	"context"
 	"errors"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -103,6 +105,150 @@ func RunConformance(t *testing.T, newStore func(t *testing.T) Store) {
 		}
 		if len(got) != 1 || got[0].RunID != "a" {
 			t.Fatalf("project filter did not narrow: %+v", got)
+		}
+	})
+
+	t.Run("concurrent identical Record calls are idempotent", func(t *testing.T) {
+		s := newStore(t)
+		r := mk("a", "p", time.Now())
+		const n = 64
+		var wg sync.WaitGroup
+		errs := make([]error, n)
+		for i := 0; i < n; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				// Every goroutine records the exact same value, so a correct
+				// backend must accept all of them as the same content.
+				errs[i] = s.Record(ctx, r)
+			}(i)
+		}
+		wg.Wait()
+		for i, err := range errs {
+			if err != nil {
+				t.Fatalf("goroutine %d: re-recording identical content concurrently should succeed, got %v", i, err)
+			}
+		}
+		got, err := s.List(ctx, Query{Project: "p"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) != 1 {
+			t.Fatalf("want exactly one row after %d concurrent identical writes, got %d: %+v", n, len(got), got)
+		}
+	})
+
+	t.Run("concurrent conflicting Record calls yield exactly one winner", func(t *testing.T) {
+		s := newStore(t)
+		const n = 64
+		var wg sync.WaitGroup
+		errs := make([]error, n)
+		for i := 0; i < n; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				r := mk("a", "p", time.Now())
+				// Every goroutine records different content under the same
+				// run id, so at most one write may win.
+				r.Seed = int64(i)
+				r.Fingerprint = r.Compute()
+				errs[i] = s.Record(ctx, r)
+			}(i)
+		}
+		wg.Wait()
+
+		var successes, conflicts int
+		for i, err := range errs {
+			switch {
+			case err == nil:
+				successes++
+			case errors.Is(err, ErrConflict):
+				conflicts++
+			default:
+				t.Fatalf("goroutine %d: want nil or ErrConflict, got %v", i, err)
+			}
+		}
+		if successes != 1 {
+			t.Fatalf("want exactly one goroutine to win, got %d successes and %d conflicts", successes, conflicts)
+		}
+		if conflicts != n-1 {
+			t.Fatalf("want %d conflicts, got %d", n-1, conflicts)
+		}
+		if _, err := s.Get(ctx, "a"); err != nil {
+			t.Fatalf("the winning write should be readable, got %v", err)
+		}
+		got, err := s.List(ctx, Query{Project: "p"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) != 1 {
+			t.Fatalf("want exactly one row after %d concurrent conflicting writes, got %d: %+v", n, len(got), got)
+		}
+	})
+
+	t.Run("List never observes a partially-written run during concurrent Record", func(t *testing.T) {
+		s := newStore(t)
+		const n = 64
+		stop := make(chan struct{})
+		violations := make(chan error, n)
+
+		var readers sync.WaitGroup
+		readers.Add(1)
+		go func() {
+			defer readers.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				got, err := s.List(ctx, Query{Project: "p"})
+				if err != nil {
+					violations <- fmt.Errorf("List returned an error during concurrent writes: %w", err)
+					return
+				}
+				for _, r := range got {
+					// A torn write would show up here as a run missing the
+					// fields Record is required to have set together, or as
+					// a run whose provenance doesn't match its identity.
+					if err := r.Validate(); err != nil {
+						violations <- fmt.Errorf("List observed an incomplete run %q: %v", r.RunID, err)
+						return
+					}
+					if r.GitCommit != "c"+r.RunID || r.ConfigHash != "cfg" || r.Fingerprint == "" {
+						violations <- fmt.Errorf("List observed a run %q with mismatched fields: %+v", r.RunID, r)
+						return
+					}
+				}
+			}
+		}()
+
+		var writers sync.WaitGroup
+		for i := 0; i < n; i++ {
+			writers.Add(1)
+			go func(i int) {
+				defer writers.Done()
+				id := fmt.Sprintf("run-%d", i)
+				if err := s.Record(ctx, mk(id, "p", time.Now())); err != nil {
+					violations <- fmt.Errorf("record %q: %w", id, err)
+				}
+			}(i)
+		}
+		writers.Wait()
+		close(stop)
+		readers.Wait()
+		close(violations)
+
+		for err := range violations {
+			t.Fatal(err)
+		}
+
+		got, err := s.List(ctx, Query{Project: "p"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) != n {
+			t.Fatalf("want %d runs after concurrent writes, got %d", n, len(got))
 		}
 	})
 


### PR DESCRIPTION
Closes #7

Adds three concurrency cases to `RunConformance` so every backend (including a future SQL-backed one) inherits them, run under `-race` via the existing `make test`:

- **Identical concurrent writes are idempotent**: N goroutines calling `Record` with the exact same content under one run id all succeed, and exactly one row exists afterward.
- **Conflicting concurrent writes have exactly one winner**: N goroutines calling `Record` with different content under the same run id — exactly one succeeds, the rest return `ErrConflict`. No partial write, no last-writer-wins overwrite.
- **Concurrent Record/List never exposes a torn write**: while N goroutines record distinct runs into the same project, a concurrent reader loop calls `List` and asserts every returned run passes `Validate()` and has fields consistent with what `Record` wrote (catches a SQL backend that inserts a row before all its columns are committed).

`Memory` already passes all three (its `Record` holds the mutex across the whole read-check-write), which is exactly the behavior this locks in for future backends.

Verified locally with `go test -race ./...` (all packages pass) and `gofmt -l .` / `go vet ./...` clean.