### PR TITLE
Optional bearer auth, with separate read and write tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,30 @@ implementation cannot quietly disagree about ordering or idempotency.
 | `GET` | `/compare?a=X&b=Y` | structured diff, with `unattributable` |
 | `GET` | `/healthz` | liveness |
 
+## Auth
+
+By default the server accepts writes from anyone who can reach it — the right
+default for a single-user local ledger, and it stays the default. Running it
+anywhere reachable by more than one party needs a token:
+
+```bash
+export RUNLEDGER_TOKEN=<write-secret>          # grants reads and writes
+export RUNLEDGER_READ_TOKEN=<read-secret>      # optional: grants reads only
+./bin/runledger
+```
+
+`--token-file` and `--read-token-file` read the same tokens from a file
+instead, for a secrets manager that mounts one. With no token configured
+either way, the server logs once, at startup, that it is running
+unauthenticated.
+
+- Tokens are compared with `crypto/subtle.ConstantTimeCompare`.
+- The read token cannot write; the write token can do both, so `rlctl` needs
+  only one credential for a normal workflow.
+- `/healthz` stays unauthenticated so a probe does not need a credential.
+- `rlctl` reads its token from `RUNLEDGER_TOKEN` only — never from a flag,
+  since a token in a flag lands in shell history and in the process table.
+
 ## Decisions worth knowing
 
 - **The server computes the fingerprint, never the client.** A caller that could

