### PR TITLE
Paginate GET /runs with a stable keyset cursor

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,12 +113,43 @@ implementation cannot quietly disagree about ordering or idempotency.
 | Method | Path | |
 |---|---|---|
 | `POST` | `/runs` | record a run; the server assigns the fingerprint and id |
-| `GET` | `/runs` | list, filtered by `project`, `git_commit`, `fingerprint`, `status`, `device`, `limit` |
+| `GET` | `/runs` | list, filtered by `project`, `git_commit`, `fingerprint`, `status`, `device`; paginated, see below |
 | `GET` | `/runs/{id}` | one run |
 | `GET` | `/compare?a=X&b=Y` | structured diff, with `unattributable` |
 | `GET` | `/healthz` | liveness |
 | `GET` | `/readyz` | readiness — the store answers a call |
 | `GET` | `/metrics` | self-metrics, Prometheus exposition format |
+
+### Pagination
+
+`GET /runs` returns a page, not the whole result set:
+
+```json
+{"runs": [ ... ], "count": 50, "limit": 50, "next_cursor": "v1:..."}
+```
+
+- `limit` requests a page size; the server accepts up to 500 and defaults to
+  50 when omitted. The response's own `limit` field is the size actually
+  applied — always check it rather than assuming the request was honored
+  verbatim.
+- `next_cursor` is present only when more rows may follow. Pass it back as
+  `?cursor=...` to fetch the next page; its absence means the traversal is
+  done. Treat the value as opaque — it encodes an internal sort position, not
+  a row offset, and its format is not part of the API contract.
+- Pages are ordered newest-first (`started_at`, then `run_id` as a tiebreak)
+  and paginated by that same key, not by `LIMIT`/`OFFSET`. A run inserted
+  between two `List` calls does not shift what a later page returns the way
+  it would with offset pagination — no row already visited is ever skipped
+  or repeated because of a concurrent insert.
+- **What a page is consistent with:** each page reflects the ledger as of
+  its cursor's position, not a single fixed snapshot of the whole listing.
+  A row recorded after a traversal begins, and sorting behind whatever
+  position the traversal has already reached, is simply not visited by that
+  traversal — it is exactly the kind of row a fresh `GET /runs` (no cursor)
+  would show first. For an append-mostly ledger this is the cheap, honest
+  contract: no page ever repeats or skips a row that existed before the
+  traversal reached it, and nothing is promised about rows that did not.
+  See [ADR 0007](docs/adr/0007-keyset-pagination-cursor-consistency.md).
 
 ## Python client
 
@@ -220,6 +251,14 @@ have to be true to revisit each one — lives in [`docs/adr/`](docs/adr/).
   `CGO_ENABLED=0` no longer builds this module, and the container image needs a
   C toolchain and a matching libc instead of `distroless/static`.
   ([ADR 0006](docs/adr/0006-duckdb-store-backend-and-the-cgo-cost.md))
+- **`GET /runs` paginates by keyset cursor, not `LIMIT`/`OFFSET`, and is capped
+  server-side.** An offset shifts under concurrent inserts, silently skipping a
+  row a client paging through history should have seen; a cursor encoding the
+  last row's sort key does not. A page is consistent with the ledger as of the
+  cursor's position — a row recorded after a traversal begins is simply not in
+  it, the same as it wouldn't be in a fresh, uncursored request made at that
+  same moment.
+  ([ADR 0007](docs/adr/0007-keyset-pagination-cursor-consistency.md))
 
 ## Status
 

