### PR TITLE
Expose server health and self-metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ implementation cannot quietly disagree about ordering or idempotency.
 | `GET` | `/runs/{id}` | one run |
 | `GET` | `/compare?a=X&b=Y` | structured diff, with `unattributable` |
 | `GET` | `/healthz` | liveness |
+| `GET` | `/readyz` | readiness — the store answers a call |
+| `GET` | `/metrics` | self-metrics, Prometheus exposition format |
 
 ## Decisions worth knowing
 
@@ -115,6 +117,11 @@ implementation cannot quietly disagree about ordering or idempotency.
   collide, and **params are sorted before hashing** because Go randomizes map
   iteration — without that, the same experiment fingerprints differently between
   runs of the same binary.
+- **`/metrics` is hand-rolled, not built on a client library.** The project ships
+  as one dependency-free binary, and a few counters and a histogram don't
+  justify breaking that. `runledger_runs` is read from the store at scrape
+  time rather than tracked as a local counter, since recording is idempotent
+  and a retried record must not inflate it.
 
 ## Status
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -2,23 +2,29 @@
 package api
 
 import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
+	"runtime/debug"
 	"strconv"
 	"time"
 
 	"github.com/kornsour/run-ledger/internal/compare"
 	"github.com/kornsour/run-ledger/internal/lineage"
+	"github.com/kornsour/run-ledger/internal/metrics"
 	"github.com/kornsour/run-ledger/internal/store"
 )
 
 // Server wires the store to an HTTP mux.
 type Server struct {
-	store store.Store
-	log   *slog.Logger
+	store   store.Store
+	log     *slog.Logger
+	metrics *metrics.Registry
 }
 
 // New returns a Server. A nil logger discards output.
@@ -26,10 +32,23 @@ func New(s store.Store, log *slog.Logger) *Server {
 	if log == nil {
 		log = slog.New(slog.DiscardHandler)
 	}
-	return &Server{store: s, log: log}
+	srv := &Server{store: s, log: log}
+	// The gauge is driven by the store at scrape time, not by a local
+	// increment-only counter: recording is idempotent, so a retried record
+	// must not inflate it, and once the store is out of process it becomes
+	// the only source of truth anyway.
+	srv.metrics = metrics.New(func() float64 {
+		runs, err := s.List(context.Background(), store.Query{})
+		if err != nil {
+			return -1
+		}
+		return float64(len(runs))
+	})
+	return srv
 }
 
-// Handler returns the routed mux.
+// Handler returns the routed mux, wrapped in request-scoped logging,
+// duration/metrics instrumentation, and panic recovery.
 func (s *Server) Handler() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /runs", s.record)
@@ -40,7 +59,101 @@ func (s *Server) Handler() http.Handler {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok\n"))
 	})
