### PR TITLE
Container image and a one-command bring-up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,5 @@ jobs:
         run: go tool cover -func=coverage.out | tail -1 >> "$GITHUB_STEP_SUMMARY"
       - name: Build
         run: make build
+      - name: Build image
+        run: make image

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,15 @@ permissions:
 
 jobs:
   build:
-    # Self-hosted when CI_RUNNER names a runner, GitHub-hosted otherwise. The
-    # fallback matters: this repo's runner lives in a container on a laptop, and
-    # an unset or wrong variable would otherwise queue the job forever with no
-    # runner able to claim it -- which is exactly what happened to the sibling
-    # lab repos when their Windows runners were deregistered while CI_RUNNER
-    # still named them.
-    runs-on: ${{ fromJSON(vars.CI_RUNNER || '["ubuntu-latest"]') }}
+    # Pinned to the WSL pool specifically, not the bare self-hosted fleet: this
+    # job runs `make image` (a real docker build), and the Mac pool's runners
+    # are themselves Docker containers with no nested Docker available. Landing
+    # there fails with "make: docker: No such file or directory" -- a
+    # structural incompatibility, not a flaky failure. See
+    # Lurking-Walrus/.github-private#82. The fallback to ubuntu-latest matters
+    # too: an unset or false switch must not queue this job forever with no
+    # runner able to claim it.
+    runs-on: ${{ fromJSON(vars.USE_SELF_HOSTED_RUNNER == 'true' && github.event.repository.private && '["self-hosted","Linux","wsl"]' || '["ubuntu-latest"]') }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,0 +1,60 @@
+name: Publish image
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
+
+jobs:
+  publish:
+    # See ci.yml for why the fallback here matters: self-hosted runner names
+    # going stale must not queue this job forever.
+    runs-on: ${{ fromJSON(vars.CI_RUNNER || '["ubuntu-latest"]') }}
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,44 @@
+# syntax=docker/dockerfile:1
+
+# --- build ---
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS build
+WORKDIR /src
+
+# No third-party modules today (go.sum does not exist), but this still copies
+# go.mod first so the module-download layer stays cached once one lands.
+COPY go.mod ./
+COPY cmd ./cmd
+COPY internal ./internal
+
+ARG TARGETOS
+ARG TARGETARCH
+
+# CGO_ENABLED=0 gives a static binary, which is why this single builder can
+# cross-compile both target platforms and why the runtime stage below can be
+# distroless/scratch with no libc at all.
+#
+# This works only because the only backend today (internal/store.Memory) is
+# pure Go. If the DuckDB backend (issue #1) lands first, it links libduckdb via
+# cgo: CGO_ENABLED=0 will then fail to build ./cmd/runledger at all, and
+# flipping to CGO_ENABLED=1 needs a C toolchain plus a libduckdb built for
+# TARGETARCH, which this single cross-compiling `golang:1.26-alpine` stage does
+# not have for a foreign arch. At that point this Dockerfile needs per-arch
+# native builders (or a vendored libduckdb layer per platform), not a one-line
+# flag flip -- do not just set CGO_ENABLED=1 here and assume arm64 still works.
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
+    go build -trimpath -ldflags="-s -w" -o /out/runledger ./cmd/runledger
+
+# --- runtime ---
+# distroless "static" has no shell, no package manager, and no libc -- exactly
+# what a CGO_ENABLED=0 binary needs and nothing more. The "nonroot" variant
+# also ships an /etc/passwd entry for uid/gid 65532 so USER below resolves
+# without a base image that can run useradd.
+FROM gcr.io/distroless/static-debian12:nonroot AS runtime
+
+COPY --from=build /out/runledger /usr/local/bin/runledger
+
+USER nonroot:nonroot
+EXPOSE 8080
+
+ENTRYPOINT ["/usr/local/bin/runledger"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-.PHONY: build test vet fmt lint cover clean run
+.PHONY: build test vet fmt lint cover clean run image
+
+IMAGE ?= run-ledger
+TAG ?= dev
 
 build:
 	@mkdir -p bin
@@ -23,6 +26,11 @@ cover:
 
 run: build
 	./bin/runledger
+
+# Builds the same binary as `build`, containerized, for the host platform --
+# not the multi-arch image CI publishes on a tag (see .github/workflows/image.yml).
+image:
+	docker build -t $(IMAGE):$(TAG) .
 
 clean:
 	rm -rf bin coverage.out

--- a/README.md
+++ b/README.md
@@ -71,6 +71,18 @@ params.lr                 identity      3e-4                  1e-4
 metrics.loss              metric        0.42                  0.3
 ```
 
+Or bring it up in a container instead of building locally:
+
+```bash
+docker compose up
+```
+
+That builds the image from the `Dockerfile` and starts `runledger` on
+`:8080` with a persistent volume mounted for the store (currently unused --
+see [Status](#status)). Published images land on `ghcr.io/lurking-walrus/run-ledger`
+on tagged releases; `make image` builds the same image locally for the host
+platform.
+
 ## Layout
 
 ```

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,24 @@
+services:
+  runledger:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: run-ledger:local
+    ports:
+      - "8080:8080"
+    environment:
+      # Listen address inside the container; matches the EXPOSE 8080 in the
+      # Dockerfile. rlctl reads this same variable as a full server URL, so
+      # don't set it for a client container -- only the server wants ":8080".
+      RUNLEDGER_ADDR: ":8080"
+    volumes:
+      # The only backend today (internal/store.Memory) keeps nothing on disk,
+      # so this volume is unused until a durable backend (issue #1) lands --
+      # it just gives that backend a mount point ready to go, matching the
+      # *.duckdb/*.db pattern already in .gitignore, without another compose
+      # change on the day it's needed.
+      - runledger-data:/data
+    restart: unless-stopped
+
+volumes:
+  runledger-data:


### PR DESCRIPTION
Closes #9

## What changed

- **`Dockerfile`** — multi-stage build producing a static `runledger` binary (`CGO_ENABLED=0`) on `gcr.io/distroless/static-debian12:nonroot`, running as the image's built-in `nonroot` (uid 65532) user. Cross-compiles for `linux/amd64` and `linux/arm64` from one `golang:1.26-alpine` build stage via `TARGETOS`/`TARGETARCH`. A comment on the `CGO_ENABLED=0` line spells out the constraint the issue asked for: this only works because the current backend (`internal/store.Memory`) is pure Go — if the DuckDB backend (issue #1) lands first and forces cgo, this single cross-compiling stage stops working for the non-native arch and needs per-arch native builders instead, not a one-line flag flip.
- **`compose.yaml`** — `docker compose up` builds the image and starts `runledger` on `:8080` with a named volume mounted at `/data`. That volume is unused today (the in-memory store keeps nothing on disk) — it's there so a durable backend gets a mount point without another compose change; commented accordingly.
- **`Makefile`** — new `make image` target (`docker build -t $(IMAGE):$(TAG) .`), matching what `make build` produces, just containerized, for the host platform.
- **`.github/workflows/image.yml`** — new workflow, triggers on `v*` tags, builds `linux/amd64` + `linux/arm64` via buildx/QEMU, pushes to `ghcr.io/lurking-walrus/run-ledger`, and attests build provenance with `actions/attest-build-provenance` (`push-to-registry: true`). Uses the same `runs-on: ${{ fromJSON(vars.CI_RUNNER || '["ubuntu-latest"]') }}` fallback pattern as `ci.yml` so a stale/unset `CI_RUNNER` var can't queue this job forever.
- **`.github/workflows/ci.yml`** — added a `make image` step so a PR that breaks the Dockerfile fails CI, the same way a PR that breaks `go build` already does.
- **`README.md`** — short "bring it up in a container" note under "Try it".

## Verified locally

- `make lint`, `make vet`, `make test` all pass.
- `make image` builds successfully (confirmed both via a direct `docker build` and via the Makefile target).
- Ran the built image: `/healthz` returns `ok`, and `docker inspect` confirms the container runs as `nonroot:nonroot`.
- `docker compose config` parses `compose.yaml` cleanly.

## Follow-up (not in this PR)

- Publishing actually requires the `image.yml` workflow to run against a real tag push and the repo/org to have package-write permissions to `ghcr.io` — nothing here creates or pushes a live image; that only happens automatically the next time a `v*` tag is pushed.