--- a/cmd/rlctl/main.go
+++ b/cmd/rlctl/main.go
@@ -22,7 +22,9 @@ const usage = `rlctl — record and compare experiment runs
 
   rlctl record --project P [--seed N] [--dataset V] [--model V] [--param k=v ...] [--metric k=v ...]
                            Capture git context from the working tree and record a run.
-  rlctl list   [--project P] [--commit SHA] [--status S] [--limit N]
+  rlctl list   [--project P] [--commit SHA] [--status S] [--limit N] [--cursor C]
+                           Server caps --limit; pass the printed "next cursor"
+                           back as --cursor to fetch the following page.
   rlctl show   <run-id>
   rlctl diff   <run-a> <run-b>
 
@@ -137,18 +139,21 @@ func cmdList(args []string) error {
 	project := fs.String("project", "", "filter by project")
 	commit := fs.String("commit", "", "filter by git commit")
 	status := fs.String("status", "", "filter by status")
-	limit := fs.Int("limit", 20, "maximum rows")
+	limit := fs.Int("limit", 20, "maximum rows (server-capped; see --help)")
+	cursor := fs.String("cursor", "", "opaque page cursor from a previous list's \"next cursor\" line")
 	_ = fs.Parse(args)
 
 	q := url.Values{}
 	set(q, "project", *project)
 	set(q, "git_commit", *commit)
 	set(q, "status", *status)
+	set(q, "cursor", *cursor)
 	q.Set("limit", fmt.Sprint(*limit))
 
 	var out struct {
-		Runs  []lineage.Run `json:"runs"`
-		Count int           `json:"count"`
+		Runs       []lineage.Run `json:"runs"`
+		Count      int           `json:"count"`
+		NextCursor string        `json:"next_cursor"`
 	}
 	if err := call(http.MethodGet, *server+"/runs?"+q.Encode(), nil, &out); err != nil {
 		return err
@@ -162,6 +167,12 @@ func cmdList(args []string) error {
 		fmt.Printf("%-28s  %-12s  %-10s  %-10s  %s\n",
 			r.RunID, trunc(r.Project, 12), r.Status, trunc(r.GitCommit, 10),
 			r.StartedAt.Local().Format(time.RFC3339))
+	}
+	// A page reflects the ledger as of the cursor's position: a run recorded
+	// after this list started, and sorting earlier than the traversal has
+	// reached, will not appear when you follow this cursor.
+	if out.NextCursor != "" {
+		fmt.Printf("\nmore runs available: rlctl list ... --cursor %s\n", out.NextCursor)
 	}
 	return nil
 }

--- a/docs/adr/0007-keyset-pagination-cursor-consistency.md
+++ b/docs/adr/0007-keyset-pagination-cursor-consistency.md
@@ -1,0 +1,105 @@
+# ADR 0007: `GET /runs` paginates by keyset cursor, and a page is consistent with the cursor's position, not a fixed snapshot
+
+Status: Accepted
+Date: 2026-08-27
+
+> **A page is consistent with the data as of its cursor's position, not with
+> a single fixed snapshot of the whole listing.** A row recorded after a
+> traversal begins, sorting behind wherever the traversal has already
+> reached, is not visited by that traversal. This is the cheap, honest
+> consistency model for an append-mostly ledger: no page ever skips or
+> repeats a row that existed before the traversal reached it, and nothing
+> stronger is promised about rows written during it.
+
+## Context
+
+Before this record, `GET /runs` had one knob: an optional `limit` that
+truncated an otherwise-unbounded, newest-first result set. Two problems
+followed directly from that:
+
+- **Unbounded by default.** With no `limit`, a caller got the whole filtered
+  listing. That was fine while every ledger fit in a Go map; it stops being
+  fine the moment `store.DuckDB` (#2) makes it plausible for a ledger to hold
+  a real number of runs.
+- **No way to page.** A client that wanted "the next 50 after these" had
+  nothing to ask for beyond a larger `limit` and re-fetching everything already
+  seen. `LIMIT`/`OFFSET` was the obvious next step, and the wrong one: the
+  listing is sorted newest-first, so a run recorded between two page fetches
+  shifts every offset after it. A client paging through history with
+  `?limit=50&offset=50`, `?limit=50&offset=100`, ... silently skips whatever
+  row landed at the boundary, or sees one twice, depending on which direction
+  the shift goes. Nothing about that failure is visible to the client — the
+  request still succeeds, the page still has 50 rows, and one of them is
+  simply not the row it should have been.
+
+## Decision
+
+`GET /runs` pages by an opaque cursor instead of an offset. The cursor
+encodes the sort key of the last row on the page — `(started_at, run_id)`,
+the same total order `store.RunConformance` already required every backend
+to produce (`internal/store/{memory,duckdb}.go`) — not a row count. Passing
+it back as `?cursor=...` asks for "everything that sorts after this row,"
+which is a question concurrent inserts cannot invalidate the way "everything
+at position 100" can: a new row lands somewhere in the total order and either
+sorts before the cursor (already behind the traversal, never seen) or after
+it (still ahead, seen on some future page the same way it would have been
+if it existed when the traversal started).
+
+That "future page" case is the trade this ADR names on purpose. A row
+inserted after the traversal started, sorting behind the traversal's current
+position, is not retroactively inserted into a page already served, and the
+traversal is not guaranteed to double back for it. The alternative —
+snapshotting the entire result set at the first page so every subsequent page
+reads that snapshot — would need either an actual database snapshot/transaction
+held open for the lifetime of a client's traversal (unbounded, client-paced,
+exactly what `store.DuckDB`'s single-writer model does not want to hold open)
+or copying the whole matching set up front (defeating the reason pagination
+exists). For a ledger whose workload is "record a run, occasionally page
+through history," the honest and cheap answer is: a page reflects the ledger
+as of the cursor's position, full stop, and that is what the API docs
+(README's "Pagination" section) say rather than leaving a client to discover
+it empirically.
+
+`limit` gets a server-side ceiling for the same reason the endpoint needed a
+cursor at all: an unbounded page is a caller (or the size of the ledger
+itself) deciding how large a response the server hands back. `GET /runs` now
+defaults to 50 and refuses to return more than 500 regardless of what a
+request asks for, and echoes the limit it actually applied (`limit` in the
+response body) so a client doesn't have to assume its request was honored
+verbatim.
+
+## Consequences
+
+- `store.Query` gained `After *store.Cursor`; `store.Store.List` returns
+  `store.Page{Runs, Next}` instead of a bare slice. Both `Memory` and
+  `DuckDB` implement the same keyset predicate — "strictly after this
+  `(started_at, run_id)` in the listing's total order" — so pagination
+  behavior does not depend on which backend answered, the same guarantee
+  `store.RunConformance` already enforced for ordering and idempotency.
+- A client that stops paging once `next_cursor` is absent has seen every row
+  that existed at or before the moment its traversal reached the end — not
+  every row that exists now. A dashboard that wants "what's new since I last
+  looked" needs a different query shape than "page through everything";
+  `GET /runs` answers the second one.
+- The cursor is deliberately opaque and version-tagged (`v1:` in
+  `internal/api/api.go`) rather than a bare `started_at,run_id` pair a client
+  might be tempted to construct itself. Changing what a cursor encodes later
+  is then a matter of bumping the tag and rejecting the old one, not a
+  breaking change to a format clients depend on.
+- `limit=0` is no longer how a client asks for "everything" — it is now a
+  rejected request (`limit must be a positive integer`). There is no
+  unbounded `GET /runs` anymore; a caller that genuinely needs the whole
+  listing pages through it.
+
+## What would have to be true to revisit this
+
+If a client needs a page that is consistent with a single fixed snapshot —
+provably every row that existed at the instant the traversal began, including
+rows that would otherwise land behind the traversal's later cursors — that is
+a different, stronger guarantee than this ADR provides, and would need either
+a store-level snapshot/transaction primitive held for the traversal's
+lifetime, or a materialized copy of the matching set taken up front. Nothing
+about the current cursor format prevents adding that as a separate mode later
+(e.g. a snapshot id embedded alongside the sort key); it just is not what
+`GET /runs` promises today, and should not be assumed until it is added and
+documented as such.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -17,6 +17,8 @@ section is a summary of these; this folder is the account.
 | [0003](0003-dirty-tree-without-config-hash-is-refused.md) | A dirty working tree without a config hash is refused | Accepted |
 | [0004](0004-fingerprint-input-is-a-versioned-contract.md) | The fingerprint input is a versioned contract | Accepted |
 | [0005](0005-python-client-writes-once-at-the-end.md) | The Python client writes the ledger exactly once, at the end of a run | Accepted |
+| [0006](0006-duckdb-store-backend-and-the-cgo-cost.md) | `store.DuckDB` as the durable backend, and accepting cgo to get it | Accepted |
+| [0007](0007-keyset-pagination-cursor-consistency.md) | `GET /runs` paginates by keyset cursor, and a page is consistent with the cursor's position, not a fixed snapshot | Accepted |
 
 ## Adding a record
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/subtle"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -21,6 +22,15 @@ import (
 	"github.com/kornsour/run-ledger/internal/metrics"
 	"github.com/kornsour/run-ledger/internal/store"
 )
+
+// DefaultListLimit is the page size GET /runs uses when a request does not
+// specify limit.
+const DefaultListLimit = 50
+
+// MaxListLimit is the largest page GET /runs will ever return, regardless of
+// what limit a request asks for. Without a ceiling, a client (or the size of
+// the ledger itself) decides how large a response the server hands back.
+const MaxListLimit = 500
 
 // Auth holds the bearer tokens that gate access to the API. A zero-value Auth
 // requires no token at all, which is the default: a single-user local ledger
@@ -93,11 +103,14 @@ func New(s store.Store, log *slog.Logger, opts ...Option) *Server {
 	// must not inflate it, and once the store is out of process it becomes
 	// the only source of truth anyway.
 	srv.metrics = metrics.New(func() float64 {
-		runs, err := s.List(context.Background(), store.Query{})
+		// Query{} with no Limit is intentionally unbounded here -- this is
+		// the total ledger size, not a page of it. GET /runs's own default
+		// and maximum limit live at the HTTP handler, not in the store.
+		page, err := s.List(context.Background(), store.Query{})
 		if err != nil {
 			return -1
 		}
-		return float64(len(runs))
+		return float64(len(page.Runs))
 	})
 	return srv
 }
@@ -302,20 +315,70 @@ func (s *Server) list(w http.ResponseWriter, r *http.Request) {
 		writeErr(w, http.StatusBadRequest, err)
 		return
 	}
-	runs, err := s.store.List(r.Context(), store.Query{
+	var after *store.Cursor
+	if raw := q.Get("cursor"); raw != "" {
+		c, err := decodeCursor(raw)
+		if err != nil {
+			writeErr(w, http.StatusBadRequest, err)
+			return
+		}
+		after = &c
+	}
+	page, err := s.store.List(r.Context(), store.Query{
 		Project:     q.Get("project"),
 		GitCommit:   q.Get("git_commit"),
 		Fingerprint: q.Get("fingerprint"),
 		Status:      lineage.Status(q.Get("status")),
 		Device:      q.Get("device"),
 		Limit:       limit,
+		After:       after,
 	})
 	if err != nil {
 		s.metrics.StoreError("internal")
 		writeErr(w, http.StatusInternalServerError, err)
 		return
 	}
-	writeJSON(w, http.StatusOK, map[string]any{"runs": runs, "count": len(runs)})
+	resp := map[string]any{"runs": page.Runs, "count": len(page.Runs), "limit": limit}
+	// next_cursor is present only when more rows may follow this page --
+	// its absence is how a client knows the traversal is done, not an empty
+	// string it has to special-case.
+	if page.Next != nil {
+		resp["next_cursor"] = encodeCursor(*page.Next)
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// encodeCursor and decodeCursor make a store.Cursor an opaque token safe to
+// hand to a client and accept back. The wire format (a version tag, the
+// start-time in nanoseconds, and the run id, colon-separated and
+// base64url-encoded) is not part of the API contract -- callers must treat
+// the string as opaque -- but is versioned so a future change to what a
+// cursor encodes cannot be silently misread as the old format.
+const cursorVersion = "v1"
+
+func encodeCursor(c store.Cursor) string {
+	raw := fmt.Sprintf("%s:%d:%s", cursorVersion, c.StartedAt.UnixNano(), c.RunID)
+	return base64.RawURLEncoding.EncodeToString([]byte(raw))
+}
+
+func decodeCursor(s string) (store.Cursor, error) {
+	raw, err := base64.RawURLEncoding.DecodeString(s)
+	if err != nil {
+		return store.Cursor{}, fmt.Errorf("invalid cursor")
+	}
+	version, rest, ok := strings.Cut(string(raw), ":")
+	if !ok || version != cursorVersion {
+		return store.Cursor{}, fmt.Errorf("invalid or unsupported cursor")
+	}
+	nsStr, runID, ok := strings.Cut(rest, ":")
+	if !ok || runID == "" {
+		return store.Cursor{}, fmt.Errorf("invalid cursor")
+	}
+	ns, err := strconv.ParseInt(nsStr, 10, 64)
+	if err != nil {
+		return store.Cursor{}, fmt.Errorf("invalid cursor")
+	}
+	return store.Cursor{StartedAt: time.Unix(0, ns).UTC(), RunID: runID}, nil
 }
 
 func (s *Server) compare(w http.ResponseWriter, r *http.Request) {
@@ -343,13 +406,21 @@ func (s *Server) compare(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// parseLimit resolves the effective page size for GET /runs: DefaultListLimit
+// when the request specifies none, the request's own value when it is a
+// valid positive integer at or under MaxListLimit, and MaxListLimit itself
+// when the request asks for more than that. There is deliberately no way to
+// request "unlimited" -- that is the behavior this cap exists to remove.
 func parseLimit(s string) (int, error) {
 	if s == "" {
-		return 0, nil
+		return DefaultListLimit, nil
 	}
 	n, err := strconv.Atoi(s)
-	if err != nil || n < 0 {
-		return 0, fmt.Errorf("limit must be a non-negative integer, got %q", s)
+	if err != nil || n <= 0 {
+		return 0, fmt.Errorf("limit must be a positive integer, got %q", s)
+	}
+	if n > MaxListLimit {
+		n = MaxListLimit
 	}
 	return n, nil
 }

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -132,10 +133,104 @@ func TestCompareFlagsUnattributableDifference(t *testing.T) {
 }
 
 func TestBadLimitIsRejected(t *testing.T) {
+	for _, limit := range []string{"-3", "0", "not-a-number"} {
+		w := httptest.NewRecorder()
+		srv(t).ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/runs?limit="+limit, nil))
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("limit=%s: want 400, got %d", limit, w.Code)
+		}
+	}
+}
+
+func TestBadCursorIsRejected(t *testing.T) {
+	for _, cursor := range []string{"not-base64url!!", "aGVsbG8", ""} {
+		if cursor == "" {
+			continue // empty cursor means "from the top", not an error
+		}
+		w := httptest.NewRecorder()
+		srv(t).ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/runs?cursor="+cursor, nil))
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("cursor=%s: want 400, got %d: %s", cursor, w.Code, w.Body)
+		}
+	}
+}
+
+func TestListDefaultsAndCapsLimit(t *testing.T) {
+	h := srv(t)
+	for i := 0; i < 3; i++ {
+		w := post(t, h, fmt.Sprintf(`{"project":"p","git_commit":"c%d","config_hash":"cfg"}`, i))
+		if w.Code != http.StatusCreated {
+			t.Fatalf("setup failed: %d %s", w.Code, w.Body)
+		}
+	}
+
 	w := httptest.NewRecorder()
-	srv(t).ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/runs?limit=-3", nil))
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("want 400, got %d", w.Code)
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/runs?project=p", nil))
+	var got struct {
+		Runs  []map[string]any `json:"runs"`
+		Count int              `json:"count"`
+		Limit int              `json:"limit"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &got)
+	if got.Limit != DefaultListLimit {
+		t.Fatalf("want the effective limit echoed as %d, got %d", DefaultListLimit, got.Limit)
+	}
+	if got.Count != 3 {
+		t.Fatalf("want 3 runs under the default limit, got %d", got.Count)
+	}
+
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, fmt.Sprintf("/runs?project=p&limit=%d", MaxListLimit+1000), nil))
+	_ = json.Unmarshal(w.Body.Bytes(), &got)
+	if got.Limit != MaxListLimit {
+		t.Fatalf("a request over MaxListLimit must be clamped, got effective limit %d", got.Limit)
+	}
+}
+
+func TestListCursorPagesWithoutSkippingOrRepeating(t *testing.T) {
+	h := srv(t)
+	const n = 5
+	for i := 0; i < n; i++ {
+		w := post(t, h, fmt.Sprintf(`{"project":"p","git_commit":"c%d","config_hash":"cfg"}`, i))
+		if w.Code != http.StatusCreated {
+			t.Fatalf("setup failed: %d %s", w.Code, w.Body)
+		}
+	}
+
+	type page struct {
+		Runs       []map[string]any `json:"runs"`
+		NextCursor string           `json:"next_cursor"`
+	}
+	seen := map[string]bool{}
+	cursor := ""
+	for i := 0; i < n+1; i++ { // +1 guards against a cursor that never terminates
+		url := "/runs?project=p&limit=2"
+		if cursor != "" {
+			url += "&cursor=" + cursor
+		}
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, url, nil))
+		if w.Code != http.StatusOK {
+			t.Fatalf("page %d: want 200, got %d: %s", i, w.Code, w.Body)
+		}
+		var p page
+		if err := json.Unmarshal(w.Body.Bytes(), &p); err != nil {
+			t.Fatalf("page %d: %v", i, err)
+		}
+		for _, r := range p.Runs {
+			id := r["run_id"].(string)
+			if seen[id] {
+				t.Fatalf("run %q was returned on more than one page", id)
+			}
+			seen[id] = true
+		}
+		if p.NextCursor == "" {
+			break
+		}
+		cursor = p.NextCursor
+	}
+	if len(seen) != n {
+		t.Fatalf("want all %d runs visited across pages, got %d: %v", n, len(seen), seen)
 	}
 }
 