--- a/cmd/rlctl/main.go
+++ b/cmd/rlctl/main.go
@@ -27,6 +27,9 @@ const usage = `rlctl — record and compare experiment runs
   rlctl diff   <run-a> <run-b>
 
   --server defaults to $RUNLEDGER_ADDR or http://localhost:8080
+  RUNLEDGER_TOKEN, if set, is sent as a bearer token on every request. It is
+  never read from a flag: a token in a flag lands in shell history and in the
+  process table.
 `
 
 func main() {
@@ -221,6 +224,9 @@ func call(method, endpoint string, body []byte, out any) error {
 	}
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
+	}
+	if token := os.Getenv("RUNLEDGER_TOKEN"); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
 	}
 	resp, err := (&http.Client{Timeout: 10 * time.Second}).Do(req)
 	if err != nil {

--- a/cmd/runledger/main.go
+++ b/cmd/runledger/main.go
@@ -5,10 +5,12 @@ import (
 	"context"
 	"errors"
 	"flag"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -18,9 +20,23 @@ import (
 
 func main() {
 	addr := flag.String("addr", envOr("RUNLEDGER_ADDR", ":8080"), "listen address")
+	tokenFile := flag.String("token-file", "", "file containing the bearer token that grants read and write access (overrides RUNLEDGER_TOKEN)")
+	readTokenFile := flag.String("read-token-file", "", "file containing the bearer token that grants read-only access (overrides RUNLEDGER_READ_TOKEN)")
 	flag.Parse()
 
 	log := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+
+	writeToken, err := loadToken(*tokenFile, "RUNLEDGER_TOKEN")
+	if err != nil {
+		log.Error("loading token-file", "err", err)
+		os.Exit(1)
+	}
+	readToken, err := loadToken(*readTokenFile, "RUNLEDGER_READ_TOKEN")
+	if err != nil {
+		log.Error("loading read-token-file", "err", err)
+		os.Exit(1)
+	}
+	auth := api.Auth{WriteToken: writeToken, ReadToken: readToken}
 
 	// The in-memory store is the only backend today, so a clone runs with no
 	// external dependency. A durable backend is issue #1.
@@ -29,7 +45,7 @@ func main() {
 
 	srv := &http.Server{
 		Addr:              *addr,
-		Handler:           api.New(st, log).Handler(),
+		Handler:           api.New(st, log, api.WithAuth(auth)).Handler(),
 		ReadHeaderTimeout: 5 * time.Second,
 	}
 
@@ -59,4 +75,19 @@ func envOr(key, def string) string {
 		return v
 	}
 	return def
+}
+
+// loadToken returns the token from file if set, otherwise from the named
+// environment variable. A file's contents are trimmed of surrounding
+// whitespace so a trailing newline from an editor or `echo` does not become
+// part of the token.
+func loadToken(file, envKey string) (string, error) {
+	if file == "" {
+		return os.Getenv(envKey), nil
+	}
+	b, err := os.ReadFile(file)
+	if err != nil {
+		return "", fmt.Errorf("reading %s: %w", file, err)
+	}
+	return strings.TrimSpace(string(b)), nil
 }

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -2,12 +2,14 @@
 package api
 
 import (
+	"crypto/subtle"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/kornsour/run-ledger/internal/compare"
@@ -15,32 +17,117 @@ import (
 	"github.com/kornsour/run-ledger/internal/store"
 )
 
+// Auth holds the bearer tokens that gate access to the API. A zero-value Auth
+// requires no token at all, which is the default: a single-user local ledger
+// has no one to authenticate against.
+//
+// WriteToken grants both reads and writes. ReadToken grants reads only, so a
+// dashboard or a CI job can be handed a credential that cannot record runs.
+type Auth struct {
+	WriteToken string
+	ReadToken  string
+}
+
+func (a Auth) enabled() bool {
+	return a.WriteToken != "" || a.ReadToken != ""
+}
+
+// allows reports whether token authorizes the given access. write requests
+// need the write token; reads accept either token.
+func (a Auth) allows(write bool, token string) bool {
+	if a.WriteToken != "" && constantTimeEqual(token, a.WriteToken) {
+		return true
+	}
+	if !write && a.ReadToken != "" && constantTimeEqual(token, a.ReadToken) {
+		return true
+	}
+	return false
+}
+
+func constantTimeEqual(a, b string) bool {
+	// ConstantTimeCompare itself only compares in constant time when the
+	// lengths already match; the length check below is not a secret, so
+	// leaking it early does not weaken the comparison.
+	if len(a) != len(b) {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
+}
+
 // Server wires the store to an HTTP mux.
 type Server struct {
 	store store.Store
 	log   *slog.Logger
+	auth  Auth
+}
+
+// Option configures a Server at construction time.
+type Option func(*Server)
+
+// WithAuth requires a bearer token on every request except /healthz. Leaving
+// this unset (or passing a zero-value Auth) leaves the server unauthenticated.
+func WithAuth(a Auth) Option {
+	return func(s *Server) { s.auth = a }
 }
 
 // New returns a Server. A nil logger discards output.
-func New(s store.Store, log *slog.Logger) *Server {
+func New(s store.Store, log *slog.Logger, opts ...Option) *Server {
 	if log == nil {
 		log = slog.New(slog.DiscardHandler)
 	}
-	return &Server{store: s, log: log}
+	srv := &Server{store: s, log: log}
+	for _, opt := range opts {
+		opt(srv)
+	}
+	if !srv.auth.enabled() {
+		log.Warn("running without authentication: any client that can reach this server can write to the ledger; set RUNLEDGER_TOKEN to require a bearer token")
+	}
+	return srv
 }
 
 // Handler returns the routed mux.
 func (s *Server) Handler() http.Handler {
 	mux := http.NewServeMux()
-	mux.HandleFunc("POST /runs", s.record)
-	mux.HandleFunc("GET /runs", s.list)
-	mux.HandleFunc("GET /runs/{id}", s.get)
-	mux.HandleFunc("GET /compare", s.compare)
+	mux.HandleFunc("POST /runs", s.requireAuth(true, s.record))
+	mux.HandleFunc("GET /runs", s.requireAuth(false, s.list))
+	mux.HandleFunc("GET /runs/{id}", s.requireAuth(false, s.get))
+	mux.HandleFunc("GET /compare", s.requireAuth(false, s.compare))
+	// /healthz stays unauthenticated so a liveness probe does not need a
+	// credential.
 	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok\n"))
 	})
 	return mux
+}
+
+// requireAuth wraps next so it only runs once the request carries a bearer
+// token Auth allows for the given access. With no token configured at all,
+// every request passes through unchecked.
+func (s *Server) requireAuth(write bool, next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !s.auth.enabled() {
+			next(w, r)
+			return
+		}
+		token, ok := bearerToken(r)
+		if !ok || !s.auth.allows(write, token) {
+			w.Header().Set("WWW-Authenticate", `Bearer realm="run-ledger"`)
+			writeErr(w, http.StatusUnauthorized, errors.New("missing or invalid bearer token"))
+			return
+		}
+		next(w, r)
+	}
+}
+
+func bearerToken(r *http.Request) (string, bool) {
+	const prefix = "Bearer "
+	h := r.Header.Get("Authorization")
+	if !strings.HasPrefix(h, prefix) {
+		return "", false
+	}
+	token := strings.TrimPrefix(h, prefix)
+	return token, token != ""
 }
 
 func (s *Server) record(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -15,6 +15,19 @@ func srv(t *testing.T) http.Handler {
 	return New(store.NewMemory(), nil).Handler()
 }
 
+func srvWithAuth(t *testing.T, auth Auth) http.Handler {
+	t.Helper()
+	return New(store.NewMemory(), nil, WithAuth(auth)).Handler()
+}
+
+func authed(method, path, token string) *http.Request {
+	req := httptest.NewRequest(method, path, strings.NewReader(""))
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	return req
+}
+
 func post(t *testing.T, h http.Handler, body string) *httptest.ResponseRecorder {
 	t.Helper()
 	w := httptest.NewRecorder()
@@ -127,6 +140,93 @@ func TestBadLimitIsRejected(t *testing.T) {
 func TestHealthz(t *testing.T) {
 	w := httptest.NewRecorder()
 	srv(t).ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", w.Code)
+	}
+}
+
+func TestNoTokenConfiguredAllowsEverything(t *testing.T) {
+	h := srv(t) // no Auth option: the default, single-user, unauthenticated server.
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, authed(http.MethodGet, "/runs", ""))
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200 with no token configured, got %d: %s", w.Code, w.Body)
+	}
+
+	body := `{"project":"p","git_commit":"abc","config_hash":"cfg"}`
+	w = httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/runs", strings.NewReader(body))
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("want 201 with no token configured, got %d: %s", w.Code, w.Body)
+	}
+}
+
+func TestTokenConfiguredRefusesMissingOrWrongOnBothVerbs(t *testing.T) {
+	h := srvWithAuth(t, Auth{WriteToken: "write-secret"})
+
+	cases := []struct {
+		name   string
+		method string
+		path   string
+		token  string
+	}{
+		{"read, no token", http.MethodGet, "/runs", ""},
+		{"read, wrong token", http.MethodGet, "/runs", "nope"},
+		{"write, no token", http.MethodPost, "/runs", ""},
+		{"write, wrong token", http.MethodPost, "/runs", "nope"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, authed(c.method, c.path, c.token))
+			if w.Code != http.StatusUnauthorized {
+				t.Fatalf("want 401, got %d: %s", w.Code, w.Body)
+			}
+		})
+	}
+
+	// The correct token still works on both verbs.
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, authed(http.MethodGet, "/runs", "write-secret"))
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200 with the correct token, got %d: %s", w.Code, w.Body)
+	}
+
+	body := `{"project":"p","git_commit":"abc","config_hash":"cfg"}`
+	w = httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/runs", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer write-secret")
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("want 201 with the correct token, got %d: %s", w.Code, w.Body)
+	}
+}
+
+func TestReadTokenCannotWrite(t *testing.T) {
+	h := srvWithAuth(t, Auth{WriteToken: "write-secret", ReadToken: "read-secret"})
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, authed(http.MethodGet, "/runs", "read-secret"))
+	if w.Code != http.StatusOK {
+		t.Fatalf("read token should be able to read, got %d: %s", w.Code, w.Body)
+	}
+
+	body := `{"project":"p","git_commit":"abc","config_hash":"cfg"}`
+	w = httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/runs", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer read-secret")
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("a read token must not be able to write, got %d: %s", w.Code, w.Body)
+	}
+}
+
+func TestHealthzUnauthenticatedEvenWithTokenConfigured(t *testing.T) {
+	h := srvWithAuth(t, Auth{WriteToken: "write-secret"})
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/healthz", nil))
 	if w.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d", w.Code)
 	}


