### PR TITLE
Add PATCH /runs/{id} and a run status lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,23 @@ B=$(./bin/rlctl record --project demo --seed 1 --config-hash cfg1 \
 ./bin/rlctl diff $A $B
 ```
 
+A run can also be recorded at submission time, before its outcome is known,
+and walked through its lifecycle as it happens:
+
+```bash
+R=$(./bin/rlctl record --project demo --seed 1 --config-hash cfg1)  # status: created
+./bin/rlctl start $R                                                # status: running
+./bin/rlctl finish --metric loss=0.42 --checkpoint s3://bucket/ckpt $R
+# status: succeeded, ended_at set, loss recorded
+
+# or, if the run didn't make it:
+./bin/rlctl fail $R                                                  # status: failed
+```
+
+`start`/`finish`/`fail` only move a run forward — `created → running →
+{succeeded, failed, cancelled}` — and can never change what experiment the
+run was; see [PATCH `/runs/{id}`](#api) below.
+
 ```
 same experiment (fingerprints match)
 
@@ -96,7 +113,7 @@ Pass `--store duckdb --dsn ./runs.duckdb` (or `RUNLEDGER_STORE=duckdb` /
 
 ```
 cmd/runledger/     HTTP server
-cmd/rlctl/         researcher CLI: record · list · show · diff
+cmd/rlctl/         researcher CLI: record · start · finish · fail · list · show · diff
 internal/lineage/  the Run record, validation, content-addressed fingerprint
 internal/store/    Store interface + in-memory reference and DuckDB backends
 internal/compare/  structured diff, identity vs provenance vs metric
@@ -113,6 +130,7 @@ implementation cannot quietly disagree about ordering or idempotency.
 | Method | Path | |
 |---|---|---|
 | `POST` | `/runs` | record a run; the server assigns the fingerprint and id |
+| `PATCH` | `/runs/{id}` | update a run's provenance: `status`, `ended_at`, `checkpoint_uri`, `metrics`, `host`, `device`, `framework_version` |
 | `GET` | `/runs` | list, filtered by `project`, `git_commit`, `fingerprint`, `status`, `device`, `limit` |
 | `GET` | `/runs/{id}` | one run |
 | `GET` | `/compare?a=X&b=Y` | structured diff, with `unattributable` |
@@ -193,6 +211,16 @@ have to be true to revisit each one — lives in [`docs/adr/`](docs/adr/).
 - **Re-recording identical content is idempotent; different content under the
   same id is a conflict.** Silently overwriting a lineage record would make
   history unreliable.
+- **`PATCH /runs/{id}` moves a run's provenance forward; it can never rewrite
+  what experiment it was.** Identity fields (`project`, `git_commit`,
+  `git_dirty`, `config_hash`, `dataset_version`, `model_version`, `seed`,
+  `params`) are checked against the stored run and a mismatch is a `409`, not
+  an update. Status only moves `created → running → {succeeded, failed,
+  cancelled}`; a transition out of a terminal state — including a same-status
+  or metrics-only patch — is also a `409`, because a terminal run is a
+  finished outcome, not a waypoint. Metrics are merged into the existing map,
+  not replaced, so a long run can report as it goes; re-reporting an existing
+  key overwrites just that key.
 - **An absent metric is not a zero.** They print differently and diff
   differently.
 - **Hashed fields are length-prefixed** so `("ab","c")` and `("a","bc")` cannot

--- a/cmd/rlctl/main.go
+++ b/cmd/rlctl/main.go
@@ -22,6 +22,11 @@ const usage = `rlctl — record and compare experiment runs
 
   rlctl record --project P [--seed N] [--dataset V] [--model V] [--param k=v ...] [--metric k=v ...]
                            Capture git context from the working tree and record a run.
+  rlctl start  <run-id>    Mark a recorded run running.
+  rlctl finish [--status succeeded|failed|cancelled] [--metric k=v ...] [--checkpoint URI] <run-id>
+                           Move a running run to a terminal status. --status defaults to succeeded.
+  rlctl fail   [--metric k=v ...] <run-id>
+                           Shorthand for finish --status failed.
   rlctl list   [--project P] [--commit SHA] [--status S] [--limit N]
   rlctl show   <run-id>
   rlctl diff   <run-a> <run-b>
@@ -41,6 +46,12 @@ func main() {
 	switch os.Args[1] {
 	case "record":
 		err = cmdRecord(os.Args[2:])
+	case "start":
+		err = cmdStart(os.Args[2:])
+	case "finish":
+		err = cmdFinish(os.Args[2:])
+	case "fail":
+		err = cmdFail(os.Args[2:])
 	case "list":
 		err = cmdList(os.Args[2:])
 	case "show":
@@ -129,6 +140,89 @@ func cmdRecord(args []string) error {
 	}
 	fmt.Println(out.RunID)
 	return nil
+}
+
+func cmdStart(args []string) error {
+	fs := flag.NewFlagSet("start", flag.ExitOnError)
+	server := fs.String("server", defaultServer(), "ledger address")
+	_ = fs.Parse(args)
+	if fs.NArg() != 1 {
+		return fmt.Errorf("start takes exactly one run id")
+	}
+	out, err := patchRun(*server, fs.Arg(0), map[string]any{"status": string(lineage.StatusRunning)})
+	if err != nil {
+		return err
+	}
+	fmt.Println(out.RunID, out.Status)
+	return nil
+}
+
+func cmdFinish(args []string) error {
+	fs := flag.NewFlagSet("finish", flag.ExitOnError)
+	server := fs.String("server", defaultServer(), "ledger address")
+	status := fs.String("status", string(lineage.StatusSucceeded), "terminal status: succeeded, failed, or cancelled")
+	checkpoint := fs.String("checkpoint", "", "checkpoint URI")
+	metrics := kvFlag{}
+	fs.Var(metrics, "metric", "measured metric, key=value (repeatable)")
+	_ = fs.Parse(args)
+	if fs.NArg() != 1 {
+		return fmt.Errorf("finish takes exactly one run id")
+	}
+	return finishRun(*server, fs.Arg(0), *status, *checkpoint, metrics)
+}
+
+func cmdFail(args []string) error {
+	fs := flag.NewFlagSet("fail", flag.ExitOnError)
+	server := fs.String("server", defaultServer(), "ledger address")
+	metrics := kvFlag{}
+	fs.Var(metrics, "metric", "measured metric, key=value (repeatable)")
+	_ = fs.Parse(args)
+	if fs.NArg() != 1 {
+		return fmt.Errorf("fail takes exactly one run id")
+	}
+	return finishRun(*server, fs.Arg(0), string(lineage.StatusFailed), "", metrics)
+}
+
+// finishRun moves a run to a terminal status, setting ended_at to now and
+// optionally a checkpoint URI and metrics. finish and fail share it because
+// fail is exactly finish --status failed with no checkpoint.
+func finishRun(server, runID, status, checkpoint string, metricFlags kvFlag) error {
+	patch := map[string]any{
+		"status":   status,
+		"ended_at": time.Now().UTC(),
+	}
+	if checkpoint != "" {
+		patch["checkpoint_uri"] = checkpoint
+	}
+	if len(metricFlags) > 0 {
+		m := map[string]float64{}
+		for k, v := range metricFlags {
+			var f float64
+			if _, err := fmt.Sscanf(v, "%g", &f); err != nil {
+				return fmt.Errorf("metric %s=%s is not a number", k, v)
+			}
+			m[k] = f
+		}
+		patch["metrics"] = m
+	}
+	out, err := patchRun(server, runID, patch)
+	if err != nil {
+		return err
+	}
+	fmt.Println(out.RunID, out.Status)
+	return nil
+}
+
+func patchRun(server, runID string, fields map[string]any) (lineage.Run, error) {
+	body, err := json.Marshal(fields)
+	if err != nil {
+		return lineage.Run{}, err
+	}
+	var out lineage.Run
+	if err := call(http.MethodPatch, server+"/runs/"+url.PathEscape(runID), body, &out); err != nil {
+		return lineage.Run{}, err
+	}
+	return out, nil
 }
 
 func cmdList(args []string) error {

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -107,6 +107,7 @@ func New(s store.Store, log *slog.Logger, opts ...Option) *Server {
 func (s *Server) Handler() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /runs", s.requireAuth(true, s.record))
+	mux.HandleFunc("PATCH /runs/{id}", s.requireAuth(true, s.update))
 	mux.HandleFunc("GET /runs", s.requireAuth(false, s.list))
 	mux.HandleFunc("GET /runs/{id}", s.requireAuth(false, s.get))
 	mux.HandleFunc("GET /compare", s.requireAuth(false, s.compare))
@@ -278,6 +279,75 @@ func (s *Server) record(w http.ResponseWriter, r *http.Request) {
 	s.metrics.RecordRun(run.Project, string(run.Status))
 	s.log.Info("recorded run", "run_id", run.RunID, "project", run.Project, "fingerprint", run.Fingerprint)
 	writeJSON(w, http.StatusCreated, run)
+}
+
+// patchRequest is the PATCH /runs/{id} body. Every field is a pointer (or,
+// for the two map fields, a nil-vs-set map) so the handler can tell "the
+// caller did not mention this" apart from "the caller set this to its zero
+// value" -- a plain lineage.Run cannot make that distinction, and a PATCH
+// endpoint runs on it.
+//
+// The identity fields are listed here too, even though PATCH exists to
+// carry provenance: a client that sends one is not silently ignored, it is
+// checked against the stored run and rejected with a conflict if it
+// differs. Leaving them out of this struct entirely would turn an attempt
+// to rewrite a run's identity into a same-looking "unknown field" 400
+// instead of the 409 that states what actually happened.
+type patchRequest struct {
+	Project        *string           `json:"project"`
+	GitCommit      *string           `json:"git_commit"`
+	GitDirty       *bool             `json:"git_dirty"`
+	ConfigHash     *string           `json:"config_hash"`
+	DatasetVersion *string           `json:"dataset_version"`
+	ModelVersion   *string           `json:"model_version"`
+	Seed           *int64            `json:"seed"`
+	Params         map[string]string `json:"params"`
+
+	Status           *lineage.Status    `json:"status"`
+	EndedAt          *time.Time         `json:"ended_at"`
+	CheckpointURI    *string            `json:"checkpoint_uri"`
+	Host             *string            `json:"host"`
+	Device           *string            `json:"device"`
+	FrameworkVersion *string            `json:"framework_version"`
+	Metrics          map[string]float64 `json:"metrics"`
+}
+
+func (s *Server) update(w http.ResponseWriter, r *http.Request) {
+	var req patchRequest
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&req); err != nil {
+		writeErr(w, http.StatusBadRequest, err)
+		return
+	}
+	p := store.Patch{
+		Project: req.Project, GitCommit: req.GitCommit, GitDirty: req.GitDirty,
+		ConfigHash: req.ConfigHash, DatasetVersion: req.DatasetVersion,
+		ModelVersion: req.ModelVersion, Seed: req.Seed, Params: req.Params,
+		Status: req.Status, EndedAt: req.EndedAt, CheckpointURI: req.CheckpointURI,
+		Host: req.Host, Device: req.Device, FrameworkVersion: req.FrameworkVersion,
+		Metrics: req.Metrics,
+	}
+	run, err := s.store.Update(r.Context(), r.PathValue("id"), p)
+	if err != nil {
+		switch {
+		case errors.Is(err, store.ErrNotFound):
+			s.metrics.StoreError("not_found")
+			writeErr(w, http.StatusNotFound, err)
+		case errors.Is(err, store.ErrConflict):
+			s.metrics.StoreError("conflict")
+			writeErr(w, http.StatusConflict, err)
+		default:
+			s.metrics.StoreError("invalid")
+			writeErr(w, http.StatusBadRequest, err)
+		}
+		return
+	}
+	if req.Status != nil {
+		s.metrics.RecordRun(run.Project, string(run.Status))
+	}
+	s.log.Info("updated run", "run_id", run.RunID, "project", run.Project, "status", run.Status)
+	writeJSON(w, http.StatusOK, run)
 }
 
 func (s *Server) get(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -308,6 +308,110 @@ func TestReadTokenCannotWrite(t *testing.T) {
 	}
 }
 
+func patch(t *testing.T, h http.Handler, id, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodPatch, "/runs/"+id, strings.NewReader(body)))
+	return w
+}
+
+func TestUpdateWalksCreatedToSucceeded(t *testing.T) {
+	h := srv(t)
+	w := post(t, h, `{"project":"p","git_commit":"abc","config_hash":"cfg"}`)
+	var created map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &created)
+	id := created["run_id"].(string)
+
+	w = patch(t, h, id, `{"status":"running"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("created -> running: want 200, got %d: %s", w.Code, w.Body)
+	}
+
+	w = patch(t, h, id, `{"status":"succeeded","ended_at":"2999-01-01T00:00:00Z","metrics":{"loss":0.1}}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("running -> succeeded: want 200, got %d: %s", w.Code, w.Body)
+	}
+	var got map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &got)
+	if got["status"] != "succeeded" {
+		t.Fatalf("want status succeeded, got %v", got["status"])
+	}
+	metrics, _ := got["metrics"].(map[string]any)
+	if metrics["loss"] != 0.1 {
+		t.Fatalf("want loss=0.1 in the response, got %v", got["metrics"])
+	}
+}
+
+func TestUpdateUnknownRunIs404(t *testing.T) {
+	w := patch(t, srv(t), "nope", `{"status":"running"}`)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("want 404, got %d: %s", w.Code, w.Body)
+	}
+}
+
+func TestUpdateRejectsIdentityChange(t *testing.T) {
+	h := srv(t)
+	w := post(t, h, `{"project":"p","git_commit":"abc","config_hash":"cfg"}`)
+	var created map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &created)
+	id := created["run_id"].(string)
+
+	w = patch(t, h, id, `{"git_commit":"different"}`)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("changing an identity field must be 409, got %d: %s", w.Code, w.Body)
+	}
+}
+
+func TestUpdateRejectsIllegalTransition(t *testing.T) {
+	h := srv(t)
+	w := post(t, h, `{"project":"p","git_commit":"abc","config_hash":"cfg"}`) // starts at "created"
+	var created map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &created)
+	id := created["run_id"].(string)
+
+	w = patch(t, h, id, `{"status":"succeeded"}`) // created -> succeeded skips running
+	if w.Code != http.StatusConflict {
+		t.Fatalf("an illegal transition must be 409, got %d: %s", w.Code, w.Body)
+	}
+}
+
+func TestUpdateRejectsChangeToTerminalRun(t *testing.T) {
+	h := srv(t)
+	w := post(t, h, `{"project":"p","git_commit":"abc","config_hash":"cfg","status":"succeeded"}`)
+	var created map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &created)
+	id := created["run_id"].(string)
+
+	w = patch(t, h, id, `{"checkpoint_uri":"s3://bucket/ckpt"}`)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("a patch to a terminal run must be 409, got %d: %s", w.Code, w.Body)
+	}
+}
+
+func TestUpdateUnknownFieldIsRejected(t *testing.T) {
+	h := srv(t)
+	w := post(t, h, `{"project":"p","git_commit":"abc","config_hash":"cfg"}`)
+	var created map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &created)
+	id := created["run_id"].(string)
+
+	w = patch(t, h, id, `{"statuz":"running"}`)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("a typo'd field must be refused, got %d: %s", w.Code, w.Body)
+	}
+}
+
+func TestUpdateRequiresWriteToken(t *testing.T) {
+	h := srvWithAuth(t, Auth{WriteToken: "write-secret", ReadToken: "read-secret"})
+	req := httptest.NewRequest(http.MethodPatch, "/runs/whatever", strings.NewReader(`{"status":"running"}`))
+	req.Header.Set("Authorization", "Bearer read-secret")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("a read token must not be able to PATCH, got %d: %s", w.Code, w.Body)
+	}
+}
+
 func TestHealthzUnauthenticatedEvenWithTokenConfigured(t *testing.T) {
 	h := srvWithAuth(t, Auth{WriteToken: "write-secret"})
 	w := httptest.NewRecorder()

--- a/internal/lineage/run.go
+++ b/internal/lineage/run.go
@@ -58,6 +58,15 @@ var validStatuses = map[Status]bool{
 	StatusFailed: true, StatusCancelled: true,
 }
 
+// ValidStatus reports whether s is one of the known lifecycle states.
+func ValidStatus(s Status) bool { return validStatuses[s] }
+
+// Terminal reports whether s is a state a run does not leave: succeeded,
+// failed, and cancelled are outcomes, not waypoints.
+func Terminal(s Status) bool {
+	return s == StatusSucceeded || s == StatusFailed || s == StatusCancelled
+}
+
 // ErrDirtyTree is returned by Validate when a run reports a dirty working tree
 // without an explicit config hash. A dirty tree means the commit does not
 // describe the code that ran, so the config hash is the only remaining handle

--- a/internal/store/conformance.go
+++ b/internal/store/conformance.go
@@ -252,6 +252,146 @@ func RunConformance(t *testing.T, newStore func(t *testing.T) Store) {
 		}
 	})
 