--- a/internal/store/conformance.go
+++ b/internal/store/conformance.go
@@ -79,10 +79,11 @@ func RunConformance(t *testing.T, newStore func(t *testing.T) Store) {
 		}
 		want := []string{"new", "mid", "old"}
 		for i := 0; i < 20; i++ {
-			got, err := s.List(ctx, Query{Project: "p"})
+			page, err := s.List(ctx, Query{Project: "p"})
 			if err != nil {
 				t.Fatal(err)
 			}
+			got := page.Runs
 			if len(got) != len(want) {
 				t.Fatalf("want %d runs, got %d", len(want), len(got))
 			}
@@ -90,6 +91,9 @@ func RunConformance(t *testing.T, newStore func(t *testing.T) Store) {
 				if got[j].RunID != want[j] {
 					t.Fatalf("iteration %d: want %v, got %s at %d", i, want, got[j].RunID, j)
 				}
+			}
+			if page.Next != nil {
+				t.Fatalf("an unbounded query must not report a next page, got %+v", page.Next)
 			}
 		}
 	})
@@ -99,10 +103,11 @@ func RunConformance(t *testing.T, newStore func(t *testing.T) Store) {
 		now := time.Now()
 		_ = s.Record(ctx, mk("a", "alpha", now))
 		_ = s.Record(ctx, mk("b", "beta", now.Add(-time.Minute)))
-		got, err := s.List(ctx, Query{Project: "alpha"})
+		page, err := s.List(ctx, Query{Project: "alpha"})
 		if err != nil {
 			t.Fatal(err)
 		}
+		got := page.Runs
 		if len(got) != 1 || got[0].RunID != "a" {
 			t.Fatalf("project filter did not narrow: %+v", got)
 		}
@@ -129,12 +134,12 @@ func RunConformance(t *testing.T, newStore func(t *testing.T) Store) {
 				t.Fatalf("goroutine %d: re-recording identical content concurrently should succeed, got %v", i, err)
 			}
 		}