### PR DESCRIPTION
Closes #5

## What changed

- `internal/api`: an `Auth{WriteToken, ReadToken}` gate, off by default. `WithAuth` wires it into `Server`. Middleware (`requireAuth`) checks a `Bearer` token with `crypto/subtle.ConstantTimeCompare` before every route except `/healthz`. A write token authorizes both reads and writes; a read token authorizes reads only.
- `cmd/runledger`: reads the write token from `RUNLEDGER_TOKEN` or `--token-file`, and the read-only token from `RUNLEDGER_READ_TOKEN` or `--read-token-file` (a `*-file` flag overrides the matching env var, and file contents are trimmed). With neither token set, the server logs once, at startup, that it is running unauthenticated — the default stays unauthenticated for a single-user local ledger.
- `cmd/rlctl`: sends `RUNLEDGER_TOKEN` (env only, never a flag) as a bearer token on every request.
- `README.md`: documents the new `## Auth` section.

## Why

The server accepted writes from anyone who could reach it. That's the right default for a local single-user ledger, but there was no way to run it anywhere else, and a lineage record anyone can write isn't evidence of anything.

## Tests

Added to `internal/api/api_test.go`:
- `TestNoTokenConfiguredAllowsEverything` — no token configured, both verbs succeed unauthenticated.
- `TestTokenConfiguredRefusesMissingOrWrongOnBothVerbs` — a token configured rejects a missing or wrong token on both GET and POST, and accepts the correct one.
- `TestReadTokenCannotWrite` — a read-only token can GET but gets 401 on POST.
- `TestHealthzUnauthenticatedEvenWithTokenConfigured` — `/healthz` stays open even with auth on.

Also manually verified end-to-end with the built `runledger`/`rlctl` binaries (unauthenticated write refused, read token blocked from POST, write token both reads and writes, `/healthz` open, `rlctl` picking up `RUNLEDGER_TOKEN`, and the one-time unauthenticated-startup log line).

## Local verification

- `gofmt -l .` — clean
- `go vet ./...`
- `go test -race -coverprofile=coverage.out ./...` — all packages pass (`internal/api` at 87.4% coverage)
- `make build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)