### PR TITLE
ci: grant auto-merge issues:write so Fixes-# closes the linked issue

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -17,6 +17,11 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  # A squash-merge performed here still needs to close issues a PR body
+  # references with "Fixes #N" -- that's authorized against this token's own
+  # permissions, not just the merging user's, so without this the linked
+  # issue is left open even though the fix landed on main.
+  issues: write
 
 jobs:
   auto-merge:


### PR DESCRIPTION
## Summary
- kornsour/run-ledger#52 squash-merged with \`Fixes #23\` in the PR body, but the linked issue stayed open after merge.
- The auto-merge workflow's \`GITHUB_TOKEN\` only granted \`contents: write\` and \`pull-requests: write\`; GitHub's closing-keyword handling on merge is authorized against the acting token's own permissions, so without \`issues: write\` it can't close the issue even though the merge succeeds.
- Add \`issues: write\` to \`.github/workflows/auto-merge.yml\` so future \`Fixes #N\` PRs close their issue automatically on merge.

## Test plan
- [x] YAML is valid (workflow already runs `actions/checkout`-free, just permission block change)
- N/A — no code path to unit test; verified by re-reading the workflow file