-	return mux
+	// Ready means the store answers a call, not just that the process is
+	// up. That distinction is a no-op today -- the only backend is
+	// in-memory -- but becomes real once the store is out of process.
+	mux.HandleFunc("GET /readyz", s.readyz)
+	mux.HandleFunc("GET /metrics", s.serveMetrics)
+	return s.instrument(mux)
+}
+
+// instrument wraps mux with request-scoped logging, request-duration
+// metrics, an echoed X-Request-Id, and panic recovery. A handler panic
+// becomes a logged 500 instead of a dropped connection.
+func (s *Server) instrument(mux *http.ServeMux) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		reqID := r.Header.Get("X-Request-Id")
+		if reqID == "" {
+			reqID = newRequestID()
+		}
+		w.Header().Set("X-Request-Id", reqID)
+
+		// The pattern mux would route this request to (e.g. "GET /runs/{id}"),
+		// resolved up front so the metrics and log line report the route
+		// rather than the raw, high-cardinality path.
+		_, pattern := mux.Handler(r)
+		if pattern == "" {
+			pattern = "unmatched"
+		}
+
+		rw := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+		defer func() {
+			if rec := recover(); rec != nil {
+				s.log.Error("panic recovered", "route", pattern, "request_id", reqID,
+					"err", rec, "stack", string(debug.Stack()))
+				if !rw.wroteHeader {
+					rw.WriteHeader(http.StatusInternalServerError)
+				}
+			}
+			dur := time.Since(start)
+			s.metrics.ObserveRequest(pattern, rw.status, dur.Seconds())
+			s.log.Info("request",
+				"method", r.Method, "route", pattern, "status", rw.status,
+				"duration_ms", float64(dur.Microseconds())/1000, "request_id", reqID)
+		}()
+		mux.ServeHTTP(rw, r)
+	})
+}
+
+// statusRecorder captures the status code a handler wrote so the
+// instrumentation middleware can observe it after the fact.
+type statusRecorder struct {
+	http.ResponseWriter
+	status      int
+	wroteHeader bool
+}
+
+func (rw *statusRecorder) WriteHeader(code int) {
+	if rw.wroteHeader {
+		return
+	}
+	rw.status = code
+	rw.wroteHeader = true
+	rw.ResponseWriter.WriteHeader(code)
+}
+
+func (rw *statusRecorder) Write(b []byte) (int, error) {
+	if !rw.wroteHeader {
+		rw.WriteHeader(http.StatusOK)
+	}
+	return rw.ResponseWriter.Write(b)
+}
+
+func newRequestID() string {
+	var buf [12]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		// crypto/rand failing means the platform is broken beyond this
+		// request's concern; fall back to a fixed, clearly-synthetic id
+		// rather than panicking a request over an unrelated fault.
+		return "unavailable"
+	}
+	return hex.EncodeToString(buf[:])
+}
+
+func (s *Server) readyz(w http.ResponseWriter, r *http.Request) {
+	if _, err := s.store.List(r.Context(), store.Query{Limit: 1}); err != nil {
+		s.metrics.StoreError("readyz")
+		writeErr(w, http.StatusServiceUnavailable, fmt.Errorf("store not ready: %w", err))
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("ok\n"))
+}
+
+func (s *Server) serveMetrics(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+	_, _ = s.metrics.WriteTo(w)
 }
 
 func (s *Server) record(w http.ResponseWriter, r *http.Request) {
@@ -68,12 +181,15 @@ func (s *Server) record(w http.ResponseWriter, r *http.Request) {
 	if err := s.store.Record(r.Context(), run); err != nil {
 		switch {
 		case errors.Is(err, store.ErrConflict):
+			s.metrics.StoreError("conflict")
 			writeErr(w, http.StatusConflict, err)
 		default:
+			s.metrics.StoreError("invalid")
 			writeErr(w, http.StatusBadRequest, err)
 		}
 		return
 	}
+	s.metrics.RecordRun(run.Project, string(run.Status))
 	s.log.Info("recorded run", "run_id", run.RunID, "project", run.Project, "fingerprint", run.Fingerprint)
 	writeJSON(w, http.StatusCreated, run)
 }
@@ -81,10 +197,12 @@ func (s *Server) record(w http.ResponseWriter, r *http.Request) {
 func (s *Server) get(w http.ResponseWriter, r *http.Request) {
 	run, err := s.store.Get(r.Context(), r.PathValue("id"))
 	if errors.Is(err, store.ErrNotFound) {
+		s.metrics.StoreError("not_found")
 		writeErr(w, http.StatusNotFound, err)
 		return
 	}
 	if err != nil {
+		s.metrics.StoreError("internal")
 		writeErr(w, http.StatusInternalServerError, err)
 		return
 	}
@@ -107,6 +225,7 @@ func (s *Server) list(w http.ResponseWriter, r *http.Request) {
 		Limit:       limit,
 	})
 	if err != nil {
+		s.metrics.StoreError("internal")
 		writeErr(w, http.StatusInternalServerError, err)
 		return
 	}
@@ -121,11 +240,13 @@ func (s *Server) compare(w http.ResponseWriter, r *http.Request) {
 	}
 	a, err := s.store.Get(r.Context(), idA)
 	if err != nil {
+		s.metrics.StoreError(errKind(err))
 		writeErr(w, statusFor(err), fmt.Errorf("run a: %w", err))
 		return
 	}
 	b, err := s.store.Get(r.Context(), idB)
 	if err != nil {
+		s.metrics.StoreError(errKind(err))
 		writeErr(w, statusFor(err), fmt.Errorf("run b: %w", err))
 		return
 	}
@@ -152,6 +273,13 @@ func statusFor(err error) int {
 		return http.StatusNotFound
 	}
 	return http.StatusInternalServerError
+}
+
+func errKind(err error) string {
+	if errors.Is(err, store.ErrNotFound) {
+		return "not_found"
+	}
+	return "internal"
 }
 
 func writeJSON(w http.ResponseWriter, code int, v any) {

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -2,11 +2,13 @@ package api
 
 import (
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/kornsour/run-ledger/internal/metrics"
 	"github.com/kornsour/run-ledger/internal/store"
 )
 
@@ -129,5 +131,88 @@ func TestHealthz(t *testing.T) {
 	srv(t).ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/healthz", nil))
 	if w.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d", w.Code)
+	}
+}
+
+func TestReadyzOKWhenStoreAnswers(t *testing.T) {
+	w := httptest.NewRecorder()
+	srv(t).ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body)
+	}
+}
+
+func TestRequestIDIsEchoedAndGeneratedWhenAbsent(t *testing.T) {
+	h := srv(t)
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+	if w.Header().Get("X-Request-Id") == "" {
+		t.Fatal("no X-Request-Id generated for a request that sent none")
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	req.Header.Set("X-Request-Id", "caller-supplied-id")
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if got := w.Header().Get("X-Request-Id"); got != "caller-supplied-id" {
+		t.Fatalf("want caller's request id echoed back, got %q", got)
+	}
+}
+
+func TestPanicRecoversInto500(t *testing.T) {
+	s := &Server{store: store.NewMemory(), log: slog.New(slog.DiscardHandler)}
+	s.metrics = metrics.New(func() float64 { return 0 })
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /boom", func(http.ResponseWriter, *http.Request) {
+		panic("kaboom")
+	})
+	h := s.instrument(mux)
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/boom", nil))
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("want 500 after a handler panic, got %d", w.Code)
+	}
+}
+
+func TestMetricsEndpointExposesRunsRecordedCounter(t *testing.T) {
+	h := srv(t)
+	post(t, h, `{"project":"demo","git_commit":"abc","config_hash":"cfg","status":"succeeded"}`)
+	post(t, h, `{"project":"demo","git_commit":"def","config_hash":"cfg","status":"succeeded"}`)
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", w.Code)
+	}
+	body := w.Body.String()
+	want := `runledger_runs_recorded_total{project="demo",status="succeeded"} 2`
+	if !strings.Contains(body, want) {
+		t.Fatalf("counter did not increment as expected; want to find %q in:\n%s", want, body)
+	}
+	if !strings.Contains(body, "runledger_runs 2") {
+		t.Fatalf("runs gauge did not reflect the store; got:\n%s", body)
+	}
+}
+
+func TestMetricsEndpointReportsStoreConflict(t *testing.T) {
+	h := srv(t)
+	body := `{"project":"p","git_commit":"abc","config_hash":"cfg","run_id":"fixed-id"}`
+	post(t, h, body) // first record succeeds
+
+	w := httptest.NewRecorder()
+	// Same run id, different content -> conflict.
+	req := httptest.NewRequest(http.MethodPost, "/runs",
+		strings.NewReader(`{"project":"p","git_commit":"other","config_hash":"cfg","run_id":"fixed-id"}`))
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("want 409, got %d: %s", w.Code, w.Body)
+	}
+
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	if !strings.Contains(w.Body.String(), `runledger_store_errors_total{kind="conflict"} 1`) {
+		t.Fatalf("store error counter did not record the conflict; got:\n%s", w.Body.String())
 	}
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,164 @@
+// Package metrics collects the server's self-metrics and renders them in
+// Prometheus exposition format.
+//
+// It is hand-rolled rather than built on a client library: run-ledger ships
+// as one binary with nothing to fetch to try it, and a handful of counters
+// and a histogram don't justify breaking that for every clone.
+package metrics
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// requestBuckets are the upper bounds (seconds) of the request-duration
+// histogram, chosen for a service whose handlers are in-memory map lookups:
+// mostly sub-millisecond, with headroom out to one second for a slow client
+// or a GC pause.
+var requestBuckets = []float64{0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1}
+
+// Registry holds the counters and histogram this server reports about
+// itself. The zero value is not usable; construct with New.
+type Registry struct {
+	mu sync.Mutex
+
+	runsRecorded map[[2]string]uint64   // {project, status} -> count
+	storeErrors  map[string]uint64      // kind -> count
+	reqCount     map[[2]string]uint64   // {route, code} -> count
+	reqSum       map[[2]string]float64  // {route, code} -> seconds
+	reqBuckets   map[[2]string][]uint64 // {route, code} -> cumulative count per requestBuckets entry
+
+	// runsGauge reports the store's current run count at scrape time. It is
+	// a callback rather than a value this package tracks itself: the count
+	// must reflect the store's own state (recording is idempotent, so a
+	// local increment-only counter would overcount a retried record), and
+	// once the store is out of process it is also the only source of truth.
+	runsGauge func() float64
+}
+
+// New returns an empty Registry. runsGauge is called on every scrape of
+// runledger_runs and should be cheap.
+func New(runsGauge func() float64) *Registry {
+	return &Registry{
+		runsRecorded: make(map[[2]string]uint64),
+		storeErrors:  make(map[string]uint64),
+		reqCount:     make(map[[2]string]uint64),
+		reqSum:       make(map[[2]string]float64),
+		reqBuckets:   make(map[[2]string][]uint64),
+		runsGauge:    runsGauge,
+	}
+}
+
+// RecordRun increments runledger_runs_recorded_total for a project/status pair.
+func (r *Registry) RecordRun(project string, status string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.runsRecorded[[2]string{project, status}]++
+}
+
+// StoreError increments runledger_store_errors_total for an error kind
+// (e.g. "not_found", "conflict", "internal").
+func (r *Registry) StoreError(kind string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.storeErrors[kind]++
+}
+
+// ObserveRequest records one HTTP request's duration into
+// runledger_request_duration_seconds for a route/status-code pair.
+func (r *Registry) ObserveRequest(route string, code int, seconds float64) {
+	key := [2]string{route, strconv.Itoa(code)}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.reqCount[key]++
+	r.reqSum[key] += seconds
+	buckets, ok := r.reqBuckets[key]
+	if !ok {
+		buckets = make([]uint64, len(requestBuckets))
+		r.reqBuckets[key] = buckets
+	}
+	for i, bound := range requestBuckets {
+		if seconds <= bound {
+			buckets[i]++
+		}
+	}
+}
+
+// WriteTo renders every metric in Prometheus text exposition format.
+func (r *Registry) WriteTo(w io.Writer) (int64, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	var b strings.Builder
+
+	writeHeader(&b, "runledger_runs_recorded_total",
+		"Total number of runs recorded, by project and status.", "counter")
+	for _, key := range sortedKeys2(r.runsRecorded) {
+		fmt.Fprintf(&b, "runledger_runs_recorded_total{project=%q,status=%q} %d\n",
+			key[0], key[1], r.runsRecorded[key])
+	}
+
+	writeHeader(&b, "runledger_store_errors_total",
+		"Total number of store errors, by kind.", "counter")
+	for _, kind := range sortedKeys1(r.storeErrors) {
+		fmt.Fprintf(&b, "runledger_store_errors_total{kind=%q} %d\n", kind, r.storeErrors[kind])
+	}
+
+	writeHeader(&b, "runledger_request_duration_seconds",
+		"HTTP request duration in seconds, by route and status code.", "histogram")
+	for _, key := range sortedKeys2(r.reqCount) {
+		route, code := key[0], key[1]
+		buckets := r.reqBuckets[key]
+		for i, bound := range requestBuckets {
+			fmt.Fprintf(&b, "runledger_request_duration_seconds_bucket{route=%q,code=%q,le=%q} %d\n",
+				route, code, formatFloat(bound), buckets[i])
+		}
+		fmt.Fprintf(&b, "runledger_request_duration_seconds_bucket{route=%q,code=%q,le=\"+Inf\"} %d\n",
+			route, code, r.reqCount[key])
+		fmt.Fprintf(&b, "runledger_request_duration_seconds_sum{route=%q,code=%q} %s\n",
+			route, code, formatFloat(r.reqSum[key]))
+		fmt.Fprintf(&b, "runledger_request_duration_seconds_count{route=%q,code=%q} %d\n",
+			route, code, r.reqCount[key])
+	}
+
+	writeHeader(&b, "runledger_runs", "Current number of runs held by the store.", "gauge")
+	fmt.Fprintf(&b, "runledger_runs %s\n", formatFloat(r.runsGauge()))
+
+	n, err := io.WriteString(w, b.String())
+	return int64(n), err
+}
+
+func writeHeader(b *strings.Builder, name, help, typ string) {
+	fmt.Fprintf(b, "# HELP %s %s\n# TYPE %s %s\n", name, help, name, typ)
+}
+
+func formatFloat(f float64) string {
+	return strconv.FormatFloat(f, 'g', -1, 64)
+}
+
+func sortedKeys1(m map[string]uint64) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func sortedKeys2(m map[[2]string]uint64) [][2]string {
+	keys := make([][2]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i][0] != keys[j][0] {
+			return keys[i][0] < keys[j][0]
+		}
+		return keys[i][1] < keys[j][1]
+	})
+	return keys
+}

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1,0 +1,77 @@
+package metrics
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestWriteToRendersExpositionFormat(t *testing.T) {
+	r := New(func() float64 { return 2 })
+	r.RecordRun("demo", "succeeded")
+	r.RecordRun("demo", "succeeded")
+	r.RecordRun("demo", "failed")
+	r.StoreError("conflict")
+	r.ObserveRequest("POST /runs", 201, 0.0012)
+	r.ObserveRequest("POST /runs", 201, 2.0)
+
+	var b strings.Builder
+	if _, err := r.WriteTo(&b); err != nil {
+		t.Fatalf("WriteTo: %v", err)
+	}
+	out := b.String()
+
+	for _, want := range []string{
+		"# TYPE runledger_runs_recorded_total counter",
+		`runledger_runs_recorded_total{project="demo",status="succeeded"} 2`,
+		`runledger_runs_recorded_total{project="demo",status="failed"} 1`,
+		"# TYPE runledger_store_errors_total counter",
+		`runledger_store_errors_total{kind="conflict"} 1`,
+		"# TYPE runledger_request_duration_seconds histogram",
+		`runledger_request_duration_seconds_bucket{route="POST /runs",code="201",le="+Inf"} 2`,
+		`runledger_request_duration_seconds_count{route="POST /runs",code="201"} 2`,
+		"# TYPE runledger_runs gauge",
+		"runledger_runs 2",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q\ngot:\n%s", want, out)
+		}
+	}
+}
+
+func TestObserveRequestBucketsAreCumulative(t *testing.T) {
+	r := New(func() float64 { return 0 })
+	// One fast request (fits every bucket) and one slow one (only +Inf).
+	r.ObserveRequest("GET /runs", 200, 0.0001)
+	r.ObserveRequest("GET /runs", 200, 999)
+
+	var b strings.Builder
+	if _, err := r.WriteTo(&b); err != nil {
+		t.Fatalf("WriteTo: %v", err)
+	}
+	out := b.String()
+
+	// The smallest bucket (le="0.0005") must count only the fast request.
+	if !strings.Contains(out, `runledger_request_duration_seconds_bucket{route="GET /runs",code="200",le="0.0005"} 1`) {
+		t.Errorf("smallest bucket did not capture the fast request:\n%s", out)
+	}
+	if !strings.Contains(out, `runledger_request_duration_seconds_bucket{route="GET /runs",code="200",le="+Inf"} 2`) {
+		t.Errorf("+Inf bucket did not capture both requests:\n%s", out)
+	}
+}
+
+func TestRunsGaugeReflectsCallbackNotLocalCount(t *testing.T) {
+	// The gauge must be driven by the store, not by how many times
+	// RecordRun was called -- a retried, idempotent record should not
+	// inflate it.
+	r := New(func() float64 { return 5 })
+	r.RecordRun("p", "created")
+	r.RecordRun("p", "created")
+
+	var b strings.Builder
+	if _, err := r.WriteTo(&b); err != nil {
+		t.Fatalf("WriteTo: %v", err)
+	}
+	if !strings.Contains(b.String(), "runledger_runs 5") {
+		t.Errorf("gauge did not reflect callback value:\n%s", b.String())
+	}
+}


