### PR TITLE
docs: fix the pandas example to json_normalize, not DataFrame

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -169,8 +169,15 @@ dependencies; if you want a frame, you have lost nothing:
 
 ```python
 import pandas as pd
-df = pd.DataFrame(runledger.runs(project="demo"))
+df = pd.json_normalize(runledger.runs(project="demo"))
+df[["run_id", "metrics.loss", "params.lr"]]
 ```
+
+`params` and `metrics` are nested objects on the wire (`Dict[str, str]` and
+`Dict[str, float]`), so plain `pd.DataFrame(...)` leaves them as columns of
+dicts rather than usable columns. `json_normalize` flattens them to
+`metrics.loss`, `params.lr`, and so on — the same dotted names the
+`/v1/comparisons` endpoint already reports fields under.
 
 ### Reads raise; writes don't
 

--- a/python/runledger/read.py
+++ b/python/runledger/read.py
@@ -14,9 +14,12 @@ Design note -- why plain dicts, and no pandas
 ---------------------------------------------
 These return lists of dicts, exactly as the wire delivers them. The package
 has no dependencies and that is worth keeping: a caller who wants a frame
-writes ``pd.DataFrame(runledger.runs(project="demo"))`` and has lost
-nothing, while a caller inside a training container that has no pandas has
-not gained a mandatory install.
+writes ``pd.json_normalize(runledger.runs(project="demo"))`` and has lost
+nothing -- ``params`` and ``metrics`` are nested objects on the wire, so
+plain ``pd.DataFrame`` would leave them as columns of dicts rather than the
+``metrics.loss`` / ``params.lr`` columns most callers actually want -- while
+a caller inside a training container that has no pandas has not gained a
+mandatory install.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- `params` and `metrics` are nested objects on the wire (`Dict[str, str]` / `Dict[str, float]`), so `pd.DataFrame(runledger.runs(...))` leaves them as columns of dicts, not usable columns.
- Fixes the example in `read.py`'s module docstring and `python/README.md`'s read-side section to use `pd.json_normalize(...)`, which flattens to `metrics.loss` / `params.lr` — the same dotted field names `/v1/comparisons` already reports under.
- Left the zero-dependency reasoning as-is, per the issue: this is a documentation fix, not a dependency change.
- Root README has no pandas example, so nothing to change there.

Fixes #54

## Test plan
- [x] `python3 -m unittest discover -s python/tests -v` — 60 passed