### PR TITLE
Report metric spread across runs that share a fingerprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,10 +96,11 @@ Pass `--store duckdb --dsn ./runs.duckdb` (or `RUNLEDGER_STORE=duckdb` /
 
 ```
 cmd/runledger/     HTTP server
-cmd/rlctl/         researcher CLI: record · list · show · diff
+cmd/rlctl/         researcher CLI: record · list · show · diff · spread
 internal/lineage/  the Run record, validation, content-addressed fingerprint
 internal/store/    Store interface + in-memory reference and DuckDB backends
 internal/compare/  structured diff, identity vs provenance vs metric
+internal/spread/   per-fingerprint metric spread across repeated runs
 internal/api/      HTTP handlers
 python/runledger/  in-process Python client: `Run.start()` as a context manager
 ```
@@ -116,6 +117,8 @@ implementation cannot quietly disagree about ordering or idempotency.
 | `GET` | `/runs` | list, filtered by `project`, `git_commit`, `fingerprint`, `status`, `device`, `limit` |
 | `GET` | `/runs/{id}` | one run |
 | `GET` | `/compare?a=X&b=Y` | structured diff, with `unattributable` |
+| `GET` | `/fingerprints?project=P` | fingerprints with more than one run, ranked by widest relative metric spread |
+| `GET` | `/fingerprints/{fingerprint}` | one group: per-metric count/min/max/mean/stddev, or `no_repeats` for a lone run |
 | `GET` | `/healthz` | liveness |
 | `GET` | `/readyz` | readiness — the store answers a call |
 | `GET` | `/metrics` | self-metrics, Prometheus exposition format |

--- a/cmd/rlctl/main.go
+++ b/cmd/rlctl/main.go
@@ -11,11 +11,13 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"sort"
 	"strings"
 	"time"
 
 	"github.com/kornsour/run-ledger/internal/compare"
 	"github.com/kornsour/run-ledger/internal/lineage"
+	"github.com/kornsour/run-ledger/internal/spread"
 )
 
 const usage = `rlctl — record and compare experiment runs
@@ -25,6 +27,8 @@ const usage = `rlctl — record and compare experiment runs
   rlctl list   [--project P] [--commit SHA] [--status S] [--limit N]
   rlctl show   <run-id>
   rlctl diff   <run-a> <run-b>
+  rlctl spread [--project P]     Rank fingerprints with repeats by widest metric spread.
+  rlctl spread <fingerprint>     Show per-metric count/min/max/mean/stddev for one group.
 
   --server defaults to $RUNLEDGER_ADDR or http://localhost:8080
   RUNLEDGER_TOKEN, if set, is sent as a bearer token on every request. It is
