### PR TITLE
Gate merges on the API spec and code staying in sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,9 +142,14 @@ implementation cannot quietly disagree about ordering or idempotency.
 | `GET` | `/metrics` | self-metrics, Prometheus exposition format |
 
 The full contract, including request/response schemas, lives in
-[`docs/openapi.yaml`](docs/openapi.yaml) — keep it in sync with `internal/api`
-when routes or fields change. An interactive reference rendered straight from
-that file, no separate artifact to keep in sync, is published at
+[`docs/openapi.yaml`](docs/openapi.yaml). It has to stay in sync with
+`internal/api` by hand, but not silently: `TestRoutesMatchSpec` and
+`TestSchemasMatchGoTypes` in
+[`internal/api/spec_test.go`](internal/api/spec_test.go) check the spec's
+routes and request/response field names against the actual Go types on
+every `go test ./...`, so CI fails a PR that lets the two drift apart. An
+interactive reference rendered straight from the spec, no separate artifact
+to keep in sync, is published at
 **https://kornsour.github.io/run-ledger/** via GitHub Pages ([`docs/index.html`](docs/index.html));
 it updates the moment a change to the spec lands on `main`, since Pages just
 serves whatever is currently in `docs/`. The spec is also a valid import for

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -394,6 +394,13 @@ components:
         run_id:
           type: string
           description: Usually left unset; the server assigns one from the fingerprint.
+        fingerprint:
+          type: string
+          description: >
+            Accepted but ignored: the decoder does not reject this field, and
+            the server always overwrites it with the identity fields' own
+            computed hash. There is no way to assert a fingerprint from the
+            client.
         host:
           type: string
         device:

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/kornsour/run-ledger
 
 go 1.26.5
 