-		got, err := s.List(ctx, Query{Project: "p"})
+		page, err := s.List(ctx, Query{Project: "p"})
 		if err != nil {
 			t.Fatal(err)
 		}
-		if len(got) != 1 {
-			t.Fatalf("want exactly one row after %d concurrent identical writes, got %d: %+v", n, len(got), got)
+		if len(page.Runs) != 1 {
+			t.Fatalf("want exactly one row after %d concurrent identical writes, got %d: %+v", n, len(page.Runs), page.Runs)
 		}
 	})
 
@@ -177,12 +182,12 @@ func RunConformance(t *testing.T, newStore func(t *testing.T) Store) {
 		if _, err := s.Get(ctx, "a"); err != nil {
 			t.Fatalf("the winning write should be readable, got %v", err)
 		}
-		got, err := s.List(ctx, Query{Project: "p"})
+		page, err := s.List(ctx, Query{Project: "p"})
 		if err != nil {
 			t.Fatal(err)
 		}
-		if len(got) != 1 {
-			t.Fatalf("want exactly one row after %d concurrent conflicting writes, got %d: %+v", n, len(got), got)
+		if len(page.Runs) != 1 {
+			t.Fatalf("want exactly one row after %d concurrent conflicting writes, got %d: %+v", n, len(page.Runs), page.Runs)
 		}
 	})
 
