### PR TITLE
Exclude non-terminal runs from spread

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -351,7 +351,11 @@ paths:
         the same runs GET /fingerprints/{fingerprint} already reports for
         them as no_repeats, so this is what keeps the two endpoints'
         membership consistent. Unrecognized query parameters are rejected
-        rather than silently ignored.
+        rather than silently ignored. Only terminal runs (succeeded, failed,
+        cancelled) count toward a fingerprint's group or its min_runs
+        threshold -- a created or running run has not produced a finished
+        measurement yet, so it is excluded rather than being counted as a
+        repeat.
       security:
         - bearerAuth: []
         - {}
@@ -429,7 +433,8 @@ paths:
         "200":
           description: >
             The spread group for this fingerprint, including no_repeats for
-            a lone run.
+            a lone run. Only terminal runs (succeeded, failed, cancelled)
+            count -- a created or running run is not a finished measurement.
           content:
             application/json:
               schema:
@@ -441,7 +446,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
         "404":
-          description: No run recorded with this fingerprint
+          description: >
+            No finished (terminal-status) run recorded with this
+            fingerprint -- including when every run recorded under it is
+            still created or running.
           content:
             application/json:
               schema:

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -712,7 +712,7 @@ func (s *Server) spreadList(w http.ResponseWriter, r *http.Request) {
 	// A nil slice serializes as JSON null; an empty result must still come
 	// back as [], the same rule list already follows via page.Runs.
 	groups := []spread.Group{}
-	for _, g := range spread.Compute(page.Runs) {
+	for _, g := range spread.Compute(terminalRuns(page.Runs)) {
 		if g.Count >= minRuns {
 			groups = append(groups, g)
 		}
@@ -811,12 +811,29 @@ func (s *Server) spreadOne(w http.ResponseWriter, r *http.Request) {
 		writeErr(w, http.StatusInternalServerError, "internal", err)
 		return
 	}
-	if len(page.Runs) == 0 {
+	runs := terminalRuns(page.Runs)
+	if len(runs) == 0 {
 		s.metrics.StoreError("not_found")
-		writeErr(w, http.StatusNotFound, "not_found", fmt.Errorf("no run recorded with fingerprint %q", fp))
+		writeErr(w, http.StatusNotFound, "not_found", fmt.Errorf("no finished run recorded with fingerprint %q", fp))
 		return
 	}
-	writeJSON(w, http.StatusOK, spread.One(fp, page.Runs))
+	writeJSON(w, http.StatusOK, spread.One(fp, runs))
+}
+
+// terminalRuns filters to the runs whose status is terminal -- succeeded,
+// failed, or cancelled. A running or created run carries whatever metrics
+// happen to be logged so far, not a finished measurement: counting it toward
+// a fingerprint's spread would let an in-flight run masquerade as a repeat,
+// join a group's min/max/mean/stddev with a mid-run value, and even outrank
+// genuinely divergent experiments on Group.Widest(). See ADR 0005.
+func terminalRuns(runs []lineage.Run) []lineage.Run {
+	out := make([]lineage.Run, 0, len(runs))
+	for _, r := range runs {
+		if lineage.Terminal(r.Status) {
+			out = append(out, r)
+		}
+	}
+	return out
 }
 
 // parseLimit resolves the effective page size for GET /runs: DefaultListLimit

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -598,9 +598,9 @@ func TestFingerprintsListOnlyIncludesRepeats(t *testing.T) {
 	h := srv(t)
 	// Two runs of the same experiment (identical identity fields, so they
 	// share a fingerprint), one run of a different experiment.
-	post(t, h, `{"project":"p","git_commit":"abc","config_hash":"cfg","seed":1,"metrics":{"loss":0.4}}`)
-	post(t, h, `{"project":"p","git_commit":"abc","config_hash":"cfg","seed":1,"metrics":{"loss":0.5}}`)
-	post(t, h, `{"project":"p","git_commit":"abc","config_hash":"cfg","seed":2,"metrics":{"loss":0.1}}`)
+	post(t, h, `{"project":"p","git_commit":"abc","config_hash":"cfg","seed":1,"status":"succeeded","metrics":{"loss":0.4}}`)
+	post(t, h, `{"project":"p","git_commit":"abc","config_hash":"cfg","seed":1,"status":"succeeded","metrics":{"loss":0.5}}`)
+	post(t, h, `{"project":"p","git_commit":"abc","config_hash":"cfg","seed":2,"status":"succeeded","metrics":{"loss":0.1}}`)
 
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/fingerprints?project=p", nil))
@@ -631,9 +631,9 @@ func TestFingerprintsListMinRunsIncludesLoneRuns(t *testing.T) {
 	// the default (min_runs=2) sees only the first; min_runs=1 or 0 must
 	// also surface the lone run, matching what GET /fingerprints/{fp} would
 	// already report for it (no_repeats: true, not absent from the list).
-	post(t, h, `{"project":"p","git_commit":"abc","config_hash":"cfg","seed":1,"metrics":{"loss":0.4}}`)
-	post(t, h, `{"project":"p","git_commit":"abc","config_hash":"cfg","seed":1,"metrics":{"loss":0.5}}`)
-	w := post(t, h, `{"project":"p","git_commit":"abc","config_hash":"cfg","seed":2,"metrics":{"loss":0.1}}`)
+	post(t, h, `{"project":"p","git_commit":"abc","config_hash":"cfg","seed":1,"status":"succeeded","metrics":{"loss":0.4}}`)
+	post(t, h, `{"project":"p","git_commit":"abc","config_hash":"cfg","seed":1,"status":"succeeded","metrics":{"loss":0.5}}`)
+	w := post(t, h, `{"project":"p","git_commit":"abc","config_hash":"cfg","seed":2,"status":"succeeded","metrics":{"loss":0.1}}`)
 	var lone map[string]any
 	_ = json.Unmarshal(w.Body.Bytes(), &lone)
 	loneFP := lone["fingerprint"].(string)
@@ -690,8 +690,8 @@ func TestFingerprintsListPaginatesWithoutSkippingOrRepeating(t *testing.T) {
 		// Distinct seeds -> distinct fingerprints; two runs each so every
 		// group clears the default min_runs and has a real (zero) spread to
 		// sort on.
-		post(t, h, fmt.Sprintf(`{"project":"p","git_commit":"abc","config_hash":"cfg","seed":%d,"metrics":{"loss":0.1}}`, i))
-		w := post(t, h, fmt.Sprintf(`{"project":"p","git_commit":"abc","config_hash":"cfg","seed":%d,"metrics":{"loss":0.2}}`, i))
+		post(t, h, fmt.Sprintf(`{"project":"p","git_commit":"abc","config_hash":"cfg","seed":%d,"status":"succeeded","metrics":{"loss":0.1}}`, i))
+		w := post(t, h, fmt.Sprintf(`{"project":"p","git_commit":"abc","config_hash":"cfg","seed":%d,"status":"succeeded","metrics":{"loss":0.2}}`, i))
 		var created map[string]any
 		_ = json.Unmarshal(w.Body.Bytes(), &created)
 		fps[created["fingerprint"].(string)] = true
@@ -806,9 +806,9 @@ func TestFingerprintsListEmptyResultIsEmptyArrayNotNull(t *testing.T) {
 func TestFingerprintOneGroupReportsMetricStats(t *testing.T) {
 	h := srv(t)
 	var a, b map[string]any
-	w := post(t, h, `{"project":"p","git_commit":"abc","config_hash":"cfg","seed":1,"metrics":{"loss":0.4}}`)
+	w := post(t, h, `{"project":"p","git_commit":"abc","config_hash":"cfg","seed":1,"status":"succeeded","metrics":{"loss":0.4}}`)
 	_ = json.Unmarshal(w.Body.Bytes(), &a)
-	w = post(t, h, `{"project":"p","git_commit":"abc","config_hash":"cfg","seed":1,"metrics":{"loss":0.5}}`)
+	w = post(t, h, `{"project":"p","git_commit":"abc","config_hash":"cfg","seed":1,"status":"succeeded","metrics":{"loss":0.5}}`)
 	_ = json.Unmarshal(w.Body.Bytes(), &b)
 	fp := a["fingerprint"].(string)
 
@@ -843,7 +843,7 @@ func TestFingerprintOneGroupReportsMetricStats(t *testing.T) {
 
 func TestFingerprintSingleRunIsNoRepeats(t *testing.T) {
 	h := srv(t)
-	w := post(t, h, `{"project":"p","git_commit":"abc","config_hash":"cfg","seed":1,"metrics":{"loss":0.4}}`)
+	w := post(t, h, `{"project":"p","git_commit":"abc","config_hash":"cfg","seed":1,"status":"succeeded","metrics":{"loss":0.4}}`)
 	var created map[string]any
 	_ = json.Unmarshal(w.Body.Bytes(), &created)
 	fp := created["fingerprint"].(string)
@@ -873,6 +873,84 @@ func TestFingerprintUnknownIs404(t *testing.T) {
 	srv(t).ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/fingerprints/nope", nil))
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("want 404, got %d", w.Code)
+	}
+}
+
+// TestFingerprintOneIgnoresNonTerminalRuns pins issue #23: a running (or
+// otherwise non-terminal) run carries whatever metrics were logged so far,
+// not a finished measurement. It must not join a finished run's spread, and
+// it must not turn a lone finished run into a false no_repeats:false.
+func TestFingerprintOneIgnoresNonTerminalRuns(t *testing.T) {
+	h := srv(t)
+	w := post(t, h, `{"project":"p","git_commit":"abc","config_hash":"cfg","seed":1,"status":"succeeded","metrics":{"loss":0.4}}`)
+	var finished map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &finished)
+	fp := finished["fingerprint"].(string)
+
+	// Same experiment (same identity fields), still running -- its
+	// mid-training metric must not join the finished run's group.
+	post(t, h, `{"project":"p","git_commit":"abc","config_hash":"cfg","seed":1,"status":"running","metrics":{"loss":99.0}}`)
+
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/fingerprints/"+fp, nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body)
+	}
+	var out struct {
+		Count     int  `json:"count"`
+		NoRepeats bool `json:"no_repeats"`
+		Metrics   map[string]struct {
+			Count int     `json:"count"`
+			Mean  float64 `json:"mean"`
+		} `json:"metrics"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
+		t.Fatal(err)
+	}
+	if !out.NoRepeats || out.Count != 1 {
+		t.Fatalf("running run must not count as a repeat, got %+v", out)
+	}
+	if loss, ok := out.Metrics["loss"]; ok {
+		t.Fatalf("running run's metric must not enter the group's stats, got %+v", loss)
+	}
+
+	// Also confirm it via the collection endpoint: min_runs=1 would surface
+	// a no_repeats group for the finished run, but must not report Count=2.
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/fingerprints?project=p&min_runs=1", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body)
+	}
+	var list struct {
+		Groups []struct {
+			Fingerprint string `json:"fingerprint"`
+			Count       int    `json:"count"`
+			NoRepeats   bool   `json:"no_repeats"`
+		} `json:"groups"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &list); err != nil {
+		t.Fatal(err)
+	}
+	if len(list.Groups) != 1 || list.Groups[0].Fingerprint != fp || list.Groups[0].Count != 1 || !list.Groups[0].NoRepeats {
+		t.Fatalf("want a single no_repeats group of count 1, got %+v", list.Groups)
+	}
+}
+
+// TestFingerprintOneAllNonTerminalIs404 pins the other side of issue #23: a
+// fingerprint that exists only as a created/running run has not been
+// measured yet, so it must not be reported as a (misleadingly empty)
+// no_repeats group -- it must 404, the same as a fingerprint never seen.
+func TestFingerprintOneAllNonTerminalIs404(t *testing.T) {
+	h := srv(t)
+	w := post(t, h, `{"project":"p","git_commit":"abc","config_hash":"cfg","seed":1,"status":"running","metrics":{"loss":3.9}}`)
+	var run map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &run)
+	fp := run["fingerprint"].(string)
+
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/fingerprints/"+fp, nil))
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("want 404 for a fingerprint with no finished run, got %d: %s", w.Code, w.Body)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `spreadList` and `spreadOne` (`internal/api/api.go`) handed every run for a project/fingerprint straight to `spread.Compute`/`spread.One`, so a `running` (or still-`created`) run's mid-flight metrics could join a fingerprint's min/max/mean/stddev and flip `Count>1`, reporting a spread the ledger never actually measured — and `Group.Widest()` could then rank a half-finished run's fingerprint top of "reproduces worst."
- Add a `terminalRuns` filter (`lineage.Terminal`: succeeded, failed, cancelled) applied before both endpoints compute spread.
- `GET /fingerprints/{fingerprint}` now 404s when every run under that fingerprint is non-terminal, instead of reporting a group built from an unfinished run.
- Update `docs/openapi.yaml` descriptions to document the terminal-only behavior.

Matches the "exclude it" option from the issue, and the precondition ADR 0005 names for revisiting two-phase writes from the Python client.

Fixes #23

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `go test -race ./...`
- [x] Updated existing `/fingerprints` tests to post finished (`succeeded`) runs where the test's intent is spread-grouping behavior, not status filtering
- [x] Added `TestFingerprintOneIgnoresNonTerminalRuns` and `TestFingerprintOneAllNonTerminalIs404` pinning the fix directly