### PR TITLE
dashboard: a local marimo app to browse spread(), a group, and compare()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test vet fmt lint cover clean run image docs notebook
+.PHONY: build test vet fmt lint cover clean run image docs notebook dashboard
 
 IMAGE ?= run-ledger
 TAG ?= dev
@@ -69,6 +69,18 @@ notebook: build
 	@# nbconvert has no dark theme or toggle of its own; this adds the same
 	@# light/dark switch docs/index.html and the pdoc output already have.
 	python3 scripts/apply_theme_toggle.py docs/reproducibility.html
+
+
+# Runs the local dashboard (dashboard/README.md) against a ledger you have
+# already started -- `make build && ./bin/runledger &`, same as the
+# notebook. Not something CI runs or the Pages deploy builds: see
+# dashboard/README.md for why this stays a local-only tool.
+#
+# Needs the dashboard's own dependencies: pip install -e ./python -e ./dashboard
+dashboard:
+	@command -v marimo >/dev/null 2>&1 || \
+		{ echo "marimo not found: pip install -e ./python -e ./dashboard"; exit 1; }
+	marimo run dashboard/app.py
 
 clean:
 	rm -rf bin coverage.out docs/reproducibility.html docs/python

--- a/README.md
+++ b/README.md
@@ -119,8 +119,9 @@ internal/store/    Store interface + in-memory reference and DuckDB backends
 internal/compare/  structured diff, identity vs provenance vs metric
 internal/spread/   per-fingerprint metric spread across repeated runs
 internal/api/      HTTP handlers
-python/runledger/  Python client: `Run.start()` to record, runs()/spread() to read back
+python/runledger/  Python client: `Run.start()` to record, runs()/spread()/compare() to read back
 python/examples/   the worked reproducibility notebook
