### PR TITLE
docs: add ADRs for the four sharpest design decisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,14 +98,19 @@ implementation cannot quietly disagree about ordering or idempotency.
 
 ## Decisions worth knowing
 
+This is a summary. The full reasoning — context, consequences, and what would
+have to be true to revisit each one — lives in [`docs/adr/`](docs/adr/).
+
 - **The server computes the fingerprint, never the client.** A caller that could
   assert its own fingerprint could claim two different experiments were the same
-  run.
+  run. ([ADR 0001](docs/adr/0001-server-computes-the-fingerprint.md))
 - **Unknown JSON fields are rejected.** A typo'd field name in a lineage record
   would otherwise store a run that claims to describe an experiment it does not.
+  ([ADR 0002](docs/adr/0002-unknown-json-fields-are-rejected.md))
 - **A dirty working tree without a config hash is refused.** The commit no longer
   describes the code that ran, so the config hash is the only remaining handle on
   what actually executed.
+  ([ADR 0003](docs/adr/0003-dirty-tree-without-config-hash-is-refused.md))
 - **Re-recording identical content is idempotent; different content under the
   same id is a conflict.** Silently overwriting a lineage record would make
   history unreliable.
@@ -114,7 +119,11 @@ implementation cannot quietly disagree about ordering or idempotency.
 - **Hashed fields are length-prefixed** so `("ab","c")` and `("a","bc")` cannot
   collide, and **params are sorted before hashing** because Go randomizes map
   iteration — without that, the same experiment fingerprints differently between
-  runs of the same binary.
+  runs of the same binary. **The fingerprint input — which fields, in what
+  order, with what delimiting — is a versioned contract**: changing it orphans
+  every fingerprint already recorded, and needs a version field plus a
+  documented migration, not a patch release.
+  ([ADR 0004](docs/adr/0004-fingerprint-input-is-a-versioned-contract.md))
 
 ## Status
 

--- a/docs/adr/0001-server-computes-the-fingerprint.md
+++ b/docs/adr/0001-server-computes-the-fingerprint.md
@@ -1,0 +1,44 @@
+# ADR 0001: The server computes the fingerprint, never the client
+
+Status: Accepted
+Date: 2026-08-25
+
+## Context
+
+Every run record is compared by its fingerprint, a content-addressed hash of
+its identity fields (`internal/lineage.Run.Compute`). `POST /runs` accepts a
+`Run` as JSON. The `Run` struct is the same shape on the wire as it is
+internally, so the fingerprint field could in principle be supplied by the
+caller instead of computed.
+
+## Decision
+
+The fingerprint is always recomputed server-side in `Server.record`
+(`internal/api/api.go`), overwriting anything the client sent:
+
+```go
+run.Fingerprint = run.Compute()
+```
+
+A client can send a `fingerprint` field — it is simply discarded.
+
+## Consequences
+
+- A caller cannot assert that two runs with different identity fields were
+  the same experiment, or that two runs with the same identity fields were
+  different ones. The one property the whole system depends on — "same
+  fingerprint means same experiment" — cannot be forged by a client.
+- The client cannot pre-compute and cache a fingerprint locally before
+  recording; it must always round-trip to the server to learn it.
+- Every store implementation can trust `Fingerprint` on a `lineage.Run` it
+  receives from the API layer without re-validating it. A store used outside
+  the API (e.g. in tests, via `store.RunConformance`) is not protected by this
+  and must not treat a hand-built `Run.Fingerprint` as trustworthy.
+
+## What would have to be true to revisit this
+
+A use case where a client needs to assert identity across systems that don't
+share a fingerprint algorithm — e.g. federating fingerprints computed by a
+different, trusted service. That would need a signed or otherwise
+authenticated fingerprint, not a plain client-supplied field, to avoid
+reopening the forgery this decision closes.

