### PR TITLE
ci: route image publish through the canonical switch, pin wsl

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -13,9 +13,11 @@ permissions:
 
 jobs:
   publish:
-    # See ci.yml for why the fallback here matters: self-hosted runner names
-    # going stale must not queue this job forever.
-    runs-on: ${{ fromJSON(vars.CI_RUNNER || '["ubuntu-latest"]') }}
+    # Pins wsl: this job runs a real `docker build`, and only the WSL pool has
+    # a non-nested Docker daemon (the Mac pool's own runners are themselves
+    # Docker containers). See .github-private/docs/CI-RUNNER-ROUTING.md,
+    # "Docker-dependent jobs must pin the WSL pool".
+    runs-on: ${{ fromJSON(vars.USE_SELF_HOSTED_RUNNER == 'true' && github.event.repository.private && '["self-hosted","Linux","wsl"]' || '["ubuntu-latest"]') }}
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
`image.yml` still used the pre-canonical `vars.CI_RUNNER` pattern, which was explicitly rejected as a second competing switch (see `.github-private` PR #56 — one switch, `USE_SELF_HOSTED_RUNNER`, moves the whole fleet).

Moved it onto the canonical expression, and pinned the `wsl` label: this job runs a real `docker build` (multi-arch, via buildx/QEMU), and the Mac pool's own runners are themselves Docker containers, so they can't nest another Docker build without mounting the host socket — a boundary this org deliberately doesn't cross (see `Lurking-Walrus/.github-private#83`, "Docker-dependent jobs must pin the WSL pool").

Also deleted the now-dead repo-level `CI_RUNNER` variable this workflow was the only reader of.

Found while doing an org-wide CI sweep, flagged by another session already working this repo (run-ledger#16/#9) — this is a separate, pre-existing gap in a different workflow file, not overlapping with that fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)