+dashboard/         local marimo app: browse spread(), drill into a group, compare() two runs
 scripts/           docs build helpers used by `make docs`
 ```
 
@@ -240,6 +241,12 @@ HTTP call, at the end, rather than one at each end of the run
 ```bash
 pip install -e ./python
 ```
+
+To browse instead of scripting — a ranked list of which experiments
+reproduce worst, a group's runs and provenance disagreements, and a
+`compare()` verdict between two of them — see [`dashboard/README.md`](dashboard/README.md).
+It is a local-only marimo app built on this same client, not a hosted
+service.
 
 ## Auth
 

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -1,0 +1,76 @@
+# runledger dashboard
+
+A local, read-only browser over the ledger, built on the [Python
+client](../python/README.md): a project picker feeding the `spread()`
+ranking (worst-reproducing first), a group's runs and provenance
+disagreements, and a `compare()` verdict between two of them.
+
+It is strictly a *consumer* of `runledger` -- no new API surface. If a view
+here needs something the client cannot express, that is a gap in the
+client, not something to work around with a hand-rolled HTTP call.
+
+## Why this is a separate package
+
+`python/` promises "standard library only" and means it -- a training
+container should never need to install a dashboard's dependencies to record
+a run. This is the first thing in the repo that carries a real dependency
+tree (marimo), so it lives in its own directory with its own
+`pyproject.toml` rather than becoming an optional extra on the client.
+
+## Why marimo, not Streamlit or Jupyter
+
+See [issue #55](https://github.com/kornsour/run-ledger/issues/55) for the
+full reasoning. In short: the app is a plain `.py` file with no hidden
+execution-order state (marimo re-runs cells by dependency, not by click
+order), so `git diff` on it is a code diff, not a notebook-output diff --
+the same problem `python/tests/test_notebook.py` already enforces for the
+worked notebook, solved structurally instead of by a test here.
+
+## Run it
+
+```bash
+make build && ./bin/runledger &          # from the repo root -- the ledger
+pip install -e ./python                  # the client, editable
+pip install -e ./dashboard               # the dashboard's own dependency (marimo)
+make dashboard                           # from the repo root
+```
+
+Or directly:
+
+```bash
+marimo run dashboard/app.py              # read-only view
+marimo edit dashboard/app.py             # to change it
+```
+
+Point it at a different ledger with the "Ledger server" field in the app,
+or by setting `RUNLEDGER_ADDR` before launching.
+
+## Why this only runs locally
+
+The server sets no `Access-Control-Allow-*` headers anywhere (checked
+across `internal/`, `cmd/`, and `docs/openapi.yaml`), so a page served from
+somewhere other than the ledger's own origin cannot `fetch` it -- including
+`marimo export html-wasm` published to a static site making a Pyodide
+`fetch` back to a reader's `localhost`, which is blocked by both CORS and
+mixed content. Publishing a live version of this dashboard is a separate
+decision that starts with "should the server grow a configurable CORS
+allowlist?", not an export flag here.
+
+## Layout
+
+- `app.py` -- the marimo app: thin cells that wire UI elements to
+  `runledger_dashboard`.
+- `runledger_dashboard/` -- the data layer the cells call into
+  (`list_projects`, `ranked_groups`, `group_runs`, `pair_diff`,
+  `widest_spread`). Split out so it is testable with plain `pytest` /
+  `unittest`, without a marimo runtime.
+- `tests/` -- exercises `runledger_dashboard` against an in-process fake
+  ledger, the same approach `python/tests/test_read.py` uses for the
+  client itself.
+
+## Test
+
+```bash
+pip install -e ./python -e './dashboard[dev]'
+python3 -m unittest discover -s dashboard/tests -v
+```

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -1,0 +1,202 @@
+import marimo
+
+__generated_with = "0.24.0"
+app = marimo.App(width="medium", app_title="run-ledger dashboard")
+
+
+@app.cell(hide_code=True)
+def _():
+    import marimo as mo
+
+    mo.md(
+        """
+        # run-ledger dashboard
+
+        A local, read-only browser over `runledger` -- **which of my
+        experiments reproduce worst?**, drilled down into a group's runs and
+        a pairwise diff. Nothing here talks to the ledger except through the
+        Python client; if a view needs something `runledger` cannot express,
+        that is a gap in the client, not something to work around here.
+
+        Run with `marimo run app.py` for the read-only view, or
+        `marimo edit app.py` to poke at it.
+        """
+    )
+    return (mo,)
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    import os
+
+    server_input = mo.ui.text(
+        value=os.environ.get("RUNLEDGER_ADDR", "http://localhost:8080"),
+        label="Ledger server",
+        full_width=True,
+    )
+    server_input
+    return (server_input,)
+
+
+@app.cell(hide_code=True)
+def _(mo, server_input):
+    from runledger import LedgerError as _LedgerError
+
+    from runledger_dashboard import list_projects
+
+    # Both the project list and the ranked groups below fail the same way,
+    # by design (runledger.read raises rather than degrading) -- one banner
+    # here stands in for both rather than duplicating the try/except.
+    ledger_error = None
+    projects = []
+    try:
+        projects = list_projects(server=server_input.value)
+    except _LedgerError as exc:
+        ledger_error = exc
+
+    if ledger_error is not None:
+        mo.stop(
+            True,
+            mo.md(f"**Could not reach the ledger at `{server_input.value}`:** {ledger_error}").callout(
+                kind="danger"
+            ),
+        )
+
+    project_picker = mo.ui.dropdown(
+        options=["(all projects)"] + projects,
+        value="(all projects)",
+        label="Project",
+    )
+    project_picker
+    return (project_picker,)
+
+
+@app.cell(hide_code=True)
+def _(mo, project_picker, server_input):
+    from runledger_dashboard import ranked_groups, widest_spread
+
+    selected_project = "" if project_picker.value == "(all projects)" else project_picker.value
+    groups = ranked_groups(project=selected_project, server=server_input.value)
+
+    def _row(g):
+        worst = widest_spread(g)
+        return {
+            "fingerprint": g["fingerprint"][:16] + "...",
+            "runs": g["count"],
+            "widest metric": worst["metric"] if worst else "-",
+            "relative spread": f"{worst['cv']:.1%}" if worst else "-",
+            "provenance disagreements": ", ".join(d["field"] for d in g.get("provenance") or []) or "-",
+        }
+
+    groups_table = mo.ui.table(
+        [_row(g) for g in groups],
+        selection="single",
+        label="Fingerprint groups, worst-reproducing first",
+        page_size=15,
+    )
+
+    mo.vstack(
+        [
+            mo.md(f"**{len(groups)}** group(s) with repeats" + (f" in `{selected_project}`" if selected_project else " across every project")),
+            groups_table,
+        ]
+    )
+    return groups, groups_table
+
+
+@app.cell(hide_code=True)
+def _(groups, groups_table, mo, server_input):
+    from runledger_dashboard import group_runs
+
+    if not groups_table.value:
+        mo.stop(True, mo.md("_Select a group above to see its runs._"))
+
+    selected_index = groups_table.value[0]
+    # marimo's table selection returns the selected row dicts, not their
+    # index into the source list, so the source group is recovered by
+    # matching on the one column both the table row and the group carry:
+    # the full fingerprint's own prefix.
+    selected_group = next(
+        g for g in groups if g["fingerprint"][:16] + "..." == selected_index["fingerprint"]
+    )
+
+    runs = group_runs(selected_group, server=server_input.value)
+
+    provenance = selected_group.get("provenance") or []
+    provenance_md = (
+        "\n".join(f"- **{d['field']}**: {', '.join(d['values'])}" for d in provenance)
+        if provenance
+        else "_This group's runs agree on every recorded provenance field._"
+    )
+
+    mo.vstack(
+        [
+            mo.md(f"## Group `{selected_group['fingerprint'][:16]}...`"),
+            mo.md("**Provenance disagreements** -- usually the first place to look:"),
+            mo.md(provenance_md),
+            mo.md("**Runs in this group:**"),
+            mo.ui.table(
+                [
+                    {
+                        "run_id": r["run_id"],
+                        "status": r.get("status"),
+                        **{f"metrics.{k}": v for k, v in (r.get("metrics") or {}).items()},
+                    }
+                    for r in runs
+                ],
+                selection=None,
+            ),
+        ]
+    )
+    return runs, selected_group
+
+
+@app.cell(hide_code=True)
+def _(mo, runs):
+    if len(runs) < 2:
+        mo.stop(True, mo.md("_Need at least two runs in this group to compare._"))
+
+    run_options = {r["run_id"]: r for r in runs}
+    a_picker = mo.ui.dropdown(options=list(run_options), value=runs[0]["run_id"], label="Run A")
+    b_picker = mo.ui.dropdown(options=list(run_options), value=runs[1]["run_id"], label="Run B")
+    mo.md("## Compare two runs")
+    mo.hstack([a_picker, b_picker])
+    return a_picker, b_picker
+
+
+@app.cell(hide_code=True)
+def _(a_picker, b_picker, mo, server_input):
+    from runledger import LedgerError as _LedgerError
+
+    from runledger_dashboard import pair_diff
+
+    if a_picker.value == b_picker.value:
+        mo.stop(True, mo.md("_Pick two different runs._"))
+
+    try:
+        diff = pair_diff(a_picker.value, b_picker.value, server=server_input.value)
+    except _LedgerError as exc:
+        mo.stop(True, mo.md(f"**Comparison failed:** {exc}").callout(kind="danger"))
+
+    verdict = (
+        "Same experiment, but it measured differently -- **unattributable**: nothing in the record explains the gap."
+        if diff["unattributable"]
+        else ("Same experiment, same result." if diff["same_experiment"] else "Different experiments -- differing metrics are expected.")
+    )
+
+    mo.vstack(
+        [
+            mo.md(verdict),
+            mo.ui.table(
+                [{"field": f["name"], "kind": f["kind"], "a": f["a"], "b": f["b"]} for f in diff["fields"]],
+                selection=None,
+            )
+            if diff["fields"]
+            else mo.md("_No fields differ between these two runs._"),
+        ]
+    )
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/dashboard/pyproject.toml
+++ b/dashboard/pyproject.toml
@@ -1,0 +1,26 @@
+[project]
+name = "runledger-dashboard"
+version = "0.1.0"
+description = "A local, read-only browser over runledger: worst-reproducing experiments, a group's runs and provenance disagreements, and a pairwise diff -- no new API surface."
+readme = "README.md"
+requires-python = ">=3.9"
+license = { text = "MIT" }
+# marimo is the dashboard's only third-party dependency. runledger itself is
+# not listed here -- it is not published, so pip would have nothing to
+# resolve it against. Install both explicitly; see this package's README.
+dependencies = [
+    "marimo>=0.9",
+]
+
+[project.optional-dependencies]
+dev = ["pytest>=7"]
+
+[project.urls]
+Homepage = "https://github.com/kornsour/run-ledger"
+
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+include = ["runledger_dashboard*"]

--- a/dashboard/runledger_dashboard/__init__.py
+++ b/dashboard/runledger_dashboard/__init__.py
@@ -1,0 +1,22 @@
+"""runledger_dashboard -- data layer for the marimo browse-and-drill-down app.
+
+Split out from app.py so it can be tested with plain pytest, without a
+marimo runtime: marimo cells are still just functions, but exercising them
+means either driving the whole notebook or reaching into internals that are
+not the module's public contract. The functions here are.
+
+Everything in this package is a thin, read-only consumer of ``runledger``
+(see the repo root README's `python/` client) -- no new API surface. If a
+view here needs something the client cannot express, that is a gap in
+``runledger``, not something to work around with a hand-rolled HTTP call.
+"""
+
+from ._data import group_runs, list_projects, pair_diff, ranked_groups, widest_spread
+
+__all__ = [
+    "list_projects",
+    "ranked_groups",
+    "widest_spread",
+    "group_runs",
+    "pair_diff",
+]

--- a/dashboard/runledger_dashboard/_data.py
+++ b/dashboard/runledger_dashboard/_data.py
@@ -1,0 +1,124 @@
+"""Read-only queries the dashboard's cells wire up to marimo UI elements.
+
+Design note -- raise, don't degrade
+------------------------------------
+Same convention as ``runledger.read``: a function here raises
+``runledger.LedgerError`` (unreachable ledger, or an id that matches
+nothing) rather than swallowing it. The dashboard is what decides how to
+show that to a person -- an error banner instead of a crash -- but the data
+layer is not the place to paper over "the ledger did not answer."
+
+Design note -- no project-listing endpoint
+-------------------------------------------
+The API has no ``GET /v1/projects``, and adding one would be exactly the
+kind of new API surface this app is not supposed to need (see the package
+docstring). ``list_projects`` answers it with the client it already has:
+every distinct ``project`` seen in a bounded scan of ``runs()``. Bounded
+because an unfiltered walk of a large ledger is the expensive kind of
+"list projects" -- ``scan_limit`` trades completeness on a ledger with more
+runs than that for a picker that opens promptly; pass a larger one, or
+``None`` to walk the whole thing, if that trade is wrong for your ledger.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+import runledger
+
+DEFAULT_SCAN_LIMIT = 5000
+
+
+def list_projects(
+    *,
+    server: Optional[str] = None,
+    timeout: float = runledger.read.DEFAULT_TIMEOUT,
+    scan_limit: Optional[int] = DEFAULT_SCAN_LIMIT,
+) -> List[str]:
+    """Distinct project names, sorted, from a bounded scan of ``runs()``.
+
+    :raises runledger.LedgerUnreachableError: if the ledger cannot be reached.
+    """
+    rows = runledger.runs(limit=scan_limit, server=server, timeout=timeout)
+    return sorted({r["project"] for r in rows if r.get("project")})
+
+
+def ranked_groups(
+    *,
+    project: str = "",
+    server: Optional[str] = None,
+    timeout: float = runledger.read.DEFAULT_TIMEOUT,
+) -> List[Dict[str, Any]]:
+    """Fingerprint groups with repeats, worst relative spread first.
+
+    A thin pass-through to ``runledger.spread()`` -- the server already does
+    the ranking. ``project=""`` (the default) ranks across every project,
+    the same as the client itself.
+
+    :raises runledger.LedgerUnreachableError: if the ledger cannot be reached.
+    """
+    return runledger.spread(project=project, server=server, timeout=timeout)
+
+
+def widest_spread(group: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """The one metric responsible for a group's ranking, for display.
+
+    Mirrors the server's own ranking key (widest coefficient of variation,
+    |stddev / mean|, skipping a zero mean or a metric only one run
+    reported) -- see ``internal/spread.Group.Widest`` -- but the *value*
+    of that computation is not on the wire, only its effect on ordering.
+    Recomputing it here is what lets a group's row in the table say which
+    metric, and by how much, rather than just where it landed.
+
+    Returns ``None`` for a group with nothing measurable (``no_repeats``,
+    or no metric with a nonzero mean across more than one run).
+    """
+    best: Optional[Dict[str, Any]] = None
+    best_cv = -1.0
+    for name, stat in (group.get("metrics") or {}).items():
+        if stat.get("count", 0) < 2 or stat.get("mean") == 0:
+            continue
+        cv = abs(stat["stddev"] / stat["mean"])
+        if cv > best_cv:
+            best_cv, best = cv, {"metric": name, "cv": cv, **stat}
+    return best
+
+
+def group_runs(
+    group: Dict[str, Any],
+    *,
+    server: Optional[str] = None,
+    timeout: float = runledger.read.DEFAULT_TIMEOUT,
+) -> List[Dict[str, Any]]:
+    """The full run record for each of a group's ``run_ids``.
+
+    ``spread()`` reports the group's aggregate metrics and where its runs'
+    provenance disagrees, but not each run's own metrics -- that needs one
+    ``run()`` per id. A group is a handful of repeats, not a page of
+    results, so one call each is the whole cost of a drill-down here.
+
+    :raises runledger.RunNotFoundError: if a run named in the group was
+        deleted from the ledger after the group was fetched.
+    :raises runledger.LedgerUnreachableError: if the ledger cannot be reached.
+    """
+    return [
+        runledger.run(run_id, server=server, timeout=timeout)
+        for run_id in group.get("run_ids") or []
+    ]
+
+
+def pair_diff(
+    a: Any,
+    b: Any,
+    *,
+    server: Optional[str] = None,
+    timeout: float = runledger.read.DEFAULT_TIMEOUT,
+) -> Dict[str, Any]:
+    """What differs between two runs -- a thin pass-through to
+    ``runledger.compare()``, kept here only so every ledger call the
+    dashboard makes goes through this module and not app.py directly.
+
+    :raises runledger.RunNotFoundError: if ``a`` or ``b`` matches no run.
+    :raises runledger.LedgerUnreachableError: if the ledger cannot be reached.
+    """
+    return runledger.compare(a, b, server=server, timeout=timeout)

--- a/dashboard/tests/test_data.py
+++ b/dashboard/tests/test_data.py
@@ -1,0 +1,255 @@
+"""Tests for the dashboard's data layer -- no marimo runtime involved.
+
+Same fake-HTTP-server approach as python/tests/test_read.py: a tiny
+in-process stand-in for the ledger, not a live process or a mock of
+runledger itself, so these exercise the real request/response path.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import threading
+import unittest
+import urllib.parse
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+_HERE = os.path.dirname(__file__)
+# Neither runledger nor runledger_dashboard is installed in every dev
+# environment that runs these tests -- mirror python/tests' own raw
+# sys.path insertion rather than requiring `pip install -e` first.
+sys.path.insert(0, os.path.join(_HERE, "..", "..", "python"))
+sys.path.insert(0, os.path.join(_HERE, ".."))
+
+import runledger  # noqa: E402
+from runledger_dashboard import (  # noqa: E402
+    group_runs,
+    list_projects,
+    pair_diff,
+    ranked_groups,
+    widest_spread,
+)
+
+
+def _run_row(run_id, project="demo", **extra):
+    row = {"run_id": run_id, "project": project}
+    row.update(extra)
+    return row
+
+
+class _Handler(BaseHTTPRequestHandler):
+    def log_message(self, *args):
+        pass
+
+    def _json(self, code, body):
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps(body).encode("utf-8"))
+
+    def do_GET(self):
+        parsed = urllib.parse.urlparse(self.path)
+        query = dict(urllib.parse.parse_qsl(parsed.query))
+        self.server.requests.append({"path": parsed.path, "query": query})
+
+        if parsed.path == "/v1/runs":
+            self._json(
+                200,
+                {
+                    "runs": [
+                        _run_row("run-a", project="demo", fingerprint="fp1"),
+                        _run_row("run-b", project="demo", fingerprint="fp1"),
+                        _run_row("run-c", project="other", fingerprint="fp2"),
+                    ],
+                    "count": 3,
+                    "limit": 5000,
+                },
+            )
+            return
+
+        if parsed.path.startswith("/v1/runs/"):
+            run_id = urllib.parse.unquote(parsed.path[len("/v1/runs/") :])
+            if run_id == "missing":
+                self._json(404, {"error": "run not found"})
+            else:
+                self._json(200, _run_row(run_id, metrics={"loss": 0.5}))
+            return
+
+        if parsed.path == "/v1/fingerprints":
+            self._json(
+                200,
+                {
+                    "groups": [
+                        {
+                            "fingerprint": "fp1",
+                            "run_ids": ["run-a", "run-b"],
+                            "count": 2,
+                            "no_repeats": False,
+                            "metrics": {
+                                "loss": {
+                                    "count": 2,
+                                    "min": 0.4,
+                                    "max": 0.6,
+                                    "mean": 0.5,
+                                    "stddev": 0.1,
+                                },
+                                # count == 1: not a candidate for widest_spread.
+                                "lonely": {
+                                    "count": 1,
+                                    "min": 1.0,
+                                    "max": 1.0,
+                                    "mean": 1.0,
+                                    "stddev": 0.0,
+                                },
+                                # mean == 0: would divide by zero, must be skipped.
+                                "zeroed": {
+                                    "count": 2,
+                                    "min": -1.0,
+                                    "max": 1.0,
+                                    "mean": 0.0,
+                                    "stddev": 1.0,
+                                },
+                            },
+                        }
+                    ],
+                    "count": 1,
+                },
+            )
+            return
+
+        if parsed.path == "/v1/comparisons":
+            a, b = query.get("a"), query.get("b")
+            self._json(
+                200,
+                {
+                    "a": a,
+                    "b": b,
+                    "same_experiment": True,
+                    "fields": [{"name": "metrics.loss", "kind": "metric", "a": "0.4", "b": "0.6"}],
+                    "unattributable": True,
+                },
+            )
+            return
+
+        self._json(500, {"error": "unexpected path"})
+
+
+class _FakeLedger:
+    def __enter__(self):
+        self.server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+        self.server.requests = []
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+        self.addr = f"http://127.0.0.1:{self.server.server_port}"
+        return self
+
+    def __exit__(self, *exc_info):
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=5)
+
+    @property
+    def requests(self):
+        return self.server.requests
+
+
+class ListProjectsTests(unittest.TestCase):
+    def test_returns_sorted_distinct_projects(self):
+        with _FakeLedger() as led:
+            got = list_projects(server=led.addr)
+        self.assertEqual(got, ["demo", "other"])
+
+    def test_scan_limit_is_forwarded(self):
+        with _FakeLedger() as led:
+            list_projects(server=led.addr, scan_limit=3)
+        self.assertEqual(led.requests[0]["query"]["limit"], "3")
+
+
+class RankedGroupsTests(unittest.TestCase):
+    def test_passes_through_the_spread_response(self):
+        with _FakeLedger() as led:
+            got = ranked_groups(server=led.addr)
+        self.assertEqual(got[0]["fingerprint"], "fp1")
+
+
+class WidestSpreadTests(unittest.TestCase):
+    def test_picks_the_highest_coefficient_of_variation(self):
+        group = {
+            "metrics": {
+                "loss": {"count": 2, "mean": 0.5, "stddev": 0.1},
+                "acc": {"count": 2, "mean": 10.0, "stddev": 5.0},
+            }
+        }
+        got = widest_spread(group)
+        self.assertEqual(got["metric"], "acc")
+
+    def test_skips_a_zero_mean_metric(self):
+        group = {"metrics": {"z": {"count": 2, "mean": 0.0, "stddev": 1.0}}}
+        self.assertIsNone(widest_spread(group))
+
+    def test_skips_a_metric_only_one_run_reported(self):
+        group = {"metrics": {"lonely": {"count": 1, "mean": 1.0, "stddev": 0.0}}}
+        self.assertIsNone(widest_spread(group))
+
+    def test_no_repeats_group_has_no_metrics_to_rank(self):
+        self.assertIsNone(widest_spread({"no_repeats": True}))
+
+    def test_real_group_from_the_fake_ledger_skips_lonely_and_zeroed(self):
+        with _FakeLedger() as led:
+            group = ranked_groups(server=led.addr)[0]
+        got = widest_spread(group)
+        self.assertEqual(got["metric"], "loss")
+
+
+class GroupRunsTests(unittest.TestCase):
+    def test_fetches_every_run_id_in_the_group(self):
+        with _FakeLedger() as led:
+            got = group_runs({"run_ids": ["run-a", "run-b"]}, server=led.addr)
+        self.assertEqual([r["run_id"] for r in got], ["run-a", "run-b"])
+
+    def test_empty_group_fetches_nothing(self):
+        with _FakeLedger() as led:
+            got = group_runs({"run_ids": []}, server=led.addr)
+        self.assertEqual(got, [])
+        self.assertEqual(led.requests, [])
+
+
+class PairDiffTests(unittest.TestCase):
+    def test_returns_the_comparison(self):
+        with _FakeLedger() as led:
+            got = pair_diff("run-a", "run-b", server=led.addr)
+        self.assertTrue(got["unattributable"])
+        self.assertEqual(got["fields"][0]["name"], "metrics.loss")
+
+    def test_accepts_run_dicts(self):
+        with _FakeLedger() as led:
+            pair_diff({"run_id": "run-a"}, {"run_id": "run-b"}, server=led.addr)
+        self.assertEqual(led.requests[0]["query"], {"a": "run-a", "b": "run-b"})
+
+
+class ErrorsPropagateTests(unittest.TestCase):
+    """Every function here must raise, matching runledger.read's own
+    convention -- the data layer is not where "the ledger did not answer"
+    gets papered over.
+    """
+
+    def test_unreachable_ledger_raises_from_every_function(self):
+        addr = "http://127.0.0.1:1"
+        with self.assertRaises(runledger.LedgerUnreachableError):
+            list_projects(server=addr, timeout=2.0)
+        with self.assertRaises(runledger.LedgerUnreachableError):
+            ranked_groups(server=addr, timeout=2.0)
+        with self.assertRaises(runledger.LedgerUnreachableError):
+            group_runs({"run_ids": ["x"]}, server=addr, timeout=2.0)
+        with self.assertRaises(runledger.LedgerUnreachableError):
+            pair_diff("a", "b", server=addr, timeout=2.0)
+
+    def test_unknown_run_raises_not_found(self):
+        with _FakeLedger() as led:
+            with self.assertRaises(runledger.RunNotFoundError):
+                group_runs({"run_ids": ["missing"]}, server=led.addr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Stacked on #59

This branches from `python/compare-binding` (not `main`) because the "two runs" view needs `runledger.compare()`, added there. This PR's diff is dashboard-only; #59's changes will disappear from it once #59 merges and this branch is rebased onto `main`.

## Summary
- Adds `dashboard/`: a local, read-only marimo app over `runledger` -- no new API surface, strictly a consumer of the client (per the issue: if a view needs something the client can't express, that's a gap in `runledger`, not something to hand-roll around here).
- **Project picker** -> `spread()`'s ranked list (worst-reproducing first). Project options come from a bounded scan of `runs()` -- there's no `GET /v1/projects`, and adding one would be exactly the API surface this app isn't supposed to need.
- **A group** -> its runs (fetched via `run()` per id) with their own metrics, plus the `provenance` fields the group disagrees on.
- **Two runs** -> `compare()`'s verdict, with a diff table.
- marimo over Streamlit/Gradio per the issue's reasoning: a plain `.py` file with no hidden execution-order state, which fits a project whose thesis is that hidden state is what makes results unattributable.
- Lives in its own `dashboard/` package with its own `pyproject.toml` (marimo is the first real dependency tree in this repo) -- `python/`'s zero-dependency promise stays literal. `runledger` isn't listed as a pyproject dependency since it isn't published; the README documents installing both editable.
- Data layer (`runledger_dashboard/_data.py`) is split from `app.py` so it's testable with plain `unittest`, no marimo runtime needed. `app.py` is thin cells wiring UI to that layer.
- `make dashboard` target, mirroring `make notebook`'s pattern. Explicitly local-only: the server sets no CORS headers anywhere, so a hosted export (`marimo export html-wasm`) can't reach a reader's `localhost` ledger -- see `dashboard/README.md` for the reasoning, matching the issue's "worth settling" notes.
- Does **not** migrate `reproducibility.ipynb` to marimo -- out of scope per the issue, left as a possible future follow-up.

## Test plan
- [x] `python3 -m unittest discover -s dashboard/tests -v` -- 14 passed, against an in-process fake ledger (same approach as `python/tests/test_read.py`)
- [x] `python3 -m unittest discover -s python/tests -v` -- 65 passed (unaffected)
- [x] `gofmt`/`go vet`/`go test ./...` clean (no Go changes)
- [x] Smoke-tested with `marimo run --headless` against a live `./bin/runledger`
- [x] Full manual click-through in a real browser against a seeded live ledger (2 projects, a 3-run group with a `device` provenance disagreement): project list renders, selecting a group shows its runs and the correct disagreement, the compare panel correctly shows `unattributable: true` with the right per-field diff (`device: cpu -> cuda`, `metrics.loss`, `metrics.acc`)

Fixes #55