--- a/docs/adr/0002-unknown-json-fields-are-rejected.md
+++ b/docs/adr/0002-unknown-json-fields-are-rejected.md
@@ -1,0 +1,48 @@
+# ADR 0002: Unknown JSON fields are rejected
+
+Status: Accepted
+Date: 2026-08-25
+
+## Context
+
+`POST /runs` decodes the request body into a `lineage.Run`. A caller might
+send a field that doesn't exist on `Run` — most often a typo (`git_commmit`,
+`dataset_verison`) or a stale field from a renamed struct tag. The Go JSON
+decoder ignores fields it doesn't recognize by default.
+
+## Decision
+
+The decoder in `Server.record` (`internal/api/api.go`) calls
+`DisallowUnknownFields()`:
+
+```go
+dec := json.NewDecoder(r.Body)
+dec.DisallowUnknownFields()
+```
+
+An unrecognized field makes the whole request a `400`, not a partially-applied
+record.
+
+## Consequences
+
+- A typo'd identity field (e.g. `git_commmit` instead of `git_commit`) fails
+  loudly at record time instead of silently recording a run whose real
+  `git_commit` is empty and whose fingerprint is therefore wrong. Silent
+  acceptance would have produced a run that claims to describe an experiment
+  it does not.
+- Renaming or removing a field in `lineage.Run` is a breaking API change for
+  any client still sending the old shape, not a soft deprecation. Field
+  renames need a transition (accept both old and new for a period, or bump an
+  API version) rather than being made casually.
+- Clients cannot attach arbitrary extra metadata to a run record outside the
+  fields the schema defines. Free-form metadata, if ever needed, has to be a
+  first-class field (e.g. a `map[string]string` "tags") rather than
+  passenger fields riding along in the JSON body.
+
+## What would have to be true to revisit this
+
+A real need for forward-compatible clients — e.g. an older server that must
+accept records written by a newer client carrying fields it doesn't know
+about yet. That would call for an explicit extension point (a `metadata` map)
+rather than loosening this check, so "unknown field" keeps meaning "typo" and
+not "field we haven't gotten around to supporting."

--- a/docs/adr/0003-dirty-tree-without-config-hash-is-refused.md
+++ b/docs/adr/0003-dirty-tree-without-config-hash-is-refused.md
@@ -1,0 +1,50 @@
+# ADR 0003: A dirty working tree without a config hash is refused
+
+Status: Accepted
+Date: 2026-08-25
+
+## Context
+
+A run's identity includes `GitCommit`, `GitDirty`, and `ConfigHash`. When
+`GitDirty` is false, `GitCommit` fully describes the code that ran — checking
+out that commit reproduces it. When `GitDirty` is true, uncommitted changes
+were present at run time, and `GitCommit` alone no longer describes what
+actually executed. `ConfigHash` is the run's own hash of the config it read,
+independent of git state, so a caller can still supply a stable handle on
+"what ran" even with a dirty tree.
+
+## Decision
+
+`Run.Validate` (`internal/lineage/run.go`) refuses a record where `GitDirty`
+is true and `ConfigHash` is empty:
+
+```go
+var ErrDirtyTree = errors.New("git_dirty is set but config_hash is empty: the run is not reconstructible")
+```
+
+A dirty run with a non-empty `ConfigHash` is accepted; a clean run needs no
+`ConfigHash` at all.
+
+## Consequences
+
+- A run recorded from an uncommitted working tree with no config hash is
+  rejected outright rather than stored with a `GitCommit` that quietly
+  understates what ran. There is no "best effort" partial record for this
+  case.
+- Callers that iterate against a dirty tree (common during early
+  experimentation) must compute and pass a config hash, which pushes that
+  responsibility onto whatever harness calls `POST /runs` — not onto the
+  ledger to guess or accept an unreconstructible record.
+- `ConfigHash` alone does not make a dirty run fully reproducible — it is a
+  content handle on the config, not on the full diff of the working tree.
+  This decision treats "we know it wasn't the plain commit, and we have
+  something stable to distinguish one dirty run from another" as the bar, not
+  "this run can be reconstructed byte-for-byte."
+
+## What would have to be true to revisit this
+
+A mechanism that captures the actual diff (e.g. a patch hash or an
+auto-committed shadow ref) would make a dirty tree fully reconstructible
+without a separately-supplied config hash, and could replace this check with
+a stronger one rather than removing it — the goal (never record an
+unreconstructible dirty run silently) should survive any change here.