@@ -47,6 +51,8 @@ func main() {
 		err = cmdShow(os.Args[2:])
 	case "diff":
 		err = cmdDiff(os.Args[2:])
+	case "spread":
+		err = cmdSpread(os.Args[2:])
 	case "-h", "--help", "help":
 		fmt.Print(usage)
 		return
@@ -215,6 +221,87 @@ func cmdDiff(args []string) error {
 		fmt.Println("Something that affected the result is not captured in the record.")
 	}
 	return nil
+}
+
+func cmdSpread(args []string) error {
+	fs := flag.NewFlagSet("spread", flag.ExitOnError)
+	server := fs.String("server", defaultServer(), "ledger address")
+	project := fs.String("project", "", "filter by project (spread listing only)")
+	_ = fs.Parse(args)
+
+	switch fs.NArg() {
+	case 0:
+		return spreadList(*server, *project)
+	case 1:
+		return spreadOne(*server, fs.Arg(0))
+	default:
+		return fmt.Errorf("spread takes either --project or exactly one fingerprint, not both")
+	}
+}
+
+func spreadList(server, project string) error {
+	q := url.Values{}
+	set(q, "project", project)
+	var out struct {
+		Groups []spread.Group `json:"groups"`
+		Count  int            `json:"count"`
+	}
+	if err := call(http.MethodGet, server+"/fingerprints?"+q.Encode(), nil, &out); err != nil {
+		return err
+	}
+	if out.Count == 0 {
+		fmt.Println("no fingerprint has more than one recorded run")
+		return nil
+	}
+	// The server already ranks widest-first; keep that order.
+	fmt.Printf("%-18s  %-5s  %-10s  %s\n", "FINGERPRINT", "RUNS", "WIDEST CV", "PROVENANCE DIFFERS")
+	for _, g := range out.Groups {
+		fmt.Printf("%-18s  %-5d  %-10.4f  %s\n",
+			trunc(g.Fingerprint, 18), g.Count, g.Widest(), provenanceFields(g.Provenance))
+	}
+	return nil
+}
+
+func spreadOne(server, fingerprint string) error {
+	var g spread.Group
+	if err := call(http.MethodGet, server+"/fingerprints/"+url.PathEscape(fingerprint), nil, &g); err != nil {
+		return err
+	}
+	fmt.Printf("fingerprint %s — %d run(s)\n", g.Fingerprint, g.Count)
+	if g.NoRepeats {
+		fmt.Println("no repeats: only one run has been recorded for this experiment")
+		return nil
+	}
+
+	keys := make([]string, 0, len(g.Metrics))
+	for k := range g.Metrics {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	fmt.Printf("\n%-20s  %-4s  %-12s  %-12s  %-12s  %s\n", "METRIC", "N", "MIN", "MAX", "MEAN", "STDDEV")
+	for _, k := range keys {
+		m := g.Metrics[k]
+		fmt.Printf("%-20s  %-4d  %-12g  %-12g  %-12g  %g\n", k, m.Count, m.Min, m.Max, m.Mean, m.StdDev)
+	}
+
+	if len(g.Provenance) > 0 {
+		fmt.Println("\nprovenance differs across these runs — the likeliest explanation for the spread:")
+		for _, p := range g.Provenance {
+			fmt.Printf("  %-18s %s\n", p.Field, strings.Join(p.Values, ", "))
+		}
+	}
+	return nil
+}
+
+func provenanceFields(diffs []spread.ProvenanceDiff) string {
+	if len(diffs) == 0 {
+		return "—"
+	}
+	names := make([]string, len(diffs))
+	for i, d := range diffs {
+		names[i] = d.Field
+	}
+	return strings.Join(names, ", ")
 }
 
 func call(method, endpoint string, body []byte, out any) error {

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -12,6 +12,7 @@ import (
 	"log/slog"
 	"net/http"
 	"runtime/debug"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -19,6 +20,7 @@ import (
 	"github.com/kornsour/run-ledger/internal/compare"
 	"github.com/kornsour/run-ledger/internal/lineage"
 	"github.com/kornsour/run-ledger/internal/metrics"
+	"github.com/kornsour/run-ledger/internal/spread"
 	"github.com/kornsour/run-ledger/internal/store"
 )
 
@@ -110,6 +112,8 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /runs", s.requireAuth(false, s.list))
 	mux.HandleFunc("GET /runs/{id}", s.requireAuth(false, s.get))
 	mux.HandleFunc("GET /compare", s.requireAuth(false, s.compare))
+	mux.HandleFunc("GET /fingerprints", s.requireAuth(false, s.spreadList))
+	mux.HandleFunc("GET /fingerprints/{fingerprint}", s.requireAuth(false, s.spreadOne))
 	// /healthz stays unauthenticated so a liveness probe does not need a
 	// credential.
 	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, _ *http.Request) {
@@ -341,6 +345,46 @@ func (s *Server) compare(w http.ResponseWriter, r *http.Request) {
 		"result":         res,
 		"unattributable": res.Unattributable(),
 	})
+}
+
+// spreadList answers "which experiments in this project reproduce worst?" --
+// every fingerprint with more than one recorded run, ranked by the widest
+// relative metric spread. project is optional; omitted, it ranks across
+// every project the store holds.
+func (s *Server) spreadList(w http.ResponseWriter, r *http.Request) {
+	runs, err := s.store.List(r.Context(), store.Query{Project: r.URL.Query().Get("project")})
+	if err != nil {
+		s.metrics.StoreError("internal")
+		writeErr(w, http.StatusInternalServerError, err)
+		return
+	}
+	var groups []spread.Group
+	for _, g := range spread.Compute(runs) {
+		if g.Count > 1 {
+			groups = append(groups, g)
+		}
+	}
+	sort.Slice(groups, func(i, j int) bool { return groups[i].Widest() > groups[j].Widest() })
+	writeJSON(w, http.StatusOK, map[string]any{"groups": groups, "count": len(groups)})
+}
+
+// spreadOne answers "how much do this experiment's own repeats vary?" for
+// one fingerprint, including a group of size one -- reported as no repeats
+// rather than a misleadingly perfect standard deviation of zero.
+func (s *Server) spreadOne(w http.ResponseWriter, r *http.Request) {
+	fp := r.PathValue("fingerprint")
+	runs, err := s.store.List(r.Context(), store.Query{Fingerprint: fp})
+	if err != nil {
+		s.metrics.StoreError("internal")
+		writeErr(w, http.StatusInternalServerError, err)
+		return
+	}
+	if len(runs) == 0 {
+		s.metrics.StoreError("not_found")
+		writeErr(w, http.StatusNotFound, fmt.Errorf("no run recorded with fingerprint %q", fp))
+		return
+	}
+	writeJSON(w, http.StatusOK, spread.One(fp, runs))
 }
 
 func parseLimit(s string) (int, error) {

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -308,6 +308,110 @@ func TestReadTokenCannotWrite(t *testing.T) {
 	}
 }
 
+func TestFingerprintsListOnlyIncludesRepeats(t *testing.T) {
+	h := srv(t)
+	// Two runs of the same experiment (identical identity fields, so they
+	// share a fingerprint), one run of a different experiment.
+	post(t, h, `{"project":"p","git_commit":"abc","config_hash":"cfg","seed":1,"metrics":{"loss":0.4}}`)
+	post(t, h, `{"project":"p","git_commit":"abc","config_hash":"cfg","seed":1,"metrics":{"loss":0.5}}`)
+	post(t, h, `{"project":"p","git_commit":"abc","config_hash":"cfg","seed":2,"metrics":{"loss":0.1}}`)
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/fingerprints?project=p", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body)
+	}
+	var out struct {
+		Count  int `json:"count"`
+		Groups []struct {
+			Fingerprint string `json:"fingerprint"`
+			Count       int    `json:"count"`
+		} `json:"groups"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
+		t.Fatal(err)
+	}
+	if out.Count != 1 || len(out.Groups) != 1 {
+		t.Fatalf("want exactly one group with repeats, got %+v", out)
+	}
+	if out.Groups[0].Count != 2 {
+		t.Fatalf("want the repeated group to report 2 runs, got %d", out.Groups[0].Count)
+	}
+}
+
+func TestFingerprintOneGroupReportsMetricStats(t *testing.T) {
+	h := srv(t)
+	var a, b map[string]any
+	w := post(t, h, `{"project":"p","git_commit":"abc","config_hash":"cfg","seed":1,"metrics":{"loss":0.4}}`)
+	_ = json.Unmarshal(w.Body.Bytes(), &a)
+	w = post(t, h, `{"project":"p","git_commit":"abc","config_hash":"cfg","seed":1,"metrics":{"loss":0.5}}`)
+	_ = json.Unmarshal(w.Body.Bytes(), &b)
+	fp := a["fingerprint"].(string)
+
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/fingerprints/"+fp, nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body)
+	}
+	var out struct {
+		Count     int  `json:"count"`
+		NoRepeats bool `json:"no_repeats"`
+		Metrics   map[string]struct {
+			Count  int     `json:"count"`
+			Mean   float64 `json:"mean"`
+			StdDev float64 `json:"stddev"`
+		} `json:"metrics"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
+		t.Fatal(err)
+	}
+	if out.NoRepeats || out.Count != 2 {
+		t.Fatalf("want a two-run group, not no_repeats, got %+v", out)
+	}
+	loss, ok := out.Metrics["loss"]
+	if !ok || loss.Count != 2 {
+		t.Fatalf("want a loss stat over both runs, got %+v", out.Metrics)
+	}
+	if loss.Mean != 0.45 {
+		t.Fatalf("want mean 0.45, got %v", loss.Mean)
+	}
+}
+
+func TestFingerprintSingleRunIsNoRepeats(t *testing.T) {
+	h := srv(t)
+	w := post(t, h, `{"project":"p","git_commit":"abc","config_hash":"cfg","seed":1,"metrics":{"loss":0.4}}`)
+	var created map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &created)
+	fp := created["fingerprint"].(string)
+
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/fingerprints/"+fp, nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body)
+	}
+	var out struct {
+		NoRepeats bool           `json:"no_repeats"`
+		Metrics   map[string]any `json:"metrics"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
+		t.Fatal(err)
+	}
+	if !out.NoRepeats {
+		t.Fatal("a single run recorded for this fingerprint must be reported as no repeats")
+	}
+	if len(out.Metrics) != 0 {
+		t.Fatalf("a no-repeats group must not report metric stats, got %+v", out.Metrics)
+	}
+}
+
+func TestFingerprintUnknownIs404(t *testing.T) {
+	w := httptest.NewRecorder()
+	srv(t).ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/fingerprints/nope", nil))
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("want 404, got %d", w.Code)
+	}
+}
+
 func TestHealthzUnauthenticatedEvenWithTokenConfigured(t *testing.T) {
 	h := srvWithAuth(t, Auth{WriteToken: "write-secret"})
 	w := httptest.NewRecorder()

--- a/internal/spread/spread.go
+++ b/internal/spread/spread.go
@@ -1,0 +1,183 @@
+// Package spread answers "how much do runs of this same experiment vary?"
+//
+// compare.Runs diffs exactly two runs. Spread groups every run that shares a
+// fingerprint -- the same experiment, repeated -- and summarizes, per metric,
+// how much the measured result actually moved. That number is a project's
+// reproducibility floor: it is what tells you whether a later improvement is
+// real or inside the noise these repeats already show.
+package spread
+
+import (
+	"math"
+	"sort"
+
+	"github.com/kornsour/run-ledger/internal/lineage"
+)
+
+// MetricStat summarizes one metric across a fingerprint group's runs.
+//
+// Count is how many of the group's runs reported this metric, not the
+// group's size -- a metric only some runs logged is not zero on the rest,
+// the same rule compare.Result already follows for a missing metric.
+type MetricStat struct {
+	Count  int     `json:"count"`
+	Min    float64 `json:"min"`
+	Max    float64 `json:"max"`
+	Mean   float64 `json:"mean"`
+	StdDev float64 `json:"stddev"`
+}
+
+// ProvenanceDiff records a provenance field that is not constant across a
+// group's runs. Provenance does not feed the fingerprint, so a group is free
+// to disagree on it -- and when it does, that disagreement is the most
+// common explanation for whatever metric spread the group shows.
+type ProvenanceDiff struct {
+	Field  string   `json:"field"`
+	Values []string `json:"values"`
+}
+
+// Group is the spread summary for every recorded run of one fingerprint.
+type Group struct {
+	Fingerprint string   `json:"fingerprint"`
+	RunIDs      []string `json:"run_ids"`
+	Count       int      `json:"count"`
+	// NoRepeats is true when exactly one run has this fingerprint. Metrics is
+	// left empty rather than reporting a standard deviation of zero, which
+	// would claim a reproducibility this group was never asked to show.
+	NoRepeats  bool                  `json:"no_repeats"`
+	Metrics    map[string]MetricStat `json:"metrics,omitempty"`
+	Provenance []ProvenanceDiff      `json:"provenance,omitempty"`
+}
+
+// Widest is a group's ranking key: the largest coefficient of variation
+// (|stddev / mean|) across its metrics. A metric with a zero mean, or a
+// metric only one run in the group reported, contributes nothing measurable
+// and is skipped rather than dividing by zero or resting on a single sample.
+// A group with nothing measurable -- no repeats, or no metric with a
+// nonzero mean -- ranks last: there is no spread here for this ranking to
+// surface.
+func (g Group) Widest() float64 {
+	widest := -1.0
+	for _, m := range g.Metrics {
+		if m.Mean == 0 {
+			continue
+		}
+		if cv := math.Abs(m.StdDev / m.Mean); cv > widest {
+			widest = cv
+		}
+	}
+	return widest
+}
+
+// provenanceFields are the provenance columns most likely to explain a
+// same-fingerprint metric difference -- compare.go classifies these two the
+// same way, as KindProvenance.
+var provenanceFields = []struct {
+	name string
+	get  func(lineage.Run) string
+}{
+	{"device", func(r lineage.Run) string { return r.Device }},
+	{"framework_version", func(r lineage.Run) string { return r.FrameworkVersion }},
+}
+
+// Compute groups runs by fingerprint and summarizes each group. runs need
+// not already be grouped, sorted, or limited to one fingerprint or project.
+func Compute(runs []lineage.Run) []Group {
+	byFP := map[string][]lineage.Run{}
+	var order []string
+	for _, r := range runs {
+		if _, ok := byFP[r.Fingerprint]; !ok {
+			order = append(order, r.Fingerprint)
+		}
+		byFP[r.Fingerprint] = append(byFP[r.Fingerprint], r)
+	}
+	groups := make([]Group, 0, len(order))
+	for _, fp := range order {
+		groups = append(groups, One(fp, byFP[fp]))
+	}
+	return groups
+}
+
+// One summarizes a single fingerprint's runs. It is exported separately from
+// Compute so GET /fingerprints/{fingerprint} -- which already has exactly the
+// runs of one group, via Store.List(Query{Fingerprint: fp}) -- does not need
+// to re-derive the grouping Compute exists to do over a wider listing.
+func One(fingerprint string, runs []lineage.Run) Group {
+	ids := make([]string, len(runs))
+	for i, r := range runs {
+		ids[i] = r.RunID
+	}
+	sort.Strings(ids)
+
+	g := Group{Fingerprint: fingerprint, RunIDs: ids, Count: len(runs)}
+	if len(runs) < 2 {
+		g.NoRepeats = true
+		return g
+	}
+	g.Metrics = metricStats(runs)
+	g.Provenance = provenanceDiffs(runs)
+	return g
+}
+
+func metricStats(runs []lineage.Run) map[string]MetricStat {
+	values := map[string][]float64{}
+	for _, r := range runs {
+		for k, v := range r.Metrics {
+			values[k] = append(values[k], v)
+		}
+	}
+	if len(values) == 0 {
+		return nil
+	}
+	out := make(map[string]MetricStat, len(values))
+	for k, vs := range values {
+		out[k] = stat(vs)
+	}
+	return out
+}
+
+// stat computes count/min/max/mean/stddev over a non-empty slice.
+//
+// StdDev is the population standard deviation, not a sample estimate: a
+// fingerprint group is every run of that experiment recorded so far, not a
+// sample drawn from some larger population of runs.
+func stat(vs []float64) MetricStat {
+	n := len(vs)
+	min, max, sum := vs[0], vs[0], 0.0
+	for _, v := range vs {
+		if v < min {
+			min = v
+		}
+		if v > max {
+			max = v
+		}
+		sum += v
+	}
+	mean := sum / float64(n)
+	var sq float64
+	for _, v := range vs {
+		d := v - mean
+		sq += d * d
+	}
+	return MetricStat{Count: n, Min: min, Max: max, Mean: mean, StdDev: math.Sqrt(sq / float64(n))}
+}
+
+func provenanceDiffs(runs []lineage.Run) []ProvenanceDiff {
+	var diffs []ProvenanceDiff
+	for _, f := range provenanceFields {
+		seen := map[string]bool{}
+		var values []string
+		for _, r := range runs {
+			v := f.get(r)
+			if !seen[v] {
+				seen[v] = true
+				values = append(values, v)
+			}
+		}
+		if len(values) > 1 {
+			sort.Strings(values)
+			diffs = append(diffs, ProvenanceDiff{Field: f.name, Values: values})
+		}
+	}
+	return diffs
+}

--- a/internal/spread/spread_test.go
+++ b/internal/spread/spread_test.go
@@ -1,0 +1,149 @@
+package spread
+
+import (
+	"math"
+	"testing"
+
+	"github.com/kornsour/run-ledger/internal/lineage"
+)
+
+func run(id string, metrics map[string]float64) lineage.Run {
+	r := lineage.Run{Project: "p", GitCommit: "abc", ConfigHash: "cfg", Seed: 1, RunID: id, Metrics: metrics}
+	r.Fingerprint = r.Compute()
+	return r
+}
+
+func TestGroupOfOneIsNoRepeats(t *testing.T) {
+	a := run("a", map[string]float64{"loss": 0.42})
+	g := One(a.Fingerprint, []lineage.Run{a})
+	if !g.NoRepeats {
+		t.Fatal("a single run must be reported as no repeats")
+	}
+	if g.Metrics != nil {
+		t.Fatalf("a group with no repeats must not report metric stats, got %+v", g.Metrics)
+	}
+	if g.Count != 1 {
+		t.Fatalf("want count 1, got %d", g.Count)
+	}
+}
+
+func TestGroupStatsAcrossRepeats(t *testing.T) {
+	fp := run("x", nil).Fingerprint
+	runs := []lineage.Run{
+		run("a", map[string]float64{"loss": 0.40}),
+		run("b", map[string]float64{"loss": 0.50}),
+	}
+	runs[0].Fingerprint, runs[1].Fingerprint = fp, fp
+	g := One(fp, runs)
+	if g.NoRepeats {
+		t.Fatal("two runs is a repeat, not a singleton")
+	}
+	m, ok := g.Metrics["loss"]
+	if !ok {
+		t.Fatal("want a loss entry")
+	}
+	if m.Count != 2 {
+		t.Fatalf("want count 2, got %d", m.Count)
+	}
+	if m.Min != 0.40 || m.Max != 0.50 {
+		t.Fatalf("want min 0.40 max 0.50, got min=%v max=%v", m.Min, m.Max)
+	}
+	if math.Abs(m.Mean-0.45) > 1e-9 {
+		t.Fatalf("want mean 0.45, got %v", m.Mean)
+	}
+	wantStdDev := 0.05 // population stddev of {0.40, 0.50}
+	if math.Abs(m.StdDev-wantStdDev) > 1e-9 {
+		t.Fatalf("want stddev %v, got %v", wantStdDev, m.StdDev)
+	}
+}
+
+func TestAbsentMetricIsNotCountedAsZero(t *testing.T) {
+	runs := []lineage.Run{
+		run("a", map[string]float64{"loss": 0.4, "acc": 0.9}),
+		run("b", map[string]float64{"loss": 0.5}), // no acc reported
+	}
+	g := One("fp", runs)
+	acc := g.Metrics["acc"]
+	if acc.Count != 1 {
+		t.Fatalf("acc was reported by one run, want count 1, got %d", acc.Count)
+	}
+	if acc.StdDev != 0 {
+		t.Fatalf("a single sample has no spread, got stddev %v", acc.StdDev)
+	}
+	loss := g.Metrics["loss"]
+	if loss.Count != 2 {
+		t.Fatalf("loss was reported by both runs, want count 2, got %d", loss.Count)
+	}
+}
+
+func TestProvenanceDiffsSurfaceDeviceAndFrameworkVersion(t *testing.T) {
+	a := run("a", map[string]float64{"loss": 0.4})
+	a.Device, a.FrameworkVersion = "cpu", "2.1"
+	b := run("b", map[string]float64{"loss": 0.5})
+	b.Device, b.FrameworkVersion = "cuda", "2.1"
+
+	g := One("fp", []lineage.Run{a, b})
+	if len(g.Provenance) != 1 {
+		t.Fatalf("want exactly one provenance diff (device), got %+v", g.Provenance)
+	}
+	if g.Provenance[0].Field != "device" {
+		t.Fatalf("want device to be flagged, got %q", g.Provenance[0].Field)
+	}
+	if len(g.Provenance[0].Values) != 2 {
+		t.Fatalf("want both device values listed, got %v", g.Provenance[0].Values)
+	}
+}
+
+func TestProvenanceDiffsEmptyWhenConstant(t *testing.T) {
+	a := run("a", map[string]float64{"loss": 0.4})
+	a.Device = "cpu"
+	b := run("b", map[string]float64{"loss": 0.5})
+	b.Device = "cpu"
+
+	g := One("fp", []lineage.Run{a, b})
+	if len(g.Provenance) != 0 {
+		t.Fatalf("no provenance field differs, want none flagged, got %+v", g.Provenance)
+	}
+}
+
+func TestComputeGroupsByFingerprint(t *testing.T) {
+	a := run("a", map[string]float64{"loss": 0.4})
+	b := run("b", map[string]float64{"loss": 0.5})
+	b.Seed = 2
+	b.Fingerprint = b.Compute() // a different experiment
+
+	groups := Compute([]lineage.Run{a, b})
+	if len(groups) != 2 {
+		t.Fatalf("want two distinct fingerprint groups, got %d", len(groups))
+	}
+	for _, g := range groups {
+		if g.Count != 1 || !g.NoRepeats {
+			t.Fatalf("each fingerprint here has exactly one run: %+v", g)
+		}
+	}
+}
+
+func TestWidestRanksLargerCoefficientOfVariationFirst(t *testing.T) {
+	tight := Group{Metrics: map[string]MetricStat{"loss": {Mean: 1.0, StdDev: 0.01}}}
+	wide := Group{Metrics: map[string]MetricStat{"loss": {Mean: 1.0, StdDev: 0.5}}}
+	if !(wide.Widest() > tight.Widest()) {
+		t.Fatalf("want the wider relative spread to rank higher: wide=%v tight=%v", wide.Widest(), tight.Widest())
+	}
+}
+
+func TestWidestIgnoresZeroMeanMetric(t *testing.T) {
+	g := Group{Metrics: map[string]MetricStat{
+		"delta": {Mean: 0, StdDev: 3}, // would divide by zero if not skipped
+		"loss":  {Mean: 1.0, StdDev: 0.2},
+	}}
+	if got := g.Widest(); math.Abs(got-0.2) > 1e-9 {
+		t.Fatalf("want the zero-mean metric skipped and loss's cv (0.2) used, got %v", got)
+	}
+}
+
+func TestWidestOfNoRepeatsGroupRanksLast(t *testing.T) {
+	g := Group{NoRepeats: true}
+	if got := g.Widest(); got >= 0 {
+		t.Fatalf("a group with nothing measurable should rank below any group that has a spread, got %v", got)
+	}
+}


### PR DESCRIPTION
Closes #4

Adds `internal/spread`, which groups runs by fingerprint and summarizes each
group's metrics (count, min, max, mean, population standard deviation) plus
any provenance fields (`device`, `framework_version`) that differ across the
group — the most common explanation for spread the record can't otherwise
attribute. A group of size one is reported as `no_repeats` rather than a
standard deviation of zero, following the same absent-is-not-zero rule
`compare.Result` already applies to a missing metric.

**New HTTP endpoints**
- `GET /fingerprints?project=P` — fingerprints with more than one run,
  ranked by widest relative metric spread (coefficient of variation,
  `|stddev / mean|`, max across a group's metrics)
- `GET /fingerprints/{fingerprint}` — one group's full per-metric stats

**New CLI**
- `rlctl spread --project P` — renders the ranked table
- `rlctl spread <fingerprint>` — drills into one group

No changes to `store.Store`: both endpoints are built on the existing
`Store.List(Query{Project, Fingerprint})`, so `Memory` and `DuckDB` both
support this with no interface or schema change.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`, `gofmt -l .` clean
- [x] `go test -race ./...` — all packages pass, including new
      `internal/spread` unit tests and new `internal/api` handler tests
- [x] Manual smoke test: `make build`, ran `runledger`, recorded two runs of
      the same experiment (differing `device`) plus one unrelated run,
      verified `rlctl spread --project demo` ranks the repeated group with
      its coefficient of variation and flags `device` as differing
      provenance, `rlctl spread <fingerprint>` shows per-metric stats, and
      a lone run's fingerprint reports "no repeats" instead of stddev 0