+	t.Run("update on an unknown id is ErrNotFound", func(t *testing.T) {
+		s := newStore(t)
+		status := lineage.StatusRunning
+		if _, err := s.Update(ctx, "nope", Patch{Status: &status}); !errors.Is(err, ErrNotFound) {
+			t.Fatalf("want ErrNotFound, got %v", err)
+		}
+	})
+
+	t.Run("update walks the run through its lifecycle", func(t *testing.T) {
+		s := newStore(t)
+		r := mk("a", "p", time.Now())
+		r.Status = lineage.StatusCreated
+		if err := s.Record(ctx, r); err != nil {
+			t.Fatal(err)
+		}
+
+		running := lineage.StatusRunning
+		got, err := s.Update(ctx, "a", Patch{Status: &running})
+		if err != nil {
+			t.Fatalf("created -> running: %v", err)
+		}
+		if got.Status != lineage.StatusRunning {
+			t.Fatalf("want running, got %s", got.Status)
+		}
+
+		succeeded := lineage.StatusSucceeded
+		endedAt := time.Now()
+		got, err = s.Update(ctx, "a", Patch{
+			Status:  &succeeded,
+			EndedAt: &endedAt,
+			Metrics: map[string]float64{"loss": 0.1},
+		})
+		if err != nil {
+			t.Fatalf("running -> succeeded: %v", err)
+		}
+		if got.Status != lineage.StatusSucceeded || got.Metrics["loss"] != 0.1 {
+			t.Fatalf("want succeeded with loss=0.1, got %+v", got)
+		}
+		if !got.EndedAt.Equal(endedAt) {
+			t.Fatalf("ended_at not applied: got %v, want %v", got.EndedAt, endedAt)
+		}
+
+		// The updated run is durable, not just returned.
+		reGot, err := s.Get(ctx, "a")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if reGot.Status != lineage.StatusSucceeded || reGot.Metrics["loss"] != 0.1 {
+			t.Fatalf("update did not persist: %+v", reGot)
+		}
+	})
+
+	t.Run("update merges metrics instead of replacing the map", func(t *testing.T) {
+		s := newStore(t)
+		r := mk("a", "p", time.Now())
+		r.Status = lineage.StatusRunning
+		r.Metrics = map[string]float64{"loss": 1.0}
+		r.Fingerprint = r.Compute()
+		if err := s.Record(ctx, r); err != nil {
+			t.Fatal(err)
+		}
+
+		got, err := s.Update(ctx, "a", Patch{Metrics: map[string]float64{"acc": 0.5}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Metrics["loss"] != 1.0 || got.Metrics["acc"] != 0.5 {
+			t.Fatalf("want both metrics present, got %+v", got.Metrics)
+		}
+
+		// Re-reporting an existing key overwrites just that key.
+		got, err = s.Update(ctx, "a", Patch{Metrics: map[string]float64{"loss": 0.2}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Metrics["loss"] != 0.2 || got.Metrics["acc"] != 0.5 {
+			t.Fatalf("want loss overwritten and acc untouched, got %+v", got.Metrics)
+		}
+	})
+
+	t.Run("update refuses to change an identity field", func(t *testing.T) {
+		s := newStore(t)
+		r := mk("a", "p", time.Now())
+		r.Status = lineage.StatusRunning
+		if err := s.Record(ctx, r); err != nil {
+			t.Fatal(err)
+		}
+		other := "different-commit"
+		if _, err := s.Update(ctx, "a", Patch{GitCommit: &other}); !errors.Is(err, ErrConflict) {
+			t.Fatalf("want ErrConflict for a changed identity field, got %v", err)
+		}
+		// The identity field matching the existing value is not a conflict.
+		same := r.GitCommit
+		if _, err := s.Update(ctx, "a", Patch{GitCommit: &same, Status: &r.Status}); err != nil {
+			t.Fatalf("an unchanged identity field must not conflict, got %v", err)
+		}
+	})
+
+	t.Run("update refuses an illegal status transition", func(t *testing.T) {
+		s := newStore(t)
+		r := mk("a", "p", time.Now())
+		r.Status = lineage.StatusCreated
+		if err := s.Record(ctx, r); err != nil {
+			t.Fatal(err)
+		}
+		succeeded := lineage.StatusSucceeded
+		if _, err := s.Update(ctx, "a", Patch{Status: &succeeded}); !errors.Is(err, ErrConflict) {
+			t.Fatalf("created -> succeeded must skip illegally, want ErrConflict, got %v", err)
+		}
+	})
+
+	t.Run("update refuses any change once a run is terminal", func(t *testing.T) {
+		s := newStore(t)
+		r := mk("a", "p", time.Now()) // mk sets StatusSucceeded
+		if err := s.Record(ctx, r); err != nil {
+			t.Fatal(err)
+		}
+		uri := "s3://bucket/ckpt"
+		if _, err := s.Update(ctx, "a", Patch{CheckpointURI: &uri}); !errors.Is(err, ErrConflict) {
+			t.Fatalf("a terminal run must refuse further updates, got %v", err)
+		}
+		cancelled := lineage.StatusCancelled
+		if _, err := s.Update(ctx, "a", Patch{Status: &cancelled}); !errors.Is(err, ErrConflict) {
+			t.Fatalf("a transition out of a terminal state must be ErrConflict, got %v", err)
+		}
+	})
+
+	t.Run("update rejects an unknown status", func(t *testing.T) {
+		s := newStore(t)
+		r := mk("a", "p", time.Now())
+		r.Status = lineage.StatusCreated
+		if err := s.Record(ctx, r); err != nil {
+			t.Fatal(err)
+		}
+		bogus := lineage.Status("bogus")
+		if _, err := s.Update(ctx, "a", Patch{Status: &bogus}); err == nil || errors.Is(err, ErrConflict) {
+			t.Fatalf("an unrecognized status should be a plain error, not ErrConflict or nil: %v", err)
+		}
+	})
+
 	t.Run("limit truncates after ordering", func(t *testing.T) {
 		s := newStore(t)
 		now := time.Now()

--- a/internal/store/duckdb.go
+++ b/internal/store/duckdb.go
@@ -217,6 +217,62 @@ func (d *DuckDB) Record(ctx context.Context, r lineage.Run) error {
 	return tx.Commit()
 }
 
+// Update applies a partial, provenance-only change to an already-recorded
+// run. Like Record, it serializes behind d.mu and reads-then-writes inside
+// one critical section, since a read-modify-write across two unguarded
+// statements is exactly the race the mutex exists to rule out.
+func (d *DuckDB) Update(ctx context.Context, runID string, p Patch) (lineage.Run, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	existing, err := d.get(ctx, d.db, runID)
+	if err != nil {
+		return lineage.Run{}, err
+	}
+	updated, err := applyPatch(existing, p)
+	if err != nil {
+		return lineage.Run{}, err
+	}
+
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return lineage.Run{}, err
+	}
+	defer func() { _ = tx.Rollback() }() // no-op once committed
+
+	var endedAt any
+	if !updated.EndedAt.IsZero() {
+		endedAt = updated.EndedAt.UnixNano()
+	}
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE runs SET status = ?, ended_at_ns = ?, checkpoint_uri = ?,
+			host = ?, device = ?, framework_version = ?
+		WHERE run_id = ?`,
+		string(updated.Status), endedAt, updated.CheckpointURI,
+		updated.Host, updated.Device, updated.FrameworkVersion, runID,
+	); err != nil {
+		return lineage.Run{}, fmt.Errorf("updating run: %w", err)
+	}
+
+	// Only the keys the patch actually touched -- merging happened in
+	// applyPatch against the Go value, so this upserts p.Metrics (the
+	// delta), not updated.Metrics (the full merged map).
+	for k, v := range p.Metrics {
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO run_metrics (run_id, key, value) VALUES (?, ?, ?)
+			ON CONFLICT (run_id, key) DO UPDATE SET value = excluded.value`,
+			runID, k, v,
+		); err != nil {
+			return lineage.Run{}, fmt.Errorf("upserting metric %q: %w", k, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return lineage.Run{}, err
+	}
+	return updated, nil
+}
+
 // queryer is the subset of *sql.DB and *sql.Tx that reads need.
 type queryer interface {
 	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row

--- a/internal/store/memory.go
+++ b/internal/store/memory.go
@@ -38,6 +38,21 @@ func (m *Memory) Record(_ context.Context, r lineage.Run) error {
 	return nil
 }
 
+func (m *Memory) Update(_ context.Context, runID string, p Patch) (lineage.Run, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	existing, ok := m.runs[runID]
+	if !ok {
+		return lineage.Run{}, ErrNotFound
+	}
+	updated, err := applyPatch(existing, p)
+	if err != nil {
+		return lineage.Run{}, err
+	}
+	m.runs[runID] = updated
+	return updated, nil
+}
+
 func (m *Memory) Get(_ context.Context, runID string) (lineage.Run, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -4,6 +4,8 @@ package store
 import (
 	"context"
 	"errors"
+	"fmt"
+	"time"
 
 	"github.com/kornsour/run-ledger/internal/lineage"
 )
@@ -11,9 +13,13 @@ import (
 // ErrNotFound is returned when a run id matches nothing.
 var ErrNotFound = errors.New("run not found")
 
-// ErrConflict is returned when a run id already exists with different content.
-// Recording is idempotent for identical content and an error otherwise —
-// silently overwriting a lineage record would make history unreliable.
+// ErrConflict is returned when a write would change what Record and Update
+// are not allowed to change: Record refuses a second write under an id with
+// different content, and Update refuses to alter a run's identity fields or
+// to move it through an illegal status transition. Recording and updating
+// are idempotent for a value that matches what is already stored, and an
+// error otherwise — silently overwriting a lineage record would make
+// history unreliable.
 var ErrConflict = errors.New("run already recorded with different content")
 
 // Query filters a run listing. A zero-valued field does not filter.
@@ -26,6 +32,40 @@ type Query struct {
 	Limit       int
 }
 
+// Patch is a partial update to a run, as accepted by Store.Update.
+//
+// The identity fields (everything above Provenance in lineage.Run) are
+// listed here too, but only to be checked, never applied: if one is set and
+// differs from the run's existing value, Update returns ErrConflict rather
+// than silently rewriting what experiment the run's id refers to. A nil
+// pointer field means "leave this alone"; a set pointer that matches the
+// existing value is a no-op, the same idempotence Record gives identical
+// content.
+//
+// Metrics is merged into the existing map rather than replacing it, so a
+// long run can report as it goes — re-reporting an existing key overwrites
+// just that key's value, not the whole map.
+type Patch struct {
+	// Identity — checked against the existing run, never written.
+	Project        *string
+	GitCommit      *string
+	GitDirty       *bool
+	ConfigHash     *string
+	DatasetVersion *string
+	ModelVersion   *string
+	Seed           *int64
+	Params         map[string]string
+
+	// Provenance — applied when set.
+	Status           *lineage.Status
+	EndedAt          *time.Time
+	CheckpointURI    *string
+	Host             *string
+	Device           *string
+	FrameworkVersion *string
+	Metrics          map[string]float64
+}
+
 // Store is the persistence boundary.
 //
 // The in-memory implementation is the reference; it defines the semantics every
@@ -33,7 +73,117 @@ type Query struct {
 // any implementation via RunConformance.
 type Store interface {
 	Record(ctx context.Context, r lineage.Run) error
+	// Update applies a partial, provenance-only change to an already-recorded
+	// run and returns the result. It returns ErrNotFound if runID matches no
+	// run, and ErrConflict if the patch would change an identity field, move
+	// the run through an illegal status transition, or apply at all to a run
+	// already in a terminal status (succeeded, failed, cancelled) — a
+	// terminal run is a finished outcome, not a waypoint.
+	Update(ctx context.Context, runID string, p Patch) (lineage.Run, error)
 	Get(ctx context.Context, runID string) (lineage.Run, error)
 	List(ctx context.Context, q Query) ([]lineage.Run, error)
 	Close() error
+}
+
+// legalTransitions is the run status lifecycle every backend enforces:
+// created -> running -> {succeeded, failed, cancelled}. A status not listed
+// as a key (including every terminal one) has no legal outgoing transition.
+var legalTransitions = map[lineage.Status]map[lineage.Status]bool{
+	lineage.StatusCreated: {lineage.StatusRunning: true},
+	lineage.StatusRunning: {
+		lineage.StatusSucceeded: true,
+		lineage.StatusFailed:    true,
+		lineage.StatusCancelled: true,
+	},
+}
+
+// applyPatch computes the result of applying p to existing, without
+// persisting it. Every backend's Update calls this after loading the
+// current row, so the identity/transition/merge rules live in exactly one
+// place instead of being reimplemented per backend.
+func applyPatch(existing lineage.Run, p Patch) (lineage.Run, error) {
+	if err := checkIdentityUnchanged(existing, p); err != nil {
+		return lineage.Run{}, err
+	}
+	if p.Status != nil && !lineage.ValidStatus(*p.Status) {
+		return lineage.Run{}, fmt.Errorf("unknown status %q", *p.Status)
+	}
+	if lineage.Terminal(existing.Status) {
+		// A terminal run is a finished outcome. Nothing about it — status
+		// included — moves again, even a same-value or metrics-only patch:
+		// there is no "in progress" left for it to report.
+		return lineage.Run{}, ErrConflict
+	}
+
+	updated := existing
+	if p.Status != nil && *p.Status != existing.Status {
+		if !legalTransitions[existing.Status][*p.Status] {
+			return lineage.Run{}, ErrConflict
+		}
+		updated.Status = *p.Status
+	}
+	if p.EndedAt != nil {
+		updated.EndedAt = *p.EndedAt
+	}
+	if p.CheckpointURI != nil {
+		updated.CheckpointURI = *p.CheckpointURI
+	}
+	if p.Host != nil {
+		updated.Host = *p.Host
+	}
+	if p.Device != nil {
+		updated.Device = *p.Device
+	}
+	if p.FrameworkVersion != nil {
+		updated.FrameworkVersion = *p.FrameworkVersion
+	}
+	if p.Metrics != nil {
+		merged := make(map[string]float64, len(updated.Metrics)+len(p.Metrics))
+		for k, v := range updated.Metrics {
+			merged[k] = v
+		}
+		for k, v := range p.Metrics {
+			merged[k] = v
+		}
+		updated.Metrics = merged
+	}
+
+	if err := updated.Validate(); err != nil {
+		return lineage.Run{}, err
+	}
+	return updated, nil
+}
+
+// checkIdentityUnchanged reports ErrConflict if p sets any identity field to
+// a value that differs from existing's. A field p leaves nil is not
+// checked, and a set field equal to the current value is a no-op, not a
+// conflict — the same idempotence Record gives identical content.
+func checkIdentityUnchanged(existing lineage.Run, p Patch) error {
+	switch {
+	case p.Project != nil && *p.Project != existing.Project,
+		p.GitCommit != nil && *p.GitCommit != existing.GitCommit,
+		p.GitDirty != nil && *p.GitDirty != existing.GitDirty,
+		p.ConfigHash != nil && *p.ConfigHash != existing.ConfigHash,
+		p.DatasetVersion != nil && *p.DatasetVersion != existing.DatasetVersion,
+		p.ModelVersion != nil && *p.ModelVersion != existing.ModelVersion,
+		p.Seed != nil && *p.Seed != existing.Seed,
+		p.Params != nil && !paramsEqual(p.Params, existing.Params):
+		return ErrConflict
+	}
+	return nil
+}
+
+// paramsEqual compares two params maps as equivalent regardless of whether
+// "no params" is represented as nil or an empty map — the two mean the same
+// thing and neither should look like a change from the other.
+func paramsEqual(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if b[k] != v {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
Closes #1

A run recorded at submission time could never be completed: `Store.Record` treats a second write under the same id as `ErrConflict` unless it is byte-identical, so `StatusRunning`/`StatusSucceeded`/`StatusFailed`/`StatusCancelled` were unreachable through the API. This adds an update path so a caller can record a run's identity at submission time and fill in its outcome as it becomes known.

## What changed

- **`Store.Update(ctx, runID, Patch) (lineage.Run, error)`** added to the `Store` interface, implemented by both `Memory` and `DuckDB` via a shared `applyPatch`/`checkIdentityUnchanged` helper in `internal/store/store.go` so the two backends can't quietly disagree:
  - **Identity is immutable.** `project`, `git_commit`, `git_dirty`, `config_hash`, `dataset_version`, `model_version`, `seed`, `params` are checked against the stored run; a mismatch is `ErrConflict` (409), a match is a no-op — the same idempotence `Record` gives identical content.
  - **Legal status transitions only:** `created → running → {succeeded, failed, cancelled}`. Any other move, and any further update at all to an already-terminal run (status change, metrics-only, whatever) is `ErrConflict` — a terminal run is a finished outcome, not a waypoint.
  - **Metrics are merged, not replaced**, so a long run can report as it goes; re-reporting an existing key overwrites just that key.
- **`RunConformance`** extended with Update coverage (lifecycle walk, metric merge, identity immutability, illegal transitions, terminal lock, unknown status) — both `TestMemoryConformance` and `TestDuckDBConformance` exercise it.
- **`PATCH /runs/{id}`** added to the HTTP API (`internal/api/api.go`), gated by the write token like `POST /runs`. It decodes into a pointer-typed request struct so "field omitted" and "field set to its zero value" are distinguishable, keeps `DisallowUnknownFields` for the existing typo protection, and maps `ErrNotFound`/`ErrConflict`/other errors to 404/409/400 the same way `record` does.
- **`lineage.ValidStatus`** and **`lineage.Terminal`** exported as small helpers used by the store package.
- **`rlctl` gains `start`, `finish [--status S] [--metric k=v] [--checkpoint URI]`, and `fail`**, all backed by the new endpoint (flags precede the run id, matching Go's stdlib `flag` parsing).
- README: documented the new endpoint, the transition rules, and a `start`/`finish`/`fail` example in "Try it".

## Test plan

- [x] `make lint` (vet + gofmt) clean
- [x] `make test` (`go test -race ./...`) — all packages pass, including the new `Store.Update` conformance cases against both `Memory` and `DuckDB`
- [x] Manual end-to-end smoke test against a running `runledger` + `rlctl`: `record` → `start` → `finish --metric --checkpoint` → `show` (succeeded, metrics/checkpoint/ended_at all present); a second run `record` → `start` → `fail`; a third run where `finish` was called directly from `created` correctly returned `409 Conflict`