--- a/docs/adr/0004-fingerprint-input-is-a-versioned-contract.md
+++ b/docs/adr/0004-fingerprint-input-is-a-versioned-contract.md
@@ -1,0 +1,76 @@
+# ADR 0004: The fingerprint input is a versioned contract
+
+Status: Accepted
+Date: 2026-08-25
+
+> **The fingerprint input is a versioned contract.** Any change to which
+> fields are hashed, their order, or the delimiting is a breaking change. It
+> orphans every fingerprint already recorded — two records of the same real
+> experiment, one hashed before the change and one after, will no longer
+> compare equal, and the ledger's central claim ("same fingerprint means same
+> experiment") silently stops holding for old data. Changing the hash input
+> needs a version field on the record plus a documented migration. It is
+> never a patch release.
+
+## Context
+
+`Run.Compute` (`internal/lineage/run.go`) hashes the identity fields in a
+fixed order, each field length-prefixed:
+
+```go
+write := func(parts ...string) {
+    for _, p := range parts {
+        fmt.Fprintf(h, "%d:%s", len(p), p)
+    }
+}
+write(r.Project, r.GitCommit, fmt.Sprint(r.GitDirty), r.ConfigHash,
+    r.DatasetVersion, r.ModelVersion, fmt.Sprint(r.Seed))
+```
+
+Without length-prefixing, concatenating fields directly would let different
+identities collide on the same bytes — `Project="ab", GitCommit="c"` and
+`Project="a", GitCommit="bc"` would hash identically, because
+`"ab"+"c" == "a"+"bc"`. Length-prefixing (`fmt.Fprintf(h, "%d:%s", len(p),
+p)`) makes each field's boundary part of what's hashed, so this cannot
+happen. `Params` is sorted by key before hashing for the same
+reason `Compute`'s doc comment gives: Go's map iteration order is randomized,
+so an unsorted hash would make the same experiment fingerprint differently
+between two runs of the same binary.
+
+## Decision
+
+The exact byte sequence `Compute` feeds into SHA-256 — which fields, in what
+order, with what delimiting — is a versioned contract on the wire, not an
+implementation detail. See the boxed rule above.
+
+Today there is no version field on `Run` and no second hash version, because
+nothing has needed to change the input yet. This record exists so that the
+first time something does, the person making the change finds the rule
+before they make it, not after.
+
+## Consequences
+
+- Adding a new identity field, removing one, or reordering the `write(...)`
+  call changes every fingerprint computed from that code, including for
+  historical runs whose identity fields didn't change at all. It must ship
+  with a version field on the record and a migration, not as a normal code
+  change.
+- Fixing a bug in `Compute` (e.g. a hypothetical delimiter collision) is
+  still a hash-input change by this rule, even though it reads as a "fix." A
+  correctness fix to the hash input is exactly the case this rule is for: it
+  is tempting to ship as a patch because it's "just a fix," and doing so is
+  what would orphan existing fingerprints silently.
+- Every future storage backend (see the storage-engine ADR once #2 lands)
+  must treat `Fingerprint` as opaque and versioned rather than deriving it
+  itself, so the version lives with the record, not with whichever backend
+  happens to compute it.
+
+## What would have to be true to revisit this
+
+This is a standing rule, not a decision that gets revisited — it is the
+precondition for ever safely changing `Compute`. Revisit only the mechanism:
+today "the hash input never changes" is enforced by nothing but this
+document; if that stops being reliable enough, add an automated check (e.g. a
+golden-fingerprint test that fails if `Compute`'s output changes for a fixed
+input) so a hash-input change cannot land without the person making it
+noticing.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,25 @@
+# Architecture decision records
+
+This folder records the decisions in run-ledger that a reader is most likely to
+want to overturn, and that are most expensive to overturn silently. Each record
+is short: context, decision, consequences, and what would have to be true to
+revisit it.
+
+The README's ["Decisions worth knowing"](../../README.md#decisions-worth-knowing)
+section is a summary of these; this folder is the account.
+
+## Records
+
+| # | Title | Status |
+|---|---|---|
+| [0001](0001-server-computes-the-fingerprint.md) | The server computes the fingerprint, never the client | Accepted |
+| [0002](0002-unknown-json-fields-are-rejected.md) | Unknown JSON fields are rejected | Accepted |
+| [0003](0003-dirty-tree-without-config-hash-is-refused.md) | A dirty working tree without a config hash is refused | Accepted |
+| [0004](0004-fingerprint-input-is-a-versioned-contract.md) | The fingerprint input is a versioned contract | Accepted |
+
+## Adding a record
+
+Copy the format of an existing record. Number new records sequentially; never
+reuse or renumber. A record that is later reversed gets a new record that
+supersedes it (linked both ways) — existing records are not edited to pretend
+the original reasoning never held.


### PR DESCRIPTION
Closes #10

## What changed

Adds `docs/adr/` with one short record per decision (context, decision,
consequences, what would have to be true to revisit it):

- **ADR 0001** — the server computes the fingerprint, never the client
- **ADR 0002** — unknown JSON fields are rejected
- **ADR 0003** — a dirty working tree without a config hash is refused
- **ADR 0004** — the fingerprint input is a versioned contract (covers the
  length-prefixing/field-ordering rationale, and states prominently the
  compatibility rule the issue called out: any change to which fields are
  hashed, their order, or the delimiting is a breaking change that orphans
  every fingerprint already recorded, and needs a version field on the
  record plus a documented migration — not a patch release)

Links each into the README's "Decisions worth knowing" section so that
section becomes a summary pointing at the full account, rather than the only
account.

## What I deliberately did not do

The issue also asked for an ADR covering "the storage-engine choice from #2
once it is made." #2 (durable/queryable store) is still open with no decision
made yet, so there's nothing to record there — adding a fifth ADR would mean
inventing a decision the project hasn't actually made. Once #2 lands, its PR
(or a quick follow-up) should add `docs/adr/0005-storage-engine.md` following
the same format.

## Testing

`make lint`, `make test` (`go test -race ./...`), `make build` all pass —
docs-only change, no Go code touched.