### PR DESCRIPTION
Closes #6

## What changed

- **`/metrics`** in Prometheus exposition format:
  - `runledger_runs_recorded_total{project,status}` — counter
  - `runledger_request_duration_seconds{route,code}` — histogram (bucket/sum/count)
  - `runledger_store_errors_total{kind}` — counter
  - `runledger_runs` — gauge, read from the store at scrape time (not tracked
    as a local counter, since `Record` is idempotent and a retried record
    must not inflate it)
- **`/readyz`**, distinct from `/healthz`: it calls the store and reports
  503 if the store errors. A no-op distinction today (the only backend is
  in-memory) but a real one once a durable backend lands.
- **Request-scoped middleware** wrapping the mux: logs method, route
  (the matched mux pattern, not the raw path), status, and duration; assigns
  or echoes `X-Request-Id`; and recovers a handler panic into a logged 500
  instead of dropping the connection.
- `internal/metrics`: a small, hand-rolled registry rendering the exposition
  text format — no client library pulled in, matching the README's "one
  binary, no external dependencies to try it" claim. `go.mod` is unchanged.

## Why

The server logged structured JSON on record and reported nothing else about
itself — no way to scrape health/throughput, no readiness signal distinct
from liveness, and a handler panic would just drop the connection.

## Testing

- `internal/metrics`: exposition-format rendering, cumulative histogram
  buckets, and that the gauge reflects the store callback rather than a
  local increment-only count.
- `internal/api`: `/readyz` returns 200 when the store answers; `X-Request-Id`
  is generated when absent and echoed back when supplied; a handler panic
  recovers into a 500; `/metrics` reflects `runledger_runs_recorded_total`
  after a real `POST /runs`, and `runledger_store_errors_total{kind="conflict"}`
  after a conflicting record — the acceptance criterion that the counter
  can't silently stop incrementing.
- `make lint`, `make build`, `make cover` all pass locally
  (`go test -race ./...` green, `gofmt -l .` clean).

## Manual smoke test

Ran the built binary and curled `/healthz`, `/readyz`, `POST /runs`, and
`/metrics` — confirmed the counter, histogram, and gauge all render
correctly and the structured request log includes route/status/duration/request_id.