### PR TITLE
API: version resource routes under /v1, and comparisons is a resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ R=$(./bin/rlctl record --project demo --seed 1 --config-hash cfg1)  # status: cr
 
 `start`/`finish`/`fail` only move a run forward — `created → running →
 {succeeded, failed, cancelled}` — and can never change what experiment the
-run was; see [PATCH `/runs/{id}`](#api) below.
+run was; see [PATCH `/v1/runs/{id}`](#api) below.
 
 ```
 same experiment (fingerprints match)
@@ -132,16 +132,22 @@ implementation cannot quietly disagree about ordering or idempotency.
 
 | Method | Path | |
 |---|---|---|
-| `POST` | `/runs` | record a run; the server assigns the fingerprint and id |
-| `PATCH` | `/runs/{id}` | update a run's provenance: `status`, `ended_at`, `checkpoint_uri`, `metrics`, `host`, `device`, `framework_version` |
-| `GET` | `/runs` | list, filtered by `project`, `git_commit`, `fingerprint`, `status`, `device`; paginated, see below |
-| `GET` | `/runs/{id}` | one run |
-| `GET` | `/compare?a=X&b=Y` | structured diff, with `unattributable` |
-| `GET` | `/fingerprints?project=P` | fingerprints with more than one run, ranked by widest relative metric spread |
-| `GET` | `/fingerprints/{fingerprint}` | one group: per-metric count/min/max/mean/stddev, or `no_repeats` for a lone run |
-| `GET` | `/healthz` | liveness |
+| `POST` | `/v1/runs` | record a run; the server assigns the fingerprint and id |
+| `PATCH` | `/v1/runs/{id}` | update a run's provenance: `status`, `ended_at`, `checkpoint_uri`, `metrics`, `host`, `device`, `framework_version` |
+| `GET` | `/v1/runs` | list, filtered by `project`, `git_commit`, `fingerprint`, `status`, `device`; paginated, see below |
+| `GET` | `/v1/runs/{id}` | one run |
+| `GET` | `/v1/comparisons?a=X&b=Y` | structured diff of two runs, with `unattributable` |
+| `GET` | `/v1/fingerprints?project=P` | fingerprints with more than one run, ranked by widest relative metric spread |
+| `GET` | `/v1/fingerprints/{fingerprint}` | one group: per-metric count/min/max/mean/stddev, or `no_repeats` for a lone run |
+| `GET` | `/healthz` | liveness — unversioned; see [ADR 0009](docs/adr/0009-url-path-versioning-for-the-http-api.md) |
 | `GET` | `/readyz` | readiness — the store answers a call |
 | `GET` | `/metrics` | self-metrics, Prometheus exposition format |
+
+Resource routes are versioned (`/v1/...`); the three operational endpoints
+above are not — see [ADR 0009](docs/adr/0009-url-path-versioning-for-the-http-api.md).
+`/v1/comparisons` addresses a comparison by the pair of run ids being
+compared rather than nesting it under one of the two runs; see
+[ADR 0010](docs/adr/0010-comparisons-is-a-resource-not-a-verb.md).
 
 The full contract, including request/response schemas, lives in
 [`docs/openapi.yaml`](docs/openapi.yaml). It has to stay in sync with
@@ -175,7 +181,7 @@ being true.
 
 ### Pagination
 
-`GET /runs` returns a page, not the whole result set:
+`GET /v1/runs` returns a page, not the whole result set:
 
 ```json
 {"runs": [ ... ], "count": 50, "limit": 50, "next_cursor": "v1:..."}
@@ -198,7 +204,7 @@ being true.
   its cursor's position, not a single fixed snapshot of the whole listing.
   A row recorded after a traversal begins, and sorting behind whatever
   position the traversal has already reached, is simply not visited by that
-  traversal — it is exactly the kind of row a fresh `GET /runs` (no cursor)
+  traversal — it is exactly the kind of row a fresh `GET /v1/runs` (no cursor)
   would show first. For an append-mostly ledger this is the cheap, honest
   contract: no page ever repeats or skips a row that existed before the
   traversal reached it, and nothing is promised about rows that did not.
@@ -277,7 +283,7 @@ have to be true to revisit each one — lives in [`docs/adr/`](docs/adr/).
 - **Re-recording identical content is idempotent; different content under the
   same id is a conflict.** Silently overwriting a lineage record would make
   history unreliable.
-- **`PATCH /runs/{id}` moves a run's provenance forward; it can never rewrite
+- **`PATCH /v1/runs/{id}` moves a run's provenance forward; it can never rewrite
   what experiment it was.** Identity fields (`project`, `git_commit`,
   `git_dirty`, `config_hash`, `dataset_version`, `model_version`, `seed`,
   `params`) are checked against the stored run and a mismatch is a `409`, not
@@ -303,7 +309,7 @@ have to be true to revisit each one — lives in [`docs/adr/`](docs/adr/).
   time rather than tracked as a local counter, since recording is idempotent
   and a retried record must not inflate it.
 - **The Python client writes the ledger once, at the end of a run, not once at
-  each end.** `POST /runs` has no update path yet, so `runledger.Run.start()`
+  each end.** `POST /v1/runs` has no update path yet, so `runledger.Run.start()`
   buffers status and metrics locally and sends one record when the outcome is
   known, rather than a `running` record it cannot later revise.
   ([ADR 0005](docs/adr/0005-python-client-writes-once-at-the-end.md))
@@ -314,7 +320,7 @@ have to be true to revisit each one — lives in [`docs/adr/`](docs/adr/).
   `CGO_ENABLED=0` no longer builds this module, and the container image needs a
   C toolchain and a matching libc instead of `distroless/static`.
   ([ADR 0006](docs/adr/0006-duckdb-store-backend-and-the-cgo-cost.md))
-- **`GET /runs` paginates by keyset cursor, not `LIMIT`/`OFFSET`, and is capped
+- **`GET /v1/runs` paginates by keyset cursor, not `LIMIT`/`OFFSET`, and is capped
   server-side.** An offset shifts under concurrent inserts, silently skipping a
   row a client paging through history should have seen; a cursor encoding the
   last row's sort key does not. A page is consistent with the ledger as of the
@@ -328,9 +334,21 @@ have to be true to revisit each one — lives in [`docs/adr/`](docs/adr/).
   side's. A `400`/`409` is quarantined to `<spool>.rejected.jsonl` instead of
   being retried forever, since retrying the same bytes against the same
   server gets the same answer every time; replay is safe to interrupt and
-  re-run at all because `POST /runs` is idempotent for identical content
+  re-run at all because `POST /v1/runs` is idempotent for identical content
   under the same id.
   ([ADR 0008](docs/adr/0008-replay-raises-quarantines-and-tracks-a-read-offset.md))
+- **Resource routes are versioned with a `/v1` URL path prefix; health,
+  readiness, and metrics are not.** A path segment can be routed on
+  unmodified, so a future breaking change can add `/v2` and run it alongside
+  `/v1` for as long as a transition needs, without touching the ops
+  endpoints a probe or a scrape config already points at.
+  ([ADR 0009](docs/adr/0009-url-path-versioning-for-the-http-api.md))
+- **`/v1/comparisons?a=&b=` replaces `GET /compare`.** A comparison is
+  identified by the pair of run ids being compared, not owned by either one,
+  so it sits next to `/v1/runs` and `/v1/fingerprints` as its own resource
+  collection instead of a verb hanging off the root — and the query-param
+  shape has somewhere to grow if comparing more than two runs ever matters.
+  ([ADR 0010](docs/adr/0010-comparisons-is-a-resource-not-a-verb.md))
 
 ## Status
 

--- a/cmd/rlctl/main.go
+++ b/cmd/rlctl/main.go
@@ -20,6 +20,11 @@ import (
 	"github.com/kornsour/run-ledger/internal/spread"
 )
 
+// apiVersion is the path segment every resource route on the server is
+// versioned under -- see ADR 0009. Kept in one place so a future version
+// bump is one edit here, not one per call site below.
+const apiVersion = "/v1"
+
 const usage = `rlctl — record and compare experiment runs
 
   rlctl record --project P [--seed N] [--dataset V] [--model V] [--param k=v ...] [--metric k=v ...]
@@ -143,7 +148,7 @@ func cmdRecord(args []string) error {
 
 	body, _ := json.Marshal(run)
 	var out lineage.Run
-	if err := call(http.MethodPost, *server+"/runs", body, &out); err != nil {
+	if err := call(http.MethodPost, *server, "/runs", body, &out); err != nil {
 		return err
 	}
 	fmt.Println(out.RunID)
@@ -227,7 +232,7 @@ func patchRun(server, runID string, fields map[string]any) (lineage.Run, error) 
 		return lineage.Run{}, err
 	}
 	var out lineage.Run
-	if err := call(http.MethodPatch, server+"/runs/"+url.PathEscape(runID), body, &out); err != nil {
+	if err := call(http.MethodPatch, server, "/runs/"+url.PathEscape(runID), body, &out); err != nil {
 		return lineage.Run{}, err
 	}
 	return out, nil
@@ -255,7 +260,7 @@ func cmdList(args []string) error {
 		Count      int           `json:"count"`
 		NextCursor string        `json:"next_cursor"`
 	}
-	if err := call(http.MethodGet, *server+"/runs?"+q.Encode(), nil, &out); err != nil {
+	if err := call(http.MethodGet, *server, "/runs?"+q.Encode(), nil, &out); err != nil {
 		return err
 	}
 	if out.Count == 0 {
@@ -285,7 +290,7 @@ func cmdShow(args []string) error {
 		return fmt.Errorf("show takes exactly one run id")
 	}
 	var run lineage.Run
-	if err := call(http.MethodGet, *server+"/runs/"+url.PathEscape(fs.Arg(0)), nil, &run); err != nil {
+	if err := call(http.MethodGet, *server, "/runs/"+url.PathEscape(fs.Arg(0)), nil, &run); err != nil {
 		return err
 	}
 	enc := json.NewEncoder(os.Stdout)
@@ -302,7 +307,7 @@ func cmdDiff(args []string) error {
 	}
 	q := url.Values{"a": {fs.Arg(0)}, "b": {fs.Arg(1)}}
 	var out compare.Result
-	if err := call(http.MethodGet, *server+"/compare?"+q.Encode(), nil, &out); err != nil {
+	if err := call(http.MethodGet, *server, "/comparisons?"+q.Encode(), nil, &out); err != nil {
 		return err
 	}
 	if len(out.Fields) == 0 {
@@ -348,7 +353,7 @@ func spreadList(server, project string) error {
 		Groups []spread.Group `json:"groups"`
 		Count  int            `json:"count"`
 	}
-	if err := call(http.MethodGet, server+"/fingerprints?"+q.Encode(), nil, &out); err != nil {
+	if err := call(http.MethodGet, server, "/fingerprints?"+q.Encode(), nil, &out); err != nil {
 		return err
 	}
 	if out.Count == 0 {
@@ -366,7 +371,7 @@ func spreadList(server, project string) error {
 
 func spreadOne(server, fingerprint string) error {
 	var g spread.Group
-	if err := call(http.MethodGet, server+"/fingerprints/"+url.PathEscape(fingerprint), nil, &g); err != nil {
+	if err := call(http.MethodGet, server, "/fingerprints/"+url.PathEscape(fingerprint), nil, &g); err != nil {
 		return err
 	}
 	fmt.Printf("fingerprint %s — %d run(s)\n", g.Fingerprint, g.Count)
@@ -406,8 +411,10 @@ func provenanceFields(diffs []spread.ProvenanceDiff) string {
 	return strings.Join(names, ", ")
 }
 
-func call(method, endpoint string, body []byte, out any) error {
-	req, err := http.NewRequest(method, endpoint, bytes.NewReader(body))
+// call issues one request against path on server, splicing in apiVersion so
+// every caller gets it for free instead of remembering to add it by hand.
+func call(method, server, path string, body []byte, out any) error {
+	req, err := http.NewRequest(method, server+apiVersion+path, bytes.NewReader(body))
 	if err != nil {
 		return err
 	}

--- a/docs/adr/0009-url-path-versioning-for-the-http-api.md
+++ b/docs/adr/0009-url-path-versioning-for-the-http-api.md
@@ -1,0 +1,134 @@
+# ADR 0009: URL path versioning for the HTTP API, and which routes it excludes
+
+Status: Accepted
+Date: 2026-08-29
+
+> **Every resource route is versioned with a `/v1` URL path prefix.**
+> `/healthz`, `/readyz`, and `/metrics` are not: they are fixed operational
+> conventions a probe or a scrape config points at once, not part of the
+> ledger's resource model, so an API version bump must never also mean
+> reconfiguring one of those. A future breaking change adds `/v2` alongside
+> `/v1` and runs both for as long as a transition needs, rather than forcing
+> every client to move on the same day the server does.
+
+## Context
+
+Every route the server registered was unversioned: `/runs`, `/runs/{id}`,
+`/compare`, `/fingerprints`, `/fingerprints/{fingerprint}`, plus the three
+operational endpoints. Nothing about the shape of a route, a query
+parameter, or a response body carried a version a client could pin to or a
+server could branch on.
+
+[ADR 0004](0004-fingerprint-input-is-a-versioned-contract.md) already
+establishes that the fingerprint hash input is a versioned contract, on the
+grounds that the first time it needs to change, the person making the
+change should find that rule before they make it, not after.
+[Issue #32](https://github.com/kornsour/run-ledger/issues/32) raised the
+same question for the HTTP surface, which had no equivalent rule, alongside
+a concrete route that was already due for a breaking change: `/compare`
+reads as a verb where every other route reads as a resource (see
+[ADR 0010](0010-comparisons-is-a-resource-not-a-verb.md) for that reshape).
+Making that change against unversioned routes would have meant either
+breaking every existing client the moment the new server deployed, or
+inventing a versioning scheme under pressure, mid-migration, with no time
+to think about what it should look like for the *next* one.
+
+There is no tagged release of this project and no external consumer
+depending on the current route shapes — the ledger has never promised route
+stability to anyone. That is what makes now the cheap moment to adopt a
+scheme: this migration does not itself need to serve both an old and a new
+shape, because nothing has shipped that depends on the old one. The value
+of doing it now is that the *next* breaking change — the one that lands
+after real clients exist — has somewhere to go.
+
+### Why a URL path prefix over the alternatives
+
+- **Media-type versioning** (`Accept:
+  application/vnd.runledger.v1+json`) keeps the URL stable across versions,
+  which is attractive in principle, but it pushes the version into a header
+  a browser address bar, a `curl` one-liner, and `rlctl`'s own request
+  logging can't show without extra work. This project's own tooling
+  (`rlctl`, the Python client, the OpenAPI viewer) all work from a URL
+  first; a header-only scheme would fight that instead of fitting it.
+- **A query parameter** (`?version=1`) is easy to forget on a single
+  request, which defeats the point of a version that is supposed to be
+  unmissable, and reads as an optional knob rather than the top-level fact
+  about what a route means that it actually is.
+- **A URL path prefix** (`/v1/runs`) makes the version the first thing a
+  reader of any request line sees, requires no new tooling to route on (Go's
+  `net/http.ServeMux`, and any reverse proxy in front of it, already
+  dispatches on path), and is what lets `/v1/...` and a future `/v2/...`
+  coexist as two entries in the same route table rather than two branches
+  inside every handler.
+
+### Why the three operational endpoints are excluded
+
+`/healthz` and `/readyz` are read by infrastructure that was not written for
+this project — a Kubernetes liveness/readiness probe, a load balancer health
+check — and follows its own naming convention regardless of what the
+application underneath it calls its resources. `/metrics` is read by a
+Prometheus scrape config that names the path once, in YAML, usually managed
+by someone other than whoever deploys a new API version. Versioning any of
+the three would mean every API version bump is also an infrastructure
+change to a probe or a scrape target, for three endpoints whose contract
+(their response is a liveness signal or an exposition-format dump, not a
+resource shape) has no reason to break the way `/runs` or `/comparisons`'s
+JSON schemas might.
+
+## Decision
+
+`internal/api/api.go` defines `apiVersion = "/v1"` and every resource
+route's pattern is built as `apiVersion + "/the/path"`; its `call` helper
+splices the same prefix into every request `cmd/rlctl/main.go` sends, so a
+call site there names only a server and a bare path, never `/v1` by hand.
+The `Location` header `POST /v1/runs` sets on success carries the same
+prefix. `/healthz`, `/readyz`, and `/metrics` keep their bare paths.
+Neither Go client goes through `internal/api`, so the constant is
+duplicated once, deliberately, at the client/server boundary -- `internal/
+api`'s version is an implementation detail of the server, and pulling
+`cmd/rlctl` into that package to avoid one repeated string would trade a
+one-line duplication for a real dependency on the server's internals. The
+Python package (`python/runledger`) has no such boundary to justify
+duplication *within* it: `read.py` defines `API_VERSION = "/v1"` once, and
+`_run.py` and `replay.py` both import it rather than each hardcoding their
+own copy.
+
+`docs/openapi.yaml`'s `paths:` keys carry the same `/v1/...` prefix (except
+the three operational endpoints), so `TestRoutesMatchSpec`
+([internal/api/spec_test.go](../../internal/api/spec_test.go)) continues to
+fail the build the moment code and spec disagree about what is versioned
+and what is not.
+
+## Consequences
+
+- A future breaking change to `/runs`, `/comparisons`, or `/fingerprints`
+  gets a `/v2` prefix and can run alongside `/v1` for however long a
+  deprecation window needs to be, rather than forcing a coordinated
+  simultaneous upgrade of every client. This migration itself does not
+  exercise that path — see Context above for why that is fine right now —
+  but the mechanism exists once it is needed.
+- Every client of this API (`rlctl`, the Python package, any external
+  script hitting the HTTP surface directly) needs `/v1` added to its request
+  paths. That is the entire migration this ADR authorizes: a one-time,
+  coordinated update, made now while it is free, instead of later under a
+  real deprecation deadline.
+- A reverse proxy or gateway placed in front of this server can route
+  `/v1/*` to one backend version and `/v2/*` to another without inspecting
+  headers or bodies — ordinary path-based routing, which every common proxy
+  already supports.
+- `/healthz`, `/readyz`, and `/metrics` staying unversioned means a
+  Kubernetes manifest, a load balancer config, or a Prometheus scrape target
+  written against this server today never needs to change on an API version
+  bump. That is a permanent property of this decision, not a transitional
+  one.
+
+## What would have to be true to revisit this
+
+A second, incompatible versioning axis becoming necessary at the same time
+as URL path versioning — for example, needing to version the wire format of
+a single route independently of the rest of the API. That would call for
+combining this scheme with a narrower one (e.g. a `schema_version` field on
+just that route's body) rather than replacing URL path versioning outright;
+the two are not mutually exclusive. Short of that, this is the standing
+scheme, the same way ADR 0004 is a standing rule rather than a decision
+that gets periodically revisited.

--- a/docs/adr/0010-comparisons-is-a-resource-not-a-verb.md
+++ b/docs/adr/0010-comparisons-is-a-resource-not-a-verb.md
@@ -1,0 +1,77 @@
+# ADR 0010: `/comparisons` is a resource, not a verb
+
+Status: Accepted
+Date: 2026-08-29
+
+> **`GET /v1/comparisons?a=&b=` replaces `GET /compare?a=&b=`.** A
+> comparison is identified by the unordered pair of run ids being compared,
+> not owned by either run, so it sits next to `/v1/runs` and
+> `/v1/fingerprints` as its own resource collection — addressed by query
+> parameters, the same way `/v1/fingerprints` already is — rather than a verb
+> hanging off the root.
+
+## Context
+
+`GET /compare?a=X&b=Y` (`internal/api/api.go`'s `compare` handler) is the
+only route in the API named as a verb rather than a resource. Every other
+route reads as a noun a client fetches, lists, or updates: `/runs`,
+`/runs/{id}`, `/fingerprints`, `/fingerprints/{fingerprint}`. `/compare`
+reads as a remote procedure call instead — closer to an RPC endpoint than
+to a REST resource, and the odd one out stylistically once a reader has
+seen the rest of the API.
+
+`internal/compare.Runs(a, b)` is symmetric: it returns `Result{A: a.RunID,
+B: b.RunID, ...}`, but nothing about the comparison privileges one run over
+the other — swapping `a` and `b` swaps which side of each `Field` a value
+lands on, not which comparison is being asked for. Two shapes were
+considered for the replacement, both raised in
+[issue #32](https://github.com/kornsour/run-ledger/issues/32):
+
+- `GET /runs/{id}/comparisons?to={other-id}` nests the comparison under one
+  of the two runs, treating it as *that run's* comparison to another.
+- `GET /comparisons?a=&b=` addresses the comparison directly, by the pair of
+  ids, owned by neither.
+
+Nesting under `/runs/{id}` would manufacture an asymmetry the underlying
+operation does not have — there is no principled way to choose which of two
+equally-weighted run ids becomes the path segment and which becomes the
+query parameter, and a client would have to make that arbitrary choice on
+every call. It also does not generalize as cleanly: a future N-way
+comparison (`a`, `b`, `c`, ...) has an obvious query-parameter shape
+(`?a=&b=&c=`) but no obvious "which one owns the path" answer once there is
+no longer a single "other" run to name with `?to=`.
+
+## Decision
+
+The route becomes `GET /v1/comparisons?a=&b=`, keeping the same `a`/`b`
+query parameters `compare` already validated and read. The handler function
+and `internal/compare` package are unchanged — only the route pattern in
+`internal/api/api.go`'s `routes()` and the corresponding path in
+`docs/openapi.yaml` move from `/compare` to (the now-versioned)
+`/v1/comparisons`.
+
+## Consequences
+
+- `rlctl diff`, the only caller of this route today, now requests
+  `/v1/comparisons?a=&b=` instead of `/compare?a=&b=`. No other client in
+  this repository calls it directly.
+- A future N-way comparison, if one is ever built, has a query-parameter
+  shape to grow into (`?a=&b=&c=`) without restructuring the resource
+  hierarchy — it stays a comparison identified by the set of run ids
+  involved, the same pattern this decision establishes for two.
+- The API surface is now uniformly noun-shaped: every route names a
+  resource a client fetches or mutates, and `/v1/comparisons` reads the same
+  way `/v1/fingerprints` already does.
+- This ships as a breaking change to `/compare`'s path, landing in the same
+  change as [ADR 0009](0009-url-path-versioning-for-the-http-api.md)'s `/v1`
+  prefix — the last route rename this project can make for free, before a
+  URL path version exists to make the next one for free instead.
+
+## What would have to be true to revisit this
+
+A real need to compare more than two runs at once, with a query-parameter
+list that becomes awkward at that scale (long URLs, ambiguous ordering
+across many ids). That would call for a request body on the comparison
+resource — `POST /v1/comparisons` with a list of run ids in the body,
+returning the same kind of structured result — rather than reworking the
+two-run shape this ADR settles.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -20,6 +20,8 @@ section is a summary of these; this folder is the account.
 | [0006](0006-duckdb-store-backend-and-the-cgo-cost.md) | `store.DuckDB` as the durable backend, and accepting cgo to get it | Accepted |
 | [0007](0007-keyset-pagination-cursor-consistency.md) | `GET /runs` paginates by keyset cursor, and a page is consistent with the cursor's position, not a fixed snapshot | Accepted |
 | [0008](0008-replay-raises-quarantines-and-tracks-a-read-offset.md) | `replay_spool()` raises on an unreachable ledger, quarantines permanent rejections, and rewrites the spool by tracked read offset | Accepted |
+| [0009](0009-url-path-versioning-for-the-http-api.md) | URL path versioning (`/v1`) for the HTTP API, excluding health/readiness/metrics | Accepted |
+| [0010](0010-comparisons-is-a-resource-not-a-verb.md) | `/comparisons` is a resource, not a verb | Accepted |
 
 ## Adding a record
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -8,7 +8,7 @@ info:
     framework_version, status, timestamps, checkpoint_uri, metrics) record
     what happened without affecting it. See the repository README for the
     full model.
-  version: "1.0"
+  version: "1.0.0"
   license:
     name: MIT
 servers:
@@ -22,7 +22,7 @@ security:
   - {}
 
 paths:
-  /runs:
+  /v1/runs:
     post:
       operationId: recordRun
       summary: Record a run
@@ -57,7 +57,7 @@ paths:
           description: Run recorded
           headers:
             Location:
-              description: /runs/{run_id} of the newly recorded run.
+              description: /v1/runs/{run_id} of the newly recorded run.
               schema:
                 type: string
           content:
@@ -183,7 +183,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
-  /runs/{id}:
+  /v1/runs/{id}:
     get:
       operationId: getRun
       summary: Get one run
@@ -289,10 +289,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
-  /compare:
+  /v1/comparisons:
     get:
       operationId: compareRuns
       summary: Structured diff of two runs
+      description: >
+        A comparison is addressed by the pair of run ids being compared (a,
+        b), not owned by either run -- this sits next to /v1/runs and
+        /v1/fingerprints as its own resource collection rather than a verb
+        hanging off the root.
       security:
         - bearerAuth: []
         - {}
@@ -339,7 +344,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
-  /fingerprints:
+  /v1/fingerprints:
     get:
       operationId: listFingerprintSpread
       summary: Fingerprints ranked by widest relative metric spread
@@ -348,7 +353,7 @@ paths:
         broken by fingerprint for a deterministic, resumable order. Defaults
         to fingerprints with more than one recorded run (min_runs=2); pass
         min_runs=1 or min_runs=0 to also see fingerprints with no repeats --
-        the same runs GET /fingerprints/{fingerprint} already reports for
+        the same runs GET /v1/fingerprints/{fingerprint} already reports for
         them as no_repeats, so this is what keeps the two endpoints'
         membership consistent. Unrecognized query parameters are rejected
         rather than silently ignored.
@@ -412,7 +417,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
-  /fingerprints/{fingerprint}:
+  /v1/fingerprints/{fingerprint}:
     get:
       operationId: getFingerprintSpread
       summary: Spread summary for one fingerprint

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -125,14 +125,22 @@ func New(s store.Store, log *slog.Logger, opts ...Option) *Server {
 }
 
 // route is one entry in the server's route table: the exact pattern
-// ServeMux registers it under (e.g. "POST /runs"), paired with its handler.
-// unmatched (below) walks this same table to tell "no such path" apart from
-// "wrong method for this path" once the mux itself has failed to find a
-// specific match.
+// ServeMux registers it under (e.g. "POST /v1/runs"), paired with its
+// handler. unmatched (below) walks this same table to tell "no such path"
+// apart from "wrong method for this path" once the mux itself has failed to
+// find a specific match.
 type route struct {
 	pattern string
 	handler http.HandlerFunc
 }
+
+// apiVersion is the path segment every resource route is versioned under --
+// see ADR 0009. Health, readiness, and metrics are deliberately excluded:
+// they are fixed operational conventions (liveness probes, Prometheus
+// scrape targets), not part of the ledger's resource model, so bumping the
+// API version must never also mean reconfiguring a probe or a scrape
+// config.
+const apiVersion = "/v1"
 
 // routes is the server's route table -- the single source of truth for what
 // this server serves. Handler builds the mux from it, and spec_test.go
@@ -140,13 +148,13 @@ type route struct {
 // without a matching spec change fails CI rather than shipping undocumented.
 func (s *Server) routes() []route {
 	return []route{
-		{"POST /runs", s.requireAuth(true, s.record)},
-		{"PATCH /runs/{id}", s.requireAuth(true, s.update)},
-		{"GET /runs", s.requireAuth(false, s.list)},
-		{"GET /runs/{id}", s.requireAuth(false, s.get)},
-		{"GET /compare", s.requireAuth(false, s.compare)},
-		{"GET /fingerprints", s.requireAuth(false, s.spreadList)},
-		{"GET /fingerprints/{fingerprint}", s.requireAuth(false, s.spreadOne)},
+		{"POST " + apiVersion + "/runs", s.requireAuth(true, s.record)},
+		{"PATCH " + apiVersion + "/runs/{id}", s.requireAuth(true, s.update)},
+		{"GET " + apiVersion + "/runs", s.requireAuth(false, s.list)},
+		{"GET " + apiVersion + "/runs/{id}", s.requireAuth(false, s.get)},
+		{"GET " + apiVersion + "/comparisons", s.requireAuth(false, s.compare)},
+		{"GET " + apiVersion + "/fingerprints", s.requireAuth(false, s.spreadList)},
+		{"GET " + apiVersion + "/fingerprints/{fingerprint}", s.requireAuth(false, s.spreadOne)},
 		// /healthz stays unauthenticated so a liveness probe does not need a
 		// credential.
 		{"GET /healthz", func(w http.ResponseWriter, _ *http.Request) {
@@ -417,7 +425,7 @@ func (s *Server) record(w http.ResponseWriter, r *http.Request) {
 	s.log.Info("recorded run", "run_id", run.RunID, "project", run.Project, "fingerprint", run.Fingerprint)
 	// The server assigns run_id when the caller doesn't supply one, so
 	// Location is the only way to learn it without parsing the body.
-	w.Header().Set("Location", "/runs/"+run.RunID)
+	w.Header().Set("Location", apiVersion+"/runs/"+run.RunID)
 	writeJSON(w, http.StatusCreated, run)
 }
 

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -35,7 +35,7 @@ func authed(method, path, token string) *http.Request {
 func post(t *testing.T, h http.Handler, body string) *httptest.ResponseRecorder {
 	t.Helper()
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/runs", strings.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/v1/runs", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	h.ServeHTTP(w, req)
 	return w
@@ -93,7 +93,7 @@ func TestDirtyTreeWithoutConfigHashIsRefused(t *testing.T) {
 
 func TestGetUnknownRunIs404(t *testing.T) {
 	w := httptest.NewRecorder()
-	srv(t).ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/runs/nope", nil))
+	srv(t).ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v1/runs/nope", nil))
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("want 404, got %d", w.Code)
 	}
@@ -101,7 +101,7 @@ func TestGetUnknownRunIs404(t *testing.T) {
 
 func TestCompareRequiresBothIDs(t *testing.T) {
 	w := httptest.NewRecorder()
-	srv(t).ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/compare?a=x", nil))
+	srv(t).ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v1/comparisons?a=x", nil))
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("want 400, got %d", w.Code)
 	}
@@ -122,7 +122,7 @@ func TestCompareFlagsUnattributableDifference(t *testing.T) {
 	b := idOf(`{"project":"p","git_commit":"abc","config_hash":"cfg","seed":1,"metrics":{"loss":0.4}}`)
 
 	w := httptest.NewRecorder()
-	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/compare?a="+a+"&b="+b, nil))
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v1/comparisons?a="+a+"&b="+b, nil))
 	if w.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d: %s", w.Code, w.Body)
 	}
@@ -154,7 +154,7 @@ func TestCompareFlagsUnattributableDifference(t *testing.T) {
 func TestBadLimitIsRejected(t *testing.T) {
 	for _, limit := range []string{"-3", "0", "not-a-number"} {
 		w := httptest.NewRecorder()
-		srv(t).ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/runs?limit="+limit, nil))
+		srv(t).ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v1/runs?limit="+limit, nil))
 		if w.Code != http.StatusBadRequest {
 			t.Fatalf("limit=%s: want 400, got %d", limit, w.Code)
 		}
@@ -177,7 +177,7 @@ func TestSinceUntilNarrowListing(t *testing.T) {
 	rec("in-range", base.Add(time.Minute))
 	rec("after", base.Add(time.Hour))
 
-	url := fmt.Sprintf("/runs?since=%s&until=%s",
+	url := fmt.Sprintf("/v1/runs?since=%s&until=%s",
 		base.Format(time.RFC3339), base.Add(time.Hour).Format(time.RFC3339))
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, url, nil))
@@ -217,7 +217,7 @@ func TestSinceUntilCombineWithOtherFilters(t *testing.T) {
 	rec("beta-in", "beta", base)
 	rec("alpha-out", "alpha", base.Add(-time.Hour))
 
-	url := fmt.Sprintf("/runs?project=alpha&status=created&since=%s&until=%s",
+	url := fmt.Sprintf("/v1/runs?project=alpha&status=created&since=%s&until=%s",
 		base.Format(time.RFC3339), base.Add(time.Hour).Format(time.RFC3339))
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, url, nil))
@@ -238,7 +238,7 @@ func TestSinceUntilCombineWithOtherFilters(t *testing.T) {
 func TestMalformedSinceUntilIsRejected(t *testing.T) {
 	for _, q := range []string{"since=not-a-time", "until=not-a-time", "since=2024-01-01"} {
 		w := httptest.NewRecorder()
-		srv(t).ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/runs?"+q, nil))
+		srv(t).ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v1/runs?"+q, nil))
 		if w.Code != http.StatusBadRequest {
 			t.Fatalf("%s: want 400, got %d: %s", q, w.Code, w.Body)
 		}
@@ -251,7 +251,7 @@ func TestBadCursorIsRejected(t *testing.T) {
 			continue // empty cursor means "from the top", not an error
 		}
 		w := httptest.NewRecorder()
-		srv(t).ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/runs?cursor="+cursor, nil))
+		srv(t).ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v1/runs?cursor="+cursor, nil))
 		if w.Code != http.StatusBadRequest {
 			t.Fatalf("cursor=%s: want 400, got %d: %s", cursor, w.Code, w.Body)
 		}
@@ -260,7 +260,7 @@ func TestBadCursorIsRejected(t *testing.T) {
 
 func TestUnknownQueryParamIsRejected(t *testing.T) {
 	w := httptest.NewRecorder()
-	srv(t).ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/runs?projct=demo", nil))
+	srv(t).ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v1/runs?projct=demo", nil))
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("a typo'd query parameter must be refused, got %d: %s", w.Code, w.Body)
 	}
@@ -268,7 +268,7 @@ func TestUnknownQueryParamIsRejected(t *testing.T) {
 
 func TestInvalidStatusIsRejected(t *testing.T) {
 	w := httptest.NewRecorder()
-	srv(t).ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/runs?status=succeded", nil))
+	srv(t).ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v1/runs?status=succeded", nil))
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("a typo'd status must be refused, not silently return an empty result, got %d: %s", w.Code, w.Body)
 	}
@@ -282,7 +282,7 @@ func TestValidStatusIsAccepted(t *testing.T) {
 	}
 
 	w = httptest.NewRecorder()
-	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/runs?status=created", nil))
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v1/runs?status=created", nil))
 	if w.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d: %s", w.Code, w.Body)
 	}
@@ -305,7 +305,7 @@ func TestListWithRecognizedParamsStillWorks(t *testing.T) {
 	_ = json.Unmarshal(w.Body.Bytes(), &run)
 	fingerprint := run["fingerprint"].(string)
 
-	url := fmt.Sprintf("/runs?project=p&git_commit=abc&fingerprint=%s&status=created&device=gpu0&limit=10&cursor=", fingerprint)
+	url := fmt.Sprintf("/v1/runs?project=p&git_commit=abc&fingerprint=%s&status=created&device=gpu0&limit=10&cursor=", fingerprint)
 	w = httptest.NewRecorder()
 	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, url, nil))
 	if w.Code != http.StatusOK {
@@ -323,7 +323,7 @@ func TestListDefaultsAndCapsLimit(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/runs?project=p", nil))
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v1/runs?project=p", nil))
 	var got struct {
 		Runs  []map[string]any `json:"runs"`
 		Count int              `json:"count"`
@@ -338,7 +338,7 @@ func TestListDefaultsAndCapsLimit(t *testing.T) {
 	}
 
 	w = httptest.NewRecorder()
-	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, fmt.Sprintf("/runs?project=p&limit=%d", MaxListLimit+1000), nil))
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, fmt.Sprintf("/v1/runs?project=p&limit=%d", MaxListLimit+1000), nil))
 	_ = json.Unmarshal(w.Body.Bytes(), &got)
 	if got.Limit != MaxListLimit {
 		t.Fatalf("a request over MaxListLimit must be clamped, got effective limit %d", got.Limit)
@@ -362,7 +362,7 @@ func TestListCursorPagesWithoutSkippingOrRepeating(t *testing.T) {
 	seen := map[string]bool{}
 	cursor := ""
 	for i := 0; i < n+1; i++ { // +1 guards against a cursor that never terminates
-		url := "/runs?project=p&limit=2"
+		url := "/v1/runs?project=p&limit=2"
 		if cursor != "" {
 			url += "&cursor=" + cursor
 		}
@@ -469,7 +469,7 @@ func TestMetricsEndpointReportsStoreConflict(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	// Same run id, different content -> conflict.
-	req := httptest.NewRequest(http.MethodPost, "/runs",
+	req := httptest.NewRequest(http.MethodPost, "/v1/runs",
 		strings.NewReader(`{"project":"p","git_commit":"other","config_hash":"cfg","run_id":"fixed-id"}`))
 	req.Header.Set("Content-Type", "application/json")
 	h.ServeHTTP(w, req)
@@ -488,14 +488,14 @@ func TestNoTokenConfiguredAllowsEverything(t *testing.T) {
 	h := srv(t) // no Auth option: the default, single-user, unauthenticated server.
 
 	w := httptest.NewRecorder()
-	h.ServeHTTP(w, authed(http.MethodGet, "/runs", ""))
+	h.ServeHTTP(w, authed(http.MethodGet, "/v1/runs", ""))
 	if w.Code != http.StatusOK {
 		t.Fatalf("want 200 with no token configured, got %d: %s", w.Code, w.Body)
 	}
 
 	body := `{"project":"p","git_commit":"abc","config_hash":"cfg"}`
 	w = httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/runs", strings.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/v1/runs", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	h.ServeHTTP(w, req)
 	if w.Code != http.StatusCreated {
@@ -512,10 +512,10 @@ func TestTokenConfiguredRefusesMissingOrWrongOnBothVerbs(t *testing.T) {
 		path   string
 		token  string
 	}{
-		{"read, no token", http.MethodGet, "/runs", ""},
-		{"read, wrong token", http.MethodGet, "/runs", "nope"},
-		{"write, no token", http.MethodPost, "/runs", ""},
-		{"write, wrong token", http.MethodPost, "/runs", "nope"},
+		{"read, no token", http.MethodGet, "/v1/runs", ""},
+		{"read, wrong token", http.MethodGet, "/v1/runs", "nope"},
+		{"write, no token", http.MethodPost, "/v1/runs", ""},
+		{"write, wrong token", http.MethodPost, "/v1/runs", "nope"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -529,14 +529,14 @@ func TestTokenConfiguredRefusesMissingOrWrongOnBothVerbs(t *testing.T) {
 
 	// The correct token still works on both verbs.
 	w := httptest.NewRecorder()
-	h.ServeHTTP(w, authed(http.MethodGet, "/runs", "write-secret"))
+	h.ServeHTTP(w, authed(http.MethodGet, "/v1/runs", "write-secret"))
 	if w.Code != http.StatusOK {
 		t.Fatalf("want 200 with the correct token, got %d: %s", w.Code, w.Body)
 	}
 
 	body := `{"project":"p","git_commit":"abc","config_hash":"cfg"}`
 	w = httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/runs", strings.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/v1/runs", strings.NewReader(body))
 	req.Header.Set("Authorization", "Bearer write-secret")
 	req.Header.Set("Content-Type", "application/json")
 	h.ServeHTTP(w, req)
@@ -549,14 +549,14 @@ func TestReadTokenCannotWrite(t *testing.T) {
 	h := srvWithAuth(t, Auth{WriteToken: "write-secret", ReadToken: "read-secret"})
 
 	w := httptest.NewRecorder()
-	h.ServeHTTP(w, authed(http.MethodGet, "/runs", "read-secret"))
+	h.ServeHTTP(w, authed(http.MethodGet, "/v1/runs", "read-secret"))
 	if w.Code != http.StatusOK {
 		t.Fatalf("read token should be able to read, got %d: %s", w.Code, w.Body)
 	}
 
 	body := `{"project":"p","git_commit":"abc","config_hash":"cfg"}`
 	w = httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/runs", strings.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/v1/runs", strings.NewReader(body))
 	req.Header.Set("Authorization", "Bearer read-secret")
 	h.ServeHTTP(w, req)
 	// The token is valid, just scoped to reads -- that's a 403 (scope
@@ -575,7 +575,7 @@ func TestMissingOrGarbageTokenIs401WithChallenge(t *testing.T) {
 
 	for _, token := range []string{"", "garbage"} {
 		w := httptest.NewRecorder()
-		h.ServeHTTP(w, authed(http.MethodGet, "/runs", token))
+		h.ServeHTTP(w, authed(http.MethodGet, "/v1/runs", token))
 		if w.Code != http.StatusUnauthorized {
 			t.Fatalf("token %q against a read endpoint: want 401, got %d: %s", token, w.Code, w.Body)
 		}
@@ -584,7 +584,7 @@ func TestMissingOrGarbageTokenIs401WithChallenge(t *testing.T) {
 		}
 
 		w = httptest.NewRecorder()
-		h.ServeHTTP(w, authed(http.MethodPost, "/runs", token))
+		h.ServeHTTP(w, authed(http.MethodPost, "/v1/runs", token))
 		if w.Code != http.StatusUnauthorized {
 			t.Fatalf("token %q against a write endpoint: want 401, got %d: %s", token, w.Code, w.Body)
 		}
@@ -603,7 +603,7 @@ func TestFingerprintsListOnlyIncludesRepeats(t *testing.T) {
 	post(t, h, `{"project":"p","git_commit":"abc","config_hash":"cfg","seed":2,"metrics":{"loss":0.1}}`)
 
 	w := httptest.NewRecorder()
-	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/fingerprints?project=p", nil))
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v1/fingerprints?project=p", nil))
 	if w.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d: %s", w.Code, w.Body)
 	}
@@ -640,7 +640,7 @@ func TestFingerprintsListMinRunsIncludesLoneRuns(t *testing.T) {
 
 	for _, minRuns := range []string{"1", "0"} {
 		w := httptest.NewRecorder()
-		h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/fingerprints?project=p&min_runs="+minRuns, nil))
+		h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v1/fingerprints?project=p&min_runs="+minRuns, nil))
 		if w.Code != http.StatusOK {
 			t.Fatalf("min_runs=%s: want 200, got %d: %s", minRuns, w.Code, w.Body)
 		}
@@ -675,7 +675,7 @@ func TestFingerprintsListMinRunsIncludesLoneRuns(t *testing.T) {
 func TestFingerprintsListInvalidMinRunsIs400(t *testing.T) {
 	for _, minRuns := range []string{"-1", "not-a-number", "1.5"} {
 		w := httptest.NewRecorder()
-		srv(t).ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/fingerprints?min_runs="+minRuns, nil))
+		srv(t).ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v1/fingerprints?min_runs="+minRuns, nil))
 		if w.Code != http.StatusBadRequest {
 			t.Fatalf("min_runs=%s: want 400, got %d: %s", minRuns, w.Code, w.Body)
 		}
@@ -711,7 +711,7 @@ func TestFingerprintsListPaginatesWithoutSkippingOrRepeating(t *testing.T) {
 
 	// First page.
 	w := httptest.NewRecorder()
-	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/fingerprints?project=p&limit=2", nil))
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v1/fingerprints?project=p&limit=2", nil))
 	if w.Code != http.StatusOK {
 		t.Fatalf("page 1: want 200, got %d: %s", w.Code, w.Body)
 	}
@@ -736,7 +736,7 @@ func TestFingerprintsListPaginatesWithoutSkippingOrRepeating(t *testing.T) {
 	var last page
 	for i := 0; i < n; i++ { // generous guard against a cursor that never terminates
 		w := httptest.NewRecorder()
-		h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/fingerprints?project=p&limit=2&cursor="+cursor, nil))
+		h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v1/fingerprints?project=p&limit=2&cursor="+cursor, nil))
 		if w.Code != http.StatusOK {
 			t.Fatalf("follow-up page: want 200, got %d: %s", w.Code, w.Body)
 		}
@@ -767,7 +767,7 @@ func TestFingerprintsListPaginatesWithoutSkippingOrRepeating(t *testing.T) {
 func TestFingerprintsListInvalidCursorIsRejected(t *testing.T) {
 	for _, cursor := range []string{"not-base64url!!", "aGVsbG8"} {
 		w := httptest.NewRecorder()
-		srv(t).ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/fingerprints?cursor="+cursor, nil))
+		srv(t).ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v1/fingerprints?cursor="+cursor, nil))
 		if w.Code != http.StatusBadRequest {
 			t.Fatalf("cursor=%s: want 400, got %d: %s", cursor, w.Code, w.Body)
 		}
@@ -780,7 +780,7 @@ func TestFingerprintsListEmptyResultIsEmptyArrayNotNull(t *testing.T) {
 	// JSON null, not []; unmarshaling into a Go slice would hide that bug
 	// (nil and [] decode the same way), so this checks the raw body text.
 	w := httptest.NewRecorder()
-	srv(t).ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/fingerprints", nil))
+	srv(t).ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v1/fingerprints", nil))
 	if w.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d: %s", w.Code, w.Body)
 	}
@@ -794,7 +794,7 @@ func TestFingerprintsListEmptyResultIsEmptyArrayNotNull(t *testing.T) {
 	post(t, h, `{"project":"p","git_commit":"abc","config_hash":"cfg","seed":1,"metrics":{"loss":0.4}}`)
 	post(t, h, `{"project":"p","git_commit":"abc","config_hash":"cfg","seed":1,"metrics":{"loss":0.5}}`)
 	w = httptest.NewRecorder()
-	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/fingerprints?min_runs=5", nil))
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v1/fingerprints?min_runs=5", nil))
 	if w.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d: %s", w.Code, w.Body)
 	}
@@ -813,7 +813,7 @@ func TestFingerprintOneGroupReportsMetricStats(t *testing.T) {
 	fp := a["fingerprint"].(string)
 
 	w = httptest.NewRecorder()
-	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/fingerprints/"+fp, nil))
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v1/fingerprints/"+fp, nil))
 	if w.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d: %s", w.Code, w.Body)
 	}
@@ -849,7 +849,7 @@ func TestFingerprintSingleRunIsNoRepeats(t *testing.T) {
 	fp := created["fingerprint"].(string)
 
 	w = httptest.NewRecorder()
-	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/fingerprints/"+fp, nil))
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v1/fingerprints/"+fp, nil))
 	if w.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d: %s", w.Code, w.Body)
 	}
@@ -870,7 +870,7 @@ func TestFingerprintSingleRunIsNoRepeats(t *testing.T) {
 
 func TestFingerprintUnknownIs404(t *testing.T) {
 	w := httptest.NewRecorder()
-	srv(t).ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/fingerprints/nope", nil))
+	srv(t).ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v1/fingerprints/nope", nil))
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("want 404, got %d", w.Code)
 	}
@@ -879,7 +879,7 @@ func TestFingerprintUnknownIs404(t *testing.T) {
 func patch(t *testing.T, h http.Handler, id, body string) *httptest.ResponseRecorder {
 	t.Helper()
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPatch, "/runs/"+id, strings.NewReader(body))
+	req := httptest.NewRequest(http.MethodPatch, "/v1/runs/"+id, strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	h.ServeHTTP(w, req)
 	return w
@@ -923,7 +923,7 @@ func TestRecordedRunOmitsEndedAtUntilItEnds(t *testing.T) {
 	id := created["run_id"].(string)
 
 	w = httptest.NewRecorder()
-	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/runs/"+id, nil))
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v1/runs/"+id, nil))
 	if w.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d: %s", w.Code, w.Body)
 	}
@@ -1063,7 +1063,7 @@ func TestRecordIDTakenHasSpecificCode(t *testing.T) {
 	post(t, h, body) // first record succeeds
 
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/runs",
+	req := httptest.NewRequest(http.MethodPost, "/v1/runs",
 		strings.NewReader(`{"project":"p","git_commit":"other","config_hash":"cfg","run_id":"fixed-id"}`))
 	req.Header.Set("Content-Type", "application/json")
 	h.ServeHTTP(w, req)
@@ -1079,7 +1079,7 @@ func TestRecordIDTakenHasSpecificCode(t *testing.T) {
 func TestErrorBodyEchoesRequestID(t *testing.T) {
 	h := srv(t)
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/runs/nope", nil)
+	req := httptest.NewRequest(http.MethodGet, "/v1/runs/nope", nil)
 	h.ServeHTTP(w, req)
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("want 404, got %d: %s", w.Code, w.Body)
@@ -1136,7 +1136,7 @@ func TestUpdateUnknownFieldIsRejected(t *testing.T) {
 
 func TestUpdateRequiresWriteToken(t *testing.T) {
 	h := srvWithAuth(t, Auth{WriteToken: "write-secret", ReadToken: "read-secret"})
-	req := httptest.NewRequest(http.MethodPatch, "/runs/whatever", strings.NewReader(`{"status":"running"}`))
+	req := httptest.NewRequest(http.MethodPatch, "/v1/runs/whatever", strings.NewReader(`{"status":"running"}`))
 	req.Header.Set("Authorization", "Bearer read-secret")
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
@@ -1176,7 +1176,7 @@ func TestUnmatchedPathIs404WithJSONEnvelope(t *testing.T) {
 
 func TestDisallowedMethodIs405WithAllowHeader(t *testing.T) {
 	w := httptest.NewRecorder()
-	srv(t).ServeHTTP(w, httptest.NewRequest(http.MethodDelete, "/runs", nil))
+	srv(t).ServeHTTP(w, httptest.NewRequest(http.MethodDelete, "/v1/runs", nil))
 	if w.Code != http.StatusMethodNotAllowed {
 		t.Fatalf("want 405, got %d: %s", w.Code, w.Body)
 	}
@@ -1189,7 +1189,7 @@ func TestDisallowedMethodIs405WithAllowHeader(t *testing.T) {
 	}
 	allow := w.Header().Get("Allow")
 	if !strings.Contains(allow, "GET") || !strings.Contains(allow, "POST") {
-		t.Fatalf("want Allow to list GET and POST for /runs, got %q", allow)
+		t.Fatalf("want Allow to list GET and POST for /v1/runs, got %q", allow)
 	}
 }
 
@@ -1204,23 +1204,23 @@ func TestRecordSetsLocationHeader(t *testing.T) {
 	if runID == "" {
 		t.Fatalf("no run id assigned: %s", w.Body)
 	}
-	want := "/runs/" + runID
+	want := "/v1/runs/" + runID
 	if got := w.Header().Get("Location"); got != want {
 		t.Fatalf("want Location %q, got %q", want, got)
 	}
 }
 
 func TestDisallowedMethodOnPathParamRouteIs405(t *testing.T) {
-	// /runs/{id} only supports GET and PATCH -- DELETE must be refused the
+	// /v1/runs/{id} only supports GET and PATCH -- DELETE must be refused the
 	// same way, with the path-templated route resolved correctly.
 	w := httptest.NewRecorder()
-	srv(t).ServeHTTP(w, httptest.NewRequest(http.MethodDelete, "/runs/xyz", nil))
+	srv(t).ServeHTTP(w, httptest.NewRequest(http.MethodDelete, "/v1/runs/xyz", nil))
 	if w.Code != http.StatusMethodNotAllowed {
 		t.Fatalf("want 405, got %d: %s", w.Code, w.Body)
 	}
 	allow := w.Header().Get("Allow")
 	if !strings.Contains(allow, "GET") || !strings.Contains(allow, "PATCH") {
-		t.Fatalf("want Allow to list GET and PATCH for /runs/{id}, got %q", allow)
+		t.Fatalf("want Allow to list GET and PATCH for /v1/runs/{id}, got %q", allow)
 	}
 }
 
@@ -1236,7 +1236,7 @@ func TestRecordWrongContentTypeIs415(t *testing.T) {
 	body := `{"project":"p","git_commit":"abc","config_hash":"cfg"}`
 	for _, ct := range []string{"text/plain", ""} {
 		w := httptest.NewRecorder()
-		srv(t).ServeHTTP(w, requestWithContentType(http.MethodPost, "/runs", ct, body))
+		srv(t).ServeHTTP(w, requestWithContentType(http.MethodPost, "/v1/runs", ct, body))
 		if w.Code != http.StatusUnsupportedMediaType {
 			t.Fatalf("Content-Type %q: want 415, got %d: %s", ct, w.Code, w.Body)
 		}
@@ -1250,7 +1250,7 @@ func TestRecordWrongContentTypeIs415(t *testing.T) {
 func TestRecordAcceptsJSONWithCharsetParameter(t *testing.T) {
 	body := `{"project":"p","git_commit":"abc","config_hash":"cfg"}`
 	w := httptest.NewRecorder()
-	srv(t).ServeHTTP(w, requestWithContentType(http.MethodPost, "/runs", "application/json; charset=utf-8", body))
+	srv(t).ServeHTTP(w, requestWithContentType(http.MethodPost, "/v1/runs", "application/json; charset=utf-8", body))
 	if w.Code != http.StatusCreated {
 		t.Fatalf("a charset parameter must not be mistaken for a wrong media type, got %d: %s", w.Code, w.Body)
 	}
@@ -1264,7 +1264,7 @@ func TestUpdateWrongContentTypeIs415(t *testing.T) {
 	id := created["run_id"].(string)
 
 	w = httptest.NewRecorder()
-	h.ServeHTTP(w, requestWithContentType(http.MethodPatch, "/runs/"+id, "text/plain", `{"status":"running"}`))
+	h.ServeHTTP(w, requestWithContentType(http.MethodPatch, "/v1/runs/"+id, "text/plain", `{"status":"running"}`))
 	if w.Code != http.StatusUnsupportedMediaType {
 		t.Fatalf("want 415, got %d: %s", w.Code, w.Body)
 	}
@@ -1281,7 +1281,7 @@ func TestOversizedBodyIsCleanBadRequest(t *testing.T) {
 	body := fmt.Sprintf(`{"project":"p","git_commit":"abc","config_hash":"cfg","params":{"huge":%q}}`, big)
 
 	w := httptest.NewRecorder()
-	srv(t).ServeHTTP(w, requestWithContentType(http.MethodPost, "/runs", "application/json", body))
+	srv(t).ServeHTTP(w, requestWithContentType(http.MethodPost, "/v1/runs", "application/json", body))
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("a body over the cap must fail cleanly as 400, got %d: %s", w.Code, w.Body)
 	}

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -892,7 +892,7 @@ func TestFingerprintOneIgnoresNonTerminalRuns(t *testing.T) {
 	post(t, h, `{"project":"p","git_commit":"abc","config_hash":"cfg","seed":1,"status":"running","metrics":{"loss":99.0}}`)
 
 	w = httptest.NewRecorder()
-	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/fingerprints/"+fp, nil))
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v1/fingerprints/"+fp, nil))
 	if w.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d: %s", w.Code, w.Body)
 	}
@@ -917,7 +917,7 @@ func TestFingerprintOneIgnoresNonTerminalRuns(t *testing.T) {
 	// Also confirm it via the collection endpoint: min_runs=1 would surface
 	// a no_repeats group for the finished run, but must not report Count=2.
 	w = httptest.NewRecorder()
-	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/fingerprints?project=p&min_runs=1", nil))
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v1/fingerprints?project=p&min_runs=1", nil))
 	if w.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d: %s", w.Code, w.Body)
 	}
@@ -948,7 +948,7 @@ func TestFingerprintOneAllNonTerminalIs404(t *testing.T) {
 	fp := run["fingerprint"].(string)
 
 	w = httptest.NewRecorder()
-	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/fingerprints/"+fp, nil))
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v1/fingerprints/"+fp, nil))
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("want 404 for a fingerprint with no finished run, got %d: %s", w.Code, w.Body)
 	}

--- a/python/README.md
+++ b/python/README.md
@@ -192,10 +192,10 @@ or fingerprint.
 
 It might look natural for `Run.start()` to record the run as `running`
 immediately, then update it to `succeeded`/`failed` at the end. The API
-supports that — `PATCH /runs/{id}` exists, and `rlctl start` / `rlctl finish`
+supports that — `PATCH /v1/runs/{id}` exists, and `rlctl start` / `rlctl finish`
 use it. This client deliberately does not.
 
-The obstacle is on the read side, not the write side. `/fingerprints` groups
+The obstacle is on the read side, not the write side. `/v1/fingerprints` groups
 every run sharing a fingerprint without filtering on status, so a `running`
 record would count as a *repeat measurement* of that experiment and its
 mid-training metric would join the group's min/max/mean/stddev. A loss

--- a/python/runledger/_run.py
+++ b/python/runledger/_run.py
@@ -2,12 +2,12 @@
 
 Design note -- why this makes exactly one HTTP call, at the end
 -----------------------------------------------------------------
-``PATCH /runs/{id}`` exists, so the mechanical obstacle to a "record
+``PATCH /v1/runs/{id}`` exists, so the mechanical obstacle to a "record
 running, then update to succeeded/failed" pair is gone -- ``rlctl start``
 and ``rlctl finish`` do exactly that. This client still does not, on
 purpose, and the reason is analytical rather than mechanical: nothing on
 the read side yet distinguishes a finished run from an in-flight one.
-``/fingerprints`` lists every run sharing a fingerprint without filtering on
+``/v1/fingerprints`` lists every run sharing a fingerprint without filtering on
 status, so a ``running`` record carrying a mid-training metric would be
 counted as a *repeat measurement* of that experiment. Its half-finished loss
 would widen the group's spread and could rank the fingerprint top of "which
@@ -52,6 +52,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, Iterator, Optional
 
 from . import _git, _provenance
+from .read import API_VERSION
 
 DEFAULT_SERVER = "http://localhost:8080"
 DEFAULT_TIMEOUT = 10.0
@@ -250,7 +251,7 @@ class Run:
     def _send(self, payload: Dict[str, Any]) -> None:
         body = json.dumps(payload).encode("utf-8")
         req = urllib.request.Request(
-            self.server.rstrip("/") + "/runs",
+            self.server.rstrip("/") + API_VERSION + "/runs",
             data=body,
             method="POST",
             headers={"Content-Type": "application/json"},

--- a/python/runledger/read.py
+++ b/python/runledger/read.py
@@ -31,6 +31,11 @@ from typing import Any, Dict, List, Optional
 DEFAULT_SERVER = "http://localhost:8080"
 DEFAULT_TIMEOUT = 10.0
 
+# Every resource route on the server is versioned under this path segment --
+# see ADR 0009 in the repo. health/ready/metrics are the only unversioned
+# routes, and nothing in this module calls them.
+API_VERSION = "/v1"
+
 # The server caps a page at 500 whatever a client asks for, and echoes the
 # limit it actually applied. Asking for the cap means the fewest round trips
 # for a walk; the pagination loop below follows next_cursor regardless, so
@@ -51,9 +56,19 @@ class RunNotFoundError(LedgerError):
 
 
 def _base(server: Optional[str]) -> str:
+    """The ledger's bare address, with no API version segment -- what a
+    person reads in an error message, and what they'd type into a browser
+    or curl. Kept separate from the URL a request is actually sent to
+    (_url, below) so "the ledger at http://host:port answered/could not be
+    reached" doesn't read as if /v1 were part of the server's address.
+    """
     if server:
         return server.rstrip("/")
     return os.environ.get("RUNLEDGER_ADDR", DEFAULT_SERVER).rstrip("/")
+
+
+def _url(server: Optional[str], path: str) -> str:
+    return _base(server) + API_VERSION + path
 
 
 def _get(
@@ -71,7 +86,7 @@ def _get(
     intend.
     """
     query = {k: str(v) for k, v in (params or {}).items() if v not in (None, "")}
-    url = _base(server) + path
+    url = _url(server, path)
     if query:
         url += "?" + urllib.parse.urlencode(query)
 

--- a/python/runledger/replay.py
+++ b/python/runledger/replay.py
@@ -54,7 +54,7 @@ import warnings
 from typing import List, Optional
 
 from ._run import DEFAULT_SERVER, DEFAULT_SPOOL_PATH, DEFAULT_TIMEOUT
-from .read import LedgerUnreachableError, _error_detail
+from .read import API_VERSION, LedgerUnreachableError, _error_detail
 
 # Statuses the server will never reconsider on an unmodified retry: the
 # payload itself is what's wrong (400), or a run with this id already
@@ -94,7 +94,7 @@ def _rejected_path(spool_path: str) -> str:
 
 def _post(line: str, *, server: str, token: Optional[str], timeout: float) -> None:
     req = urllib.request.Request(
-        server.rstrip("/") + "/runs",
+        server.rstrip("/") + API_VERSION + "/runs",
         data=line.encode("utf-8"),
         method="POST",
         headers={"Content-Type": "application/json"},

--- a/python/tests/test_read.py
+++ b/python/tests/test_read.py
@@ -49,7 +49,7 @@ class _Handler(BaseHTTPRequestHandler):
             }
         )
 
-        if parsed.path == "/runs":
+        if parsed.path == "/v1/runs":
             # Three rows total, served two at a time, so a caller that does
             # not follow next_cursor visibly comes up short.
             cursor = query.get("cursor", "")
@@ -61,15 +61,15 @@ class _Handler(BaseHTTPRequestHandler):
                 self._json(200, {"runs": [_run_row(2)], "count": 1, "limit": 2})
             return
 
-        if parsed.path.startswith("/runs/"):
-            run_id = urllib.parse.unquote(parsed.path[len("/runs/"):])
+        if parsed.path.startswith("/v1/runs/"):
+            run_id = urllib.parse.unquote(parsed.path[len("/v1/runs/"):])
             if run_id == "missing":
                 self._json(404, {"error": "run not found"})
             else:
                 self._json(200, {"run_id": run_id, "project": "demo"})
             return
 
-        if parsed.path == "/fingerprints":
+        if parsed.path == "/v1/fingerprints":
             if query.get("project") == "empty":
                 # The server sends null, not [], when nothing qualifies.
                 self._json(200, {"groups": None, "count": 0})
@@ -78,8 +78,8 @@ class _Handler(BaseHTTPRequestHandler):
                                  "count": 1})
             return
 
-        if parsed.path.startswith("/fingerprints/"):
-            fp = parsed.path[len("/fingerprints/"):]
+        if parsed.path.startswith("/v1/fingerprints/"):
+            fp = parsed.path[len("/v1/fingerprints/"):]
             if fp == "missing":
                 self._json(404, {"error": 'no run recorded with fingerprint "missing"'})
             else:
@@ -167,7 +167,7 @@ class RunTests(unittest.TestCase):
     def test_run_id_is_url_escaped(self):
         with _FakeLedger() as led:
             runledger.run("a/b?c", server=led.addr)
-        self.assertEqual(led.requests[0]["path"], "/runs/a%2Fb%3Fc")
+        self.assertEqual(led.requests[0]["path"], "/v1/runs/a%2Fb%3Fc")
 
 
 class SpreadTests(unittest.TestCase):
@@ -186,7 +186,7 @@ class SpreadTests(unittest.TestCase):
             got = runledger.spread(fingerprint="fp9", server=led.addr)
         self.assertEqual(len(got), 1)
         self.assertTrue(got[0]["no_repeats"])
-        self.assertEqual(led.requests[0]["path"], "/fingerprints/fp9")
+        self.assertEqual(led.requests[0]["path"], "/v1/fingerprints/fp9")
 
     def test_unknown_fingerprint_raises(self):
         with _FakeLedger() as led:


### PR DESCRIPTION
Closes #32.

Implements both recommendations raised in the issue:

1. **URL path versioning.** Every resource route now lives under `/v1` (`/v1/runs`, `/v1/runs/{id}`, `/v1/fingerprints`, `/v1/fingerprints/{fingerprint}`, `/v1/comparisons`). `/healthz`, `/readyz`, and `/metrics` stay unversioned — they're fixed operational conventions a probe or a scrape config points at, not part of the ledger's resource model, so an API version bump shouldn't force touching them. See [ADR 0009](docs/adr/0009-url-path-versioning-for-the-http-api.md).
2. **`/compare` becomes a resource.** `GET /compare?a=&b=` is now `GET /v1/comparisons?a=&b=`, addressed by the (symmetric) pair of run ids being compared rather than nested under one of them — sits next to `/v1/runs` and `/v1/fingerprints`, and leaves room to grow into an N-way comparison later. See [ADR 0010](docs/adr/0010-comparisons-is-a-resource-not-a-verb.md).

There's no tagged release and nothing external depends on the old route shapes, so this lands as a clean breaking change rather than needing to serve both shapes at once — the point of adopting `/v1` now is that the *next* breaking change has somewhere to go.

## What changed

- `internal/api/api.go`: `apiVersion = "/v1"` const, routes table and `Location` header updated.
- `docs/openapi.yaml`: paths renamed to match; `TestRoutesMatchSpec` keeps code and spec honest.
- `cmd/rlctl/main.go`: `call()` now takes `(method, server, path, ...)` and splices `apiVersion` in one place, instead of each of the 7 call sites doing it by hand.
- Python client (`python/runledger/`): `read.py` defines `API_VERSION = "/v1"` once; `_run.py` and `replay.py` import it rather than each hardcoding their own copy. `_base()` now returns the bare server address (for error messages) separately from `_url()` (which builds the versioned request URL) — so a `LedgerUnreachableError` reports the address a person would actually curl, not one with `/v1` tacked on.
- `internal/api/api_test.go`, `python/tests/test_read.py`: updated to the new paths.
- `README.md`, `python/README.md`, `docs/adr/README.md`: updated route references, plus two new "Decisions worth knowing" entries.
- Two new ADRs (0009, 0010).

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test ./...` — all pass, including `TestRoutesMatchSpec`/`TestSchemasMatchGoTypes`.
- [x] `python3 -m unittest discover -s tests` (60 tests) — all pass.
- [x] Manual end-to-end: built `runledger`/`rlctl`, recorded runs, ran `rlctl diff`/`rlctl spread` against a live server on the new `/v1` routes; confirmed the old `/compare` now 404s; confirmed the Python client's `runs()`/`spread()` work against `/v1` and that an unreachable-server error message reports the bare address, not one with `/v1` appended.
- [x] Ran `/code-review` (medium): found and fixed three issues before finalizing — duplicated `/v1` literals across the Python package (now share `read.py`'s `API_VERSION`), repeated `apiVersion` splicing at each `rlctl` call site (now centralized in `call()`), and a cosmetic bug where the Python client's unreachable-ledger error message included `/v1` as if it were part of the server's address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)