-require github.com/marcboeker/go-duckdb/v2 v2.4.3
+require (
+	github.com/marcboeker/go-duckdb/v2 v2.4.3
+	gopkg.in/yaml.v3 v3.0.1
+)
 
 require (
 	github.com/apache/arrow-go/v18 v18.4.1 // indirect
@@ -21,6 +24,7 @@ require (
 	github.com/marcboeker/go-duckdb/arrowmapping v0.0.21 // indirect
 	github.com/marcboeker/go-duckdb/mapping v0.0.21 // indirect
 	github.com/pierrec/lz4/v4 v4.1.22 // indirect
+	github.com/rogpeppe/go-internal v1.16.0 // indirect
 	github.com/zeebo/xxh3 v1.0.2 // indirect
 	golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0 // indirect
 	golang.org/x/mod v0.27.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,10 @@ github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zt
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzhA9Y=
 github.com/klauspost/cpuid/v2 v2.3.0/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
+github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/marcboeker/go-duckdb/arrowmapping v0.0.21 h1:geHnVjlsAJGczSWEqYigy/7ARuD+eBtjd0kLN80SPJQ=
 github.com/marcboeker/go-duckdb/arrowmapping v0.0.21/go.mod h1:flFTc9MSqQCh2Xm62RYvG3Kyj29h7OtsTb6zUx1CdK8=
 github.com/marcboeker/go-duckdb/mapping v0.0.21 h1:6woNXZn8EfYdc9Vbv0qR6acnt0TM1s1eFqnrJZVrqEs=
@@ -50,6 +54,8 @@ github.com/pierrec/lz4/v4 v4.1.22 h1:cKFw6uJDK+/gfw5BcDL0JL5aBsAFdsIT18eRtLj7VIU
 github.com/pierrec/lz4/v4 v4.1.22/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/rogpeppe/go-internal v1.16.0 h1:O9DK+vNMDVGLr2BeZqmpLeMjiMNkuXfcqntWbZV6S5g=
+github.com/rogpeppe/go-internal v1.16.0/go.mod h1:DrUVZyrJU+txYW5/1kwtXQSMFio52ZOxX7yM1VHvnxs=
 github.com/stretchr/testify v1.11.0 h1:ib4sjIrwZKxE5u/Japgo/7SJV3PvgjGiRNAvTVGqQl8=
 github.com/stretchr/testify v1.11.0/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
@@ -70,5 +76,8 @@ golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da h1:noIWHXmPHxILtqtCOPIhS
 golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da/go.mod h1:NDW/Ps6MPRej6fsCIbMTohpP40sJ/P/vI1MoTEGwX90=
 gonum.org/v1/gonum v0.16.0 h1:5+ul4Swaf3ESvrOnidPp4GZbzf0mxVQpDCYUQE7OJfk=
 gonum.org/v1/gonum v0.16.0/go.mod h1:fef3am4MQ93R2HHpKnLk4/Tbh/s0+wqD5nfa6Pnwy4E=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -117,28 +117,47 @@ func New(s store.Store, log *slog.Logger, opts ...Option) *Server {
 	return srv
 }
 
+// route is one entry in the server's route table: the exact pattern
+// ServeMux registers it under (e.g. "POST /runs"), paired with its handler.
+type route struct {
+	pattern string
+	handler http.HandlerFunc
+}
+
+// routes is the server's route table -- the single source of truth for what
+// this server serves. Handler builds the mux from it, and spec_test.go
+// checks it against docs/openapi.yaml, so an endpoint added or removed here
+// without a matching spec change fails CI rather than shipping undocumented.
+func (s *Server) routes() []route {
+	return []route{
+		{"POST /runs", s.requireAuth(true, s.record)},
+		{"PATCH /runs/{id}", s.requireAuth(true, s.update)},
+		{"GET /runs", s.requireAuth(false, s.list)},
+		{"GET /runs/{id}", s.requireAuth(false, s.get)},
+		{"GET /compare", s.requireAuth(false, s.compare)},
+		{"GET /fingerprints", s.requireAuth(false, s.spreadList)},
+		{"GET /fingerprints/{fingerprint}", s.requireAuth(false, s.spreadOne)},
+		// /healthz stays unauthenticated so a liveness probe does not need a
+		// credential.
+		{"GET /healthz", func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok\n"))
+		}},
+		// Ready means the store answers a call, not just that the process is
+		// up. That distinction is a no-op today -- the only backend is
+		// in-memory -- but becomes real once the store is out of process.
+		{"GET /readyz", s.readyz},
+		{"GET /metrics", s.serveMetrics},
+	}
+}
+
 // Handler returns the routed mux, wrapped in request-scoped logging,
 // duration/metrics instrumentation, and panic recovery.
 func (s *Server) Handler() http.Handler {
 	mux := http.NewServeMux()
-	mux.HandleFunc("POST /runs", s.requireAuth(true, s.record))
-	mux.HandleFunc("PATCH /runs/{id}", s.requireAuth(true, s.update))
-	mux.HandleFunc("GET /runs", s.requireAuth(false, s.list))
-	mux.HandleFunc("GET /runs/{id}", s.requireAuth(false, s.get))
-	mux.HandleFunc("GET /compare", s.requireAuth(false, s.compare))
-	mux.HandleFunc("GET /fingerprints", s.requireAuth(false, s.spreadList))
-	mux.HandleFunc("GET /fingerprints/{fingerprint}", s.requireAuth(false, s.spreadOne))
-	// /healthz stays unauthenticated so a liveness probe does not need a
-	// credential.
-	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte("ok\n"))
-	})
-	// Ready means the store answers a call, not just that the process is
-	// up. That distinction is a no-op today -- the only backend is
-	// in-memory -- but becomes real once the store is out of process.
-	mux.HandleFunc("GET /readyz", s.readyz)
-	mux.HandleFunc("GET /metrics", s.serveMetrics)
+	for _, rt := range s.routes() {
+		mux.HandleFunc(rt.pattern, rt.handler)
+	}
 	return s.instrument(mux)
 }
 