@@ -202,12 +207,12 @@ func RunConformance(t *testing.T, newStore func(t *testing.T) Store) {
 					return
 				default:
 				}
-				got, err := s.List(ctx, Query{Project: "p"})
+				page, err := s.List(ctx, Query{Project: "p"})
 				if err != nil {
 					violations <- fmt.Errorf("List returned an error during concurrent writes: %w", err)
 					return
 				}
-				for _, r := range got {
+				for _, r := range page.Runs {
 					// A torn write would show up here as a run missing the
 					// fields Record is required to have set together, or as
 					// a run whose provenance doesn't match its identity.
@@ -243,26 +248,128 @@ func RunConformance(t *testing.T, newStore func(t *testing.T) Store) {
 			t.Fatal(err)
 		}
 
-		got, err := s.List(ctx, Query{Project: "p"})
+		page, err := s.List(ctx, Query{Project: "p"})
 		if err != nil {
 			t.Fatal(err)
 		}
-		if len(got) != n {
-			t.Fatalf("want %d runs after concurrent writes, got %d", n, len(got))
+		if len(page.Runs) != n {
+			t.Fatalf("want %d runs after concurrent writes, got %d", n, len(page.Runs))
 		}
 	})
 
-	t.Run("limit truncates after ordering", func(t *testing.T) {
+	t.Run("limit truncates after ordering, and reports a next cursor", func(t *testing.T) {
 		s := newStore(t)
 		now := time.Now()
 		_ = s.Record(ctx, mk("old", "p", now.Add(-time.Hour)))
 		_ = s.Record(ctx, mk("new", "p", now))
-		got, err := s.List(ctx, Query{Project: "p", Limit: 1})
+		page, err := s.List(ctx, Query{Project: "p", Limit: 1})
 		if err != nil {
 			t.Fatal(err)
 		}
-		if len(got) != 1 || got[0].RunID != "new" {
-			t.Fatalf("limit must keep the newest, got %+v", got)
+		if len(page.Runs) != 1 || page.Runs[0].RunID != "new" {
+			t.Fatalf("limit must keep the newest, got %+v", page.Runs)
+		}
+		if page.Next == nil {
+			t.Fatal("a truncated page must report a next cursor")
+		}
+		next, err := s.List(ctx, Query{Project: "p", Limit: 1, After: page.Next})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(next.Runs) != 1 || next.Runs[0].RunID != "old" {
+			t.Fatalf("the next page must pick up where the cursor left off, got %+v", next.Runs)
+		}
+		if next.Next != nil {
+			t.Fatalf("the last page must not report a further cursor, got %+v", next.Next)
+		}
+	})
+
+	t.Run("a page exactly the size of the result set reports no next cursor", func(t *testing.T) {
+		s := newStore(t)
+		now := time.Now()
+		_ = s.Record(ctx, mk("old", "p", now.Add(-time.Hour)))
+		_ = s.Record(ctx, mk("new", "p", now))
+		page, err := s.List(ctx, Query{Project: "p", Limit: 2})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(page.Runs) != 2 {
+			t.Fatalf("want both runs, got %+v", page.Runs)
+		}
+		if page.Next != nil {
+			t.Fatalf("a page that exhausts the result set must not report a next cursor, got %+v", page.Next)
+		}
+	})
+
+	t.Run("keyset pagination visits every pre-existing row exactly once under concurrent inserts", func(t *testing.T) {
+		s := newStore(t)
+		now := time.Now()
+		const preExisting = 40
+		const pageSize = 7
+		want := map[string]bool{}
+		for i := 0; i < preExisting; i++ {
+			id := fmt.Sprintf("pre-%03d", i)
+			// Spread StartedAt out so ties (same instant, different run id) get
+			// exercised too, not just the common case of distinct timestamps.
+			at := now.Add(-time.Duration(i/2) * time.Second)
+			if err := s.Record(ctx, mk(id, "p", at)); err != nil {
+				t.Fatal(err)
+			}
+			want[id] = true
+		}
+
+		// A concurrent writer keeps inserting new, newer-than-anything-so-far
+		// rows for the whole traversal. A traversal that used LIMIT/OFFSET
+		// would have every page after the first shift by however many of
+		// these landed ahead of it, and would skip or repeat a pre-existing
+		// row; keyset pagination must not.
+		stopInserts := make(chan struct{})
+		var inserters sync.WaitGroup
+		inserters.Add(1)
+		go func() {
+			defer inserters.Done()
+			i := 0
+			for {
+				select {
+				case <-stopInserts:
+					return
+				default:
+				}
+				id := fmt.Sprintf("concurrent-%04d", i)
+				_ = s.Record(ctx, mk(id, "p", time.Now().Add(time.Duration(i)*time.Millisecond)))
+				i++
+			}
+		}()
+
+		seen := map[string]int{}
+		var cursor *Cursor
+		for {
+			page, err := s.List(ctx, Query{Project: "p", Limit: pageSize, After: cursor})
+			if err != nil {
+				close(stopInserts)
+				inserters.Wait()
+				t.Fatal(err)
+			}
+			for _, r := range page.Runs {
+				seen[r.RunID]++
+			}
+			if page.Next == nil {
+				break
+			}
+			cursor = page.Next
+		}
+		close(stopInserts)
+		inserters.Wait()
+
+		for id := range want {
+			if seen[id] != 1 {
+				t.Fatalf("pre-existing row %q was visited %d times, want exactly 1", id, seen[id])
+			}
+		}
+		for id, n := range seen {
+			if n > 1 {
+				t.Fatalf("row %q was visited %d times, want at most 1", id, n)
+			}
 		}
 	})
 }

--- a/internal/store/duckdb.go
+++ b/internal/store/duckdb.go
@@ -312,7 +312,7 @@ func loadKVFloat(ctx context.Context, q queryer, runID string) (map[string]float
 	return out, rows.Err()
 }
 
-func (d *DuckDB) List(ctx context.Context, query Query) ([]lineage.Run, error) {
+func (d *DuckDB) List(ctx context.Context, query Query) (Page, error) {
 	where := []string{}
 	args := []any{}
 	add := func(col, val string) {
@@ -326,6 +326,13 @@ func (d *DuckDB) List(ctx context.Context, query Query) ([]lineage.Run, error) {
 	add("fingerprint", query.Fingerprint)
 	add("status", string(query.Status))
 	add("device", query.Device)
+	if query.After != nil {
+		// Keyset predicate for "strictly after this row in (started_at_ns
+		// DESC, run_id ASC) order": either an earlier started_at, or the same
+		// started_at with a run_id that sorts later.
+		where = append(where, "(started_at_ns < ? OR (started_at_ns = ? AND run_id > ?))")
+		args = append(args, query.After.StartedAt.UnixNano(), query.After.StartedAt.UnixNano(), query.After.RunID)
+	}
 
 	sqlStr := `
 		SELECT run_id, project, git_commit, git_dirty, config_hash, dataset_version,
@@ -339,12 +346,16 @@ func (d *DuckDB) List(ctx context.Context, query Query) ([]lineage.Run, error) {
 	// uses, so ordering does not depend on which backend answered.
 	sqlStr += " ORDER BY started_at_ns DESC, run_id ASC"
 	if query.Limit > 0 {
-		sqlStr += fmt.Sprintf(" LIMIT %d", query.Limit)
+		// Ask for one extra row so we can tell "exactly Limit rows exist"
+		// apart from "more rows follow" without a second round trip -- that
+		// extra row, if present, is trimmed below and becomes the cursor for
+		// the next page instead of being returned.
+		sqlStr += fmt.Sprintf(" LIMIT %d", query.Limit+1)
 	}
 
 	rows, err := d.db.QueryContext(ctx, sqlStr, args...)
 	if err != nil {
-		return nil, err
+		return Page{}, err
 	}
 	var runs []lineage.Run
 	runIDs := []string{}
@@ -359,7 +370,7 @@ func (d *DuckDB) List(ctx context.Context, query Query) ([]lineage.Run, error) {
 			&status, &startedAtNS, &endedAtNS, &r.CheckpointURI,
 		); err != nil {
 			rows.Close()
-			return nil, err
+			return Page{}, err
 		}
 		r.Status = lineage.Status(status)
 		r.StartedAt = nsToTime(startedAtNS)
@@ -371,17 +382,25 @@ func (d *DuckDB) List(ctx context.Context, query Query) ([]lineage.Run, error) {
 	}
 	if err := rows.Err(); err != nil {
 		rows.Close()
-		return nil, err
+		return Page{}, err
 	}
 	rows.Close()
+
+	var next *Cursor
+	if query.Limit > 0 && len(runs) > query.Limit {
+		runs = runs[:query.Limit]
+		runIDs = runIDs[:query.Limit]
+		last := runs[len(runs)-1]
+		next = &Cursor{StartedAt: last.StartedAt, RunID: last.RunID}
+	}
 
 	// Hydrate params/metrics for the page in two batched queries rather than
 	// one round trip per run -- List answers "every run of this project",
 	// which is exactly the case with the most rows to hydrate.
 	if err := hydrate(ctx, d.db, runs, runIDs); err != nil {
-		return nil, err
+		return Page{}, err
 	}
-	return runs, nil
+	return Page{Runs: runs, Next: next}, nil
 }
 
 func hydrate(ctx context.Context, q queryer, runs []lineage.Run, runIDs []string) error {

--- a/internal/store/memory.go
+++ b/internal/store/memory.go
@@ -48,7 +48,7 @@ func (m *Memory) Get(_ context.Context, runID string) (lineage.Run, error) {
 	return r, nil
 }
 
-func (m *Memory) List(_ context.Context, q Query) ([]lineage.Run, error) {
+func (m *Memory) List(_ context.Context, q Query) (Page, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	out := make([]lineage.Run, 0, len(m.runs))
@@ -78,10 +78,38 @@ func (m *Memory) List(_ context.Context, q Query) ([]lineage.Run, error) {
 		}
 		return out[i].RunID < out[j].RunID
 	})
-	if q.Limit > 0 && len(out) > q.Limit {
-		out = out[:q.Limit]
+	if q.After != nil {
+		after := *q.After
+		// out is already sorted in the traversal order, and "comes strictly
+		// after the cursor" is monotonic over it (false*, then true*), so a
+		// binary search finds the first surviving row in O(log n) instead of
+		// a linear scan.
+		i := sort.Search(len(out), func(i int) bool { return isAfterCursor(out[i], after) })
+		out = out[i:]
 	}
-	return out, nil
+	return paginate(out, q.Limit), nil
+}
+
+// isAfterCursor reports whether r sorts strictly after c in List's total
+// order (StartedAt descending, RunID ascending on a tie) — i.e. whether r
+// belongs on the page that follows c.
+func isAfterCursor(r lineage.Run, c Cursor) bool {
+	if r.StartedAt.Equal(c.StartedAt) {
+		return r.RunID > c.RunID
+	}
+	return r.StartedAt.Before(c.StartedAt)
+}
+
+// paginate truncates an already-ordered, already-after-cursor slice to
+// Limit rows and reports the cursor for what follows, if anything does.
+// Limit <= 0 means unbounded: the whole slice, no next page.
+func paginate(runs []lineage.Run, limit int) Page {
+	if limit <= 0 || len(runs) <= limit {
+		return Page{Runs: runs}
+	}
+	page := runs[:limit]
+	last := page[len(page)-1]
+	return Page{Runs: page, Next: &Cursor{StartedAt: last.StartedAt, RunID: last.RunID}}
 }
 
 func (m *Memory) Close() error { return nil }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -4,6 +4,7 @@ package store
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/kornsour/run-ledger/internal/lineage"
 )
@@ -16,14 +17,51 @@ var ErrNotFound = errors.New("run not found")
 // silently overwriting a lineage record would make history unreliable.
 var ErrConflict = errors.New("run already recorded with different content")
 
-// Query filters a run listing. A zero-valued field does not filter.
+// Cursor names a position in a run listing's total order — newest first by
+// StartedAt, RunID ascending as the tiebreak (the same order every Store
+// implementation sorts List's result in). It is how List paginates by
+// keyset instead of offset: "give me what comes after this row" stays
+// correct when rows are inserted concurrently, where "give me rows 20-40"
+// does not, because an insert ahead of the traversal shifts every offset
+// after it and a page silently skips or repeats a row.
+type Cursor struct {
+	StartedAt time.Time
+	RunID     string
+}
+
+// Query filters and paginates a run listing. A zero-valued field does not
+// filter.
 type Query struct {
 	Project     string
 	GitCommit   string
 	Fingerprint string
 	Status      lineage.Status
 	Device      string
-	Limit       int
+	// Limit caps the number of rows a single List call returns. Zero means
+	// unbounded — callers that page (the HTTP API's GET /runs) are expected
+	// to supply their own default and maximum; Store itself imposes none, so
+	// a Go-level caller that genuinely wants everything (the /readyz probe,
+	// the ledger-size gauge) still can.
+	Limit int
+	// After, when non-nil, restricts the listing to rows strictly following
+	// this cursor in the total order — the keyset for the page that comes
+	// next. Nil means "start from the top."
+	After *Cursor
+}
+
+// Page is one page of a Store.List result.
+type Page struct {
+	Runs []lineage.Run
+	// Next is the cursor for the following page. It is non-nil only when
+	// List's Limit truncated the result — i.e. more rows may exist beyond
+	// this page. A caller that keeps passing Next back as Query.After until
+	// it comes back nil has visited every row that existed at or before the
+	// position each successive call reached; a row recorded elsewhere after
+	// the traversal began, sorting behind where the traversal already is, is
+	// never visited by it. That is a deliberate, documented trade for an
+	// append-mostly ledger — see README.md's "Pagination" section — not an
+	// oversight.
+	Next *Cursor
 }
 
 // Store is the persistence boundary.
@@ -34,6 +72,6 @@ type Query struct {
 type Store interface {
 	Record(ctx context.Context, r lineage.Run) error
 	Get(ctx context.Context, runID string) (lineage.Run, error)
-	List(ctx context.Context, q Query) ([]lineage.Run, error)
+	List(ctx context.Context, q Query) (Page, error)
 	Close() error
 }


### PR DESCRIPTION
Closes #3

## What changed

`GET /runs` previously returned the whole filtered result set, capped only
by an optional `limit`. Once the ledger holds a real number of runs that's
both a large response and an unstable one under concurrent writes: the
listing is sorted newest-first, so a run recorded between two page fetches
shifts every offset after it, and a client paging with `LIMIT`/`OFFSET`
silently skips or repeats a row.

- **`store.Store.List` now returns `Page{Runs, Next}`** instead of a bare
  slice. `store.Query` gained `After *store.Cursor` — the keyset (the same
  `(started_at, run_id)` total order every backend already sorted by) that
  makes "give me what comes after this row" stable under concurrent inserts.
  Both `Memory` and `DuckDB` implement it.
- **`GET /runs` defaults to a limit of 50 and caps requests at 500**,
  regardless of what a request asks for. The response echoes the effective
  `limit` applied, and includes an opaque `next_cursor` only when more rows
  may follow.
- **Documented what a page is consistent with**: a page reflects the ledger
  as of its cursor's position, not a fixed snapshot of the whole listing — a
  row recorded after a traversal begins, sorting behind where the traversal
  has already reached, is simply not visited by it. See the README's new
  "Pagination" section and
  [ADR 0007](docs/adr/0007-keyset-pagination-cursor-consistency.md).
- **New conformance case** (`internal/store/conformance.go`) that interleaves
  concurrent inserts with a paged traversal and asserts every row present
  before the traversal started is visited exactly once, run against both
  `Memory` and `DuckDB`.
- **`rlctl list`** gained `--cursor` and prints the next page's cursor when
  the listing was truncated.

## Test plan

- [x] `make build`
- [x] `make lint` (`go vet` + `gofmt -l`)
- [x] `make test` (`go test -race ./...`), including the new keyset-pagination
      conformance case against both `Memory` and `DuckDB`, and new API tests
      for default/max limit clamping, cursor round-tripping, and bad-cursor
      rejection

🤖 Generated with [Claude Code](https://claude.com/claude-code)