--- a/internal/api/spec_test.go
+++ b/internal/api/spec_test.go
@@ -1,0 +1,215 @@
+package api
+
+// This file checks docs/openapi.yaml against the code it claims to
+// describe, so a route or a JSON field that drifts between the two fails
+// the build instead of shipping as a stale spec.
+//
+// It deliberately does not attempt to reconstruct the full spec from
+// reflection -- that would just move the hand-maintained part from the
+// yaml into this file. Instead it checks the two properties most likely to
+// silently drift and easiest to state precisely: the set of routes, and
+// the set of JSON field names each request/response type actually carries.
+
+import (
+	"os"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/kornsour/run-ledger/internal/compare"
+	"github.com/kornsour/run-ledger/internal/lineage"
+	"github.com/kornsour/run-ledger/internal/spread"
+)
+
+const specPath = "../../docs/openapi.yaml"
+
+type oaOperation struct {
+	OperationID string `yaml:"operationId"`
+}
+
+type oaSpec struct {
+	Paths      map[string]map[string]oaOperation `yaml:"paths"`
+	Components struct {
+		Schemas map[string]oaSchema `yaml:"schemas"`
+	} `yaml:"components"`
+}
+
+type oaSchema struct {
+	Ref        string              `yaml:"$ref"`
+	AllOf      []oaSchema          `yaml:"allOf"`
+	Properties map[string]oaSchema `yaml:"properties"`
+}
+
+func loadSpec(t *testing.T) oaSpec {
+	t.Helper()
+	raw, err := os.ReadFile(specPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", specPath, err)
+	}
+	var spec oaSpec
+	if err := yaml.Unmarshal(raw, &spec); err != nil {
+		t.Fatalf("parse %s: %v", specPath, err)
+	}
+	return spec
+}
+
+// TestRoutesMatchSpec checks that every route this server registers has a
+// matching path+method in the spec, and vice versa.
+func TestRoutesMatchSpec(t *testing.T) {
+	spec := loadSpec(t)
+
+	inCode := map[string]bool{}
+	for _, rt := range (&Server{}).routes() {
+		inCode[rt.pattern] = true
+	}
+
+	inSpec := map[string]bool{}
+	for path, methods := range spec.Paths {
+		for method := range methods {
+			inSpec[strings.ToUpper(method)+" "+path] = true
+		}
+	}
+
+	for pattern := range inCode {
+		if !inSpec[pattern] {
+			t.Errorf("route %q is registered in Server.routes but missing from %s", pattern, specPath)
+		}
+	}
+	for pattern := range inSpec {
+		if !inCode[pattern] {
+			t.Errorf("route %q is documented in %s but not registered in Server.routes", pattern, specPath)
+		}
+	}
+}
+
+// flattenSchema resolves $ref and allOf to the flat set of property names a
+// schema describes. Nested property schemas are not recursed into --
+// top-level field names are what a Go struct's json tags can be compared
+// against directly.
+func flattenSchema(name string, spec oaSpec, seen map[string]bool) map[string]bool {
+	if seen[name] {
+		return nil
+	}
+	seen[name] = true
+	s, ok := spec.Components.Schemas[name]
+	if !ok {
+		return nil
+	}
+	names := map[string]bool{}
+	for _, sub := range s.AllOf {
+		if sub.Ref != "" {
+			for k := range flattenSchema(strings.TrimPrefix(sub.Ref, "#/components/schemas/"), spec, seen) {
+				names[k] = true
+			}
+			continue
+		}
+		for k := range sub.Properties {
+			names[k] = true
+		}
+	}
+	for k := range s.Properties {
+		names[k] = true
+	}
+	return names
+}
+
+// jsonFieldNames returns the JSON field names t's encoding/json tags
+// produce -- the exact set json.Decoder.DisallowUnknownFields accepts, or
+// json.Encoder emits.
+func jsonFieldNames(t reflect.Type) map[string]bool {
+	names := map[string]bool{}
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		if f.PkgPath != "" { // unexported
+			continue
+		}
+		tag, ok := f.Tag.Lookup("json")
+		if !ok {
+			names[f.Name] = true
+			continue
+		}
+		name, _, _ := strings.Cut(tag, ",")
+		if name == "-" {
+			continue
+		}
+		if name == "" {
+			name = f.Name
+		}
+		names[name] = true
+	}
+	return names
+}
+
+func sortedKeys(m map[string]bool) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// TestSchemasMatchGoTypes checks that each named schema in the spec that
+// corresponds to a concrete request/response type declares exactly the
+// JSON field names that type's encoding/json tags actually produce or
+// accept. Schemas backed by an ad hoc map (handlers that build a response
+// with map[string]any rather than a named struct) are checked against a
+// literal key set instead, since there is no type to reflect on.
+func TestSchemasMatchGoTypes(t *testing.T) {
+	cases := []struct {
+		schema string
+		typ    reflect.Type
+		keys   []string
+	}{
+		{schema: "RunInput", typ: reflect.TypeOf(lineage.Run{})},
+		{schema: "Run", typ: reflect.TypeOf(lineage.Run{})},
+		{schema: "RunPatch", typ: reflect.TypeOf(patchRequest{})},
+		{schema: "RunPage", keys: []string{"runs", "count", "limit", "next_cursor"}},
+		{schema: "CompareField", typ: reflect.TypeOf(compare.Field{})},
+		{schema: "CompareResult", typ: reflect.TypeOf(compare.Result{})},
+		{schema: "CompareResponse", keys: []string{"result", "unattributable"}},
+		{schema: "MetricStat", typ: reflect.TypeOf(spread.MetricStat{})},
+		{schema: "ProvenanceDiff", typ: reflect.TypeOf(spread.ProvenanceDiff{})},
+		{schema: "SpreadGroup", typ: reflect.TypeOf(spread.Group{})},
+		{schema: "SpreadGroupList", keys: []string{"groups", "count"}},
+	}
+
+	spec := loadSpec(t)
+
+	for _, c := range cases {
+		t.Run(c.schema, func(t *testing.T) {
+			if _, ok := spec.Components.Schemas[c.schema]; !ok {
+				t.Fatalf("schema %q not found in %s", c.schema, specPath)
+			}
+			wantNames := flattenSchema(c.schema, spec, map[string]bool{})
+
+			var gotNames map[string]bool
+			if c.typ != nil {
+				gotNames = jsonFieldNames(c.typ)
+			} else {
+				gotNames = map[string]bool{}
+				for _, k := range c.keys {
+					gotNames[k] = true
+				}
+			}
+
+			for name := range gotNames {
+				if !wantNames[name] {
+					t.Errorf("field %q is present in the Go type but missing from schema %q in %s", name, c.schema, specPath)
+				}
+			}
+			for name := range wantNames {
+				if !gotNames[name] {
+					t.Errorf("schema %q in %s declares field %q, which the Go type does not have", c.schema, specPath, name)
+				}
+			}
+			if t.Failed() {
+				t.Logf("go fields:   %v", sortedKeys(gotNames))
+				t.Logf("spec fields: %v", sortedKeys(wantNames))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add `TestRoutesMatchSpec` and `TestSchemasMatchGoTypes` (`internal/api/spec_test.go`), which check `docs/openapi.yaml`'s routes and request/response field names against the actual Go types they're supposed to describe. Both run as part of the existing `go test -race ./...` step in `ci.yml`, so no new workflow was needed.
- Refactor `Server.Handler` to build the mux from a single `routes()` table instead of a separate list of `mux.HandleFunc` calls, giving the route set one source of truth instead of two views that could drift apart.
- Fix a real gap the new test caught immediately: `POST /runs` decodes into the full `lineage.Run` struct, so it silently accepts (and overwrites) a client-supplied `fingerprint` field that `RunInput` didn't document. Added and documented in the spec.
- `main` now has branch protection requiring the `build` and `python` CI checks to pass before merge (enforced for admins too, no self-bypass) — otherwise a failing check wouldn't actually block anything.

## Why

Following up on the earlier work publishing `docs/openapi.yaml` and an interactive reference at https://kornsour.github.io/run-ledger/: those keep the *docs* up to date automatically, but nothing stopped the spec itself from silently drifting away from what `internal/api` actually does. This adds that guarantee at the PR gate.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...`
- [x] `gofmt -l .` clean
- [x] Sanity-checked the drift detection by deleting a route from a scratch copy of the spec and confirming `TestRoutesMatchSpec` failed with a clear message, then restored it