### PR TITLE
Fix the rlctl diff verdict, and add an example with a real bug to find

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,12 @@ jobs:
           python-version: "3.12"
       - name: Test
         run: python3 -m unittest discover -s python/tests -v
+      # examples/churn is standard library only, so it needs no install step
+      # of its own -- including this repo's Python client. The scenario it
+      # backs is exercised by `make example`, not here; these are the unit
+      # tests for the capture detector.
+      - name: Test the example
+        run: python3 -m unittest discover -s examples/churn -v
 
   notebook:
     # The notebook is documentation that makes a claim -- same fingerprint,

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test vet fmt lint cover clean run image docs notebook dashboard
+.PHONY: build test vet fmt lint cover clean run image docs notebook dashboard example
 
 IMAGE ?= run-ledger
 TAG ?= dev
@@ -81,6 +81,23 @@ dashboard:
 	@command -v marimo >/dev/null 2>&1 || \
 		{ echo "marimo not found: pip install -e ./python -e ./dashboard"; exit 1; }
 	marimo run dashboard/app.py
+
+EXAMPLE_PORT ?= 8125
+
+# Runs examples/churn against a real, ephemeral ledger: a churn model with a
+# genuine unseeded-split bug, which the ledger finds from the record alone.
+# Standard library only, so unlike `notebook` and `dashboard` this needs no
+# pip install of any kind -- including this repo's own Python client.
+example: build
+	@./bin/runledger --addr :$(EXAMPLE_PORT) >/tmp/runledger-example.log 2>&1 & \
+		echo $$! > /tmp/runledger-example.pid; \
+		RUNLEDGER_ADDR=http://localhost:$(EXAMPLE_PORT) \
+			python3 examples/churn/scenario.py; \
+		status=$$?; \
+		kill $$(cat /tmp/runledger-example.pid) 2>/dev/null; \
+		rm -f /tmp/runledger-example.pid; \
+		exit $$status
+	python3 -m unittest discover -s examples/churn
 
 clean:
 	rm -rf bin coverage.out docs/reproducibility.html docs/python

--- a/cmd/rlctl/main.go
+++ b/cmd/rlctl/main.go
@@ -310,24 +310,50 @@ func cmdDiff(args []string) error {
 	if err := call(http.MethodGet, *server, "/comparisons?"+q.Encode(), nil, &out); err != nil {
 		return err
 	}
-	if len(out.Fields) == 0 {
-		fmt.Println("the two records are identical")
-		return nil
-	}
-	if out.SameExperiment {
-		fmt.Println("same experiment (fingerprints match)")
-	} else {
-		fmt.Println("different experiments (fingerprints differ)")
-	}
-	fmt.Printf("\n%-24s  %-12s  %-20s  %s\n", "FIELD", "KIND", "A", "B")
-	for _, f := range out.Fields {
-		fmt.Printf("%-24s  %-12s  %-20s  %s\n", f.Name, f.Kind, or(f.A, "—"), or(f.B, "—"))
-	}
-	if out.Unattributable {
-		fmt.Println("\nThese runs describe the same experiment but measured differently.")
-		fmt.Println("Something that affected the result is not captured in the record.")
-	}
+	renderDiff(os.Stdout, out)
 	return nil
+}
+
+// renderDiff writes a comparison's verdict and field table.
+//
+// The verdict is read from SameExperiment, never inferred from whether any
+// field rendered. The two can disagree, and did: params {} and
+// {"foo": ""} fingerprint differently, because lineage.Run.Compute hashes
+// only the keys that are present -- while compare.Runs reads both sides
+// through a map index that yields "" for a missing key, so it emits no
+// field at all. Keying the "identical" message off len(Fields) therefore
+// printed the exact opposite of what the server had just reported.
+//
+// Split out from cmdDiff, which can only be exercised against a live
+// server, so the verdict logic is directly testable.
+func renderDiff(w io.Writer, res compare.Result) {
+	if res.SameExperiment && len(res.Fields) == 0 {
+		fmt.Fprintln(w, "the two records are identical")
+		return
+	}
+	if res.SameExperiment {
+		fmt.Fprintln(w, "same experiment (fingerprints match)")
+	} else {
+		fmt.Fprintln(w, "different experiments (fingerprints differ)")
+	}
+	if len(res.Fields) == 0 {
+		// Differing fingerprints with nothing to show. Every other hashed
+		// field is compared as a string and would have rendered, so an
+		// absent-versus-empty param is what is left.
+		fmt.Fprintln(w, "\nNo field differs in this view. For fingerprints that differ, that")
+		fmt.Fprintln(w, "means a param is absent on one run and set to the empty string on")
+		fmt.Fprintln(w, "the other: those hash differently but render the same here. Run")
+		fmt.Fprintln(w, "`rlctl show` on each id to see which.")
+		return
+	}
+	fmt.Fprintf(w, "\n%-24s  %-12s  %-20s  %s\n", "FIELD", "KIND", "A", "B")
+	for _, f := range res.Fields {
+		fmt.Fprintf(w, "%-24s  %-12s  %-20s  %s\n", f.Name, f.Kind, or(f.A, "—"), or(f.B, "—"))
+	}
+	if res.Unattributable {
+		fmt.Fprintln(w, "\nThese runs describe the same experiment but measured differently.")
+		fmt.Fprintln(w, "Something that affected the result is not captured in the record.")
+	}
 }
 
 func cmdSpread(args []string) error {

--- a/cmd/rlctl/main_test.go
+++ b/cmd/rlctl/main_test.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/kornsour/run-ledger/internal/compare"
+)
+
+// The verdict a diff prints must come from SameExperiment, not from whether
+// any field happened to render. Those two disagree for a real input -- see
+// TestRenderDiffDifferentExperimentWithNoRenderedFields -- and the earlier
+// ordering reported the opposite of what the server said.
+func TestRenderDiffVerdictFollowsSameExperiment(t *testing.T) {
+	field := []compare.Field{{Name: "seed", Kind: compare.KindIdentity, A: "1", B: "2"}}
+
+	for _, tc := range []struct {
+		name   string
+		res    compare.Result
+		want   string
+		reject string
+	}{
+		{
+			name: "same experiment with differing fields",
+			res:  compare.Result{SameExperiment: true, Fields: field},
+			want: "same experiment (fingerprints match)",
+		},
+		{
+			name: "different experiments with differing fields",
+			res:  compare.Result{SameExperiment: false, Fields: field},
+			want: "different experiments (fingerprints differ)",
+		},
+		{
+			name: "same experiment, nothing differs",
+			res:  compare.Result{SameExperiment: true},
+			want: "the two records are identical",
+		},
+		{
+			name:   "different experiments, nothing renders",
+			res:    compare.Result{SameExperiment: false},
+			want:   "different experiments (fingerprints differ)",
+			reject: "identical",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			renderDiff(&buf, tc.res)
+			if got := buf.String(); !strings.Contains(got, tc.want) {
+				t.Errorf("want %q in output, got:\n%s", tc.want, got)
+			}
+			if tc.reject != "" && strings.Contains(buf.String(), tc.reject) {
+				t.Errorf("output must not claim %q:\n%s", tc.reject, buf.String())
+			}
+		})
+	}
+}
+
+// The regression, stated as the situation that produces it. Two runs whose
+// params are {} and {"foo": ""} hash differently -- Run.Compute writes only
+// the keys present -- while compare.Runs reads both sides as "" and emits
+// no field. The server answers same_experiment:false with fields:null, and
+// the CLI used to print "the two records are identical".
+func TestRenderDiffDifferentExperimentWithNoRenderedFields(t *testing.T) {
+	var buf bytes.Buffer
+	renderDiff(&buf, compare.Result{A: "run-a", B: "run-b", SameExperiment: false})
+	out := buf.String()
+
+	if strings.Contains(out, "identical") {
+		t.Fatalf("differing fingerprints reported as identical:\n%s", out)
+	}
+	if !strings.Contains(out, "different experiments (fingerprints differ)") {
+		t.Errorf("want the differing-fingerprint verdict, got:\n%s", out)
+	}
+	// The empty table would be useless on its own; the reader needs to know
+	// why a real difference has nothing to show.
+	if !strings.Contains(out, "empty string") {
+		t.Errorf("want an explanation of the absent-versus-empty param case, got:\n%s", out)
+	}
+	if strings.Contains(out, "FIELD") {
+		t.Errorf("no rows to show, so no table header should print:\n%s", out)
+	}
+}
+
+func TestRenderDiffUnattributableNoteOnlyWhenFlagged(t *testing.T) {
+	metric := []compare.Field{{Name: "metrics.loss", Kind: compare.KindMetric, A: "0.42", B: "0.51"}}
+	const note = "not captured in the record"
+
+	var flagged bytes.Buffer
+	renderDiff(&flagged, compare.Result{SameExperiment: true, Fields: metric, Unattributable: true})
+	if !strings.Contains(flagged.String(), note) {
+		t.Errorf("want the unattributable note, got:\n%s", flagged.String())
+	}
+
+	var plain bytes.Buffer
+	renderDiff(&plain, compare.Result{SameExperiment: false, Fields: metric})
+	if strings.Contains(plain.String(), note) {
+		t.Errorf("a recorded difference must not be called unattributable:\n%s", plain.String())
+	}
+}
+
+// An absent value renders as an em dash so it is not mistaken for a value
+// the run actually had.
+func TestRenderDiffMarksAbsentValues(t *testing.T) {
+	var buf bytes.Buffer
+	renderDiff(&buf, compare.Result{
+		SameExperiment: true,
+		Fields:         []compare.Field{{Name: "metrics.auc", Kind: compare.KindMetric, A: "0.94", B: ""}},
+	})
+	if !strings.Contains(buf.String(), "—") {
+		t.Errorf("want an em dash for the absent metric, got:\n%s", buf.String())
+	}
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,137 @@
+# examples
+
+A worked, dependency-free scenario that gives the ledger something true to
+find. Unlike `python/examples/reproducibility.ipynb`, which demonstrates the
+API against numbers chosen to illustrate it, this one trains an actual model
+containing an actual reproducibility bug and lets the ledger discover it.
+
+```bash
+make example
+```
+
+That builds the binaries, starts an ephemeral in-memory ledger on `:8125`,
+runs the scenario against it, and tears it down. Nothing is persisted and no
+port you use for real is touched. To run it against a ledger you already
+have up:
+
+```bash
+RUNLEDGER_ADDR=http://localhost:8080 python3 examples/churn/scenario.py
+```
+
+Standard library only — no `pip install` of any kind, including this repo's
+own Python client. The project's pitch is "one binary, no external
+dependencies to try it," and an example that needs a dependency install
+before it demonstrates anything would undercut that.
+
+## What it does
+
+`churn/train.py` is a logistic-regression churn model in ~150 lines of pure
+Python. It contains one real bug: `split_indices` draws the train/test
+partition from an unseeded RNG. The run's recorded `seed` covers weight
+initialization only, so the split is not in the record — not in `params`,
+not in `config_hash`, not anywhere.
+
+The scenario then walks the path a person actually walks:
+
+| | | |
+|---|---|---|
+| **A** | Repeat one experiment four times | AUC scatters across ~0.75–0.81 with a byte-identical identity record. `unattributable`. |
+| **B** | Go looking, find the split, put the seed in the config | `config_hash` changes, so the fingerprint changes. Spread collapses to **exactly** 0.00%. |
+| **C** | Change the learning rate for real | Different fingerprint, metrics move, no alarm. |
+| **D** | Record one run through a sloppier path | The capture report flags it without being told. |
+
+**A is the finding and B is the lesson.** The fix is not merely to seed the
+split — it is to make the seed part of the configuration, so it lands in
+`config_hash` and therefore in the fingerprint. An unrecorded knob cannot
+explain a difference; a recorded one can. That is the whole loop the ledger
+is built around, and B is what closes it.
+
+C matters as much as A: a tool that cried wolf on a legitimate hyperparameter
+change would be worse than no tool. The ledger stays silent because the
+change is *in* the record.
+
+Because the working tree is dirty while you read this, every run here passes
+an explicit `config_hash` — which is exactly what
+[ADR 0003](../docs/adr/0003-dirty-tree-without-config-hash-is-refused.md)
+requires, and not a workaround for it.
+
+## `churn/completeness.py` — flagging a likely client fault
+
+A separate question from "what changed": **is the record itself trustworthy?**
+
+A lineage record cannot distinguish "this run genuinely had no
+`dataset_version`" from "the client forgot to send one" — both arrive as the
+empty string, and intent is unrecoverable from one record.
+
+Across a *project*, it is recoverable statistically. The detector needs no
+schema change and no new field; it reads what `GET /v1/runs` already returns
+and compares a run against its peers:
+
+- **Odd-one-out** — the field is well covered by peers and empty here.
+  Points at a single bad launch: a hand-run notebook, a missing env var, a
+  stale script. Guarded by both a share floor (60%) and a peer-count floor
+  (3), so two runs agreeing is never treated as a convention.
+- **Blind spot** — the field is empty for *every* run in the project. Points
+  at the pipeline rather than the run. Reported quietly on its own, and
+  escalated only when a fingerprint group also shows spread the record
+  cannot explain — because an uncaptured field is then a candidate
+  explanation by construction.
+
+The two signals never double-report the same absence, which
+`test_completeness.py` pins.
+
+```
+LIKELY CLIENT FAULT -- a run is missing what its peers record
+  03b66aac0a75dfb9-dl1jzcqg41pc-d4a44ebd9f
+    dataset_version    identity   empty here, recorded by 12/13 runs
+    model_version      identity   empty here, recorded by 12/13 runs
+    host               provenance empty here, recorded by 12/13 runs
+    framework_version  provenance empty here, recorded by 12/13 runs
+```
+
+This is a heuristic and is labelled as one — "likely", never "is". It is a
+prior supplied by the peer group, not a fact recovered from the record.
+Making it a fact requires representing absence on the wire; see the note
+below.
+
+## Tests
+
+```bash
+python3 -m unittest discover examples/churn
+```
+
+Eleven tests, standard library only. They cover the cases the scenario
+cannot stage without contorting itself — a genuine blind spot, the
+evidence floors that keep the detector quiet, and the CV-over-raw-stddev
+ranking. The negative cases matter more than the positive one: a detector
+that fires on thin evidence would train people to ignore it.
+
+## What this example is evidence for
+
+Running it makes two gaps in the current data model concrete:
+
+1. **`""` and "not recorded" are the same value on the wire**, for
+   `config_hash`, `dataset_version`, `model_version`, `host`, `device`, and
+   `framework_version` — a known gap the struct comment in
+   [`internal/lineage/run.go`](../internal/lineage/run.go) already
+   acknowledges. For the three identity fields it is worse than cosmetic: a
+   run that genuinely had no dataset version and one whose client dropped it
+   produce the *same fingerprint*, so they are grouped as the same
+   experiment and their metric difference is reported as unattributable.
+   That is a false positive on the single claim this ledger makes.
+
+2. **The same conflation reaches the diff.** Two runs whose params are `{}`
+   and `{"foo": ""}` fingerprint differently — `Compute` writes only the
+   keys that are present — but `compare.Runs` renders both sides of
+   `params.foo` as `""`, so no field is emitted. `GET /v1/comparisons`
+   answers `same_experiment: false` with `fields: null`.
+
+   `rlctl diff` used to key its verdict off `len(Fields)` and printed **"the
+   two records are identical"** for that pair — the opposite of what the
+   server had just said. That half is fixed: the verdict now comes from
+   `SameExperiment`, and the no-rows case explains why a real difference has
+   nothing to show. The underlying conflation in `compare.Runs` remains, and
+   is the same gap as (1): a diff still cannot name which param it was.
+
+The detector in this folder is the best available answer while both hold.
+It is a workaround for (1), not a substitute for fixing it.

--- a/examples/churn/completeness.py
+++ b/examples/churn/completeness.py
@@ -1,0 +1,191 @@
+"""Is the *client* at fault? Flagging runs whose record is under-captured.
+
+The ledger's one claim is "same fingerprint + different metrics = something
+real is going unrecorded." It deliberately does not say what. But there is a
+cheap signal it can offer about *where to look first*, and it needs no
+schema change and no new field: compare a run against its peers.
+
+The reasoning
+-------------
+A lineage record has no way to distinguish "this run genuinely had no
+dataset version" from "the client forgot to send one" -- both arrive as the
+empty string. Intent is unrecoverable from a single record.
+
+Across a *project*, though, it is recoverable statistically. If 11 of 12
+runs in a project record `framework_version` and one does not, the odds that
+the twelfth run genuinely had no framework are poor. The peer group supplies
+the prior that the individual record lacks.
+
+Two signals fall out, and they mean different things:
+
+*   **Odd-one-out** -- the field is well covered by peers and missing here.
+    Points at a single bad launch: a script invoked without an env var, a
+    notebook run by hand, a job submitted from a stale branch.
+
+*   **Blind spot** -- the field is empty for *every* run in the project.
+    Points at the pipeline, not the run: this client never captures that
+    field at all. Harmless on its own, and damning when the group also shows
+    unattributable spread, because the blind spot is then a live candidate
+    for the thing going unrecorded.
+
+The blind-spot signal is escalated only for fingerprint groups whose metrics
+actually disagree. A project that never records `device` and reproduces
+perfectly has nothing wrong with it.
+"""
+
+from __future__ import annotations
+
+import statistics
+from typing import Any, Dict, List, Sequence
+
+# The six fields where "" and "not recorded" are indistinguishable on the
+# wire. Identity fields are marked because a missing one is strictly worse:
+# it silently changes what experiment the run is recorded as being.
+CAPTURABLE = [
+    ("config_hash", "identity"),
+    ("dataset_version", "identity"),
+    ("model_version", "identity"),
+    ("host", "provenance"),
+    ("device", "provenance"),
+    ("framework_version", "provenance"),
+]
+
+# A field must be present on at least this share of a project's runs, and on
+# at least MIN_PEERS of them, before its absence on one run is called odd.
+# Both guards matter: a share alone would flag 1-of-2 as a 50% outlier.
+ODD_ONE_OUT_SHARE = 0.6
+MIN_PEERS = 3
+
+
+def coverage(runs: Sequence[Dict[str, Any]]) -> Dict[str, float]:
+    """Share of runs recording a non-empty value, per capturable field."""
+    if not runs:
+        return {}
+    out = {}
+    for field, _kind in CAPTURABLE:
+        present = sum(1 for r in runs if str(r.get(field, "")).strip())
+        out[field] = present / len(runs)
+    return out
+
+
+def odd_ones_out(runs: Sequence[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Runs missing a field their peers overwhelmingly record."""
+    cov = coverage(runs)
+    findings = []
+    for run in runs:
+        missing = []
+        for field, kind in CAPTURABLE:
+            share = cov.get(field, 0.0)
+            peers = round(share * len(runs))
+            if share >= ODD_ONE_OUT_SHARE and peers >= MIN_PEERS:
+                if not str(run.get(field, "")).strip():
+                    missing.append(
+                        {
+                            "field": field,
+                            "kind": kind,
+                            "peers": peers,
+                            "total": len(runs),
+                        }
+                    )
+        if missing:
+            findings.append({"run_id": run["run_id"], "missing": missing})
+    return findings
+
+
+def blind_spots(runs: Sequence[Dict[str, Any]]) -> List[Dict[str, str]]:
+    """Fields no run in the project ever records."""
+    cov = coverage(runs)
+    return [
+        {"field": f, "kind": k} for f, k in CAPTURABLE if cov.get(f, 0.0) == 0.0
+    ]
+
+
+def unattributable_groups(runs: Sequence[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Fingerprint groups with repeats whose metrics disagree.
+
+    Mirrors what `GET /v1/fingerprints` ranks, computed here so the report
+    can join it against the capture findings in one pass.
+    """
+    by_fp: Dict[str, List[Dict[str, Any]]] = {}
+    for r in runs:
+        by_fp.setdefault(r["fingerprint"], []).append(r)
+    out = []
+    for fp, group in by_fp.items():
+        if len(group) < 2:
+            continue
+        widest, worst = 0.0, None
+        for key in {k for r in group for k in (r.get("metrics") or {})}:
+            vals = [r["metrics"][key] for r in group if key in (r.get("metrics") or {})]
+            if len(vals) < 2:
+                continue
+            mean = statistics.mean(vals)
+            if mean == 0:
+                continue
+            cv = abs(statistics.pstdev(vals) / mean)
+            if cv > widest:
+                widest, worst = cv, key
+        if worst is not None and widest > 0:
+            out.append(
+                {
+                    "fingerprint": fp,
+                    "count": len(group),
+                    "metric": worst,
+                    "cv": widest,
+                    "runs": group,
+                }
+            )
+    return sorted(out, key=lambda g: -g["cv"])
+
+
+def report(runs: Sequence[Dict[str, Any]]) -> str:
+    """Human-readable capture report for a project's runs."""
+    lines: List[str] = []
+    cov = coverage(runs)
+    lines.append(f"capture coverage across {len(runs)} runs")
+    for field, kind in CAPTURABLE:
+        share = cov.get(field, 0.0)
+        bar = "#" * round(share * 20)
+        lines.append(f"  {field:<18} {kind:<10} {share:6.0%} {bar}")
+
+    odd = odd_ones_out(runs)
+    lines.append("")
+    if odd:
+        lines.append("LIKELY CLIENT FAULT -- a run is missing what its peers record")
+        for f in odd:
+            lines.append(f"  {f['run_id']}")
+            for m in f["missing"]:
+                lines.append(
+                    f"    {m['field']:<18} {m['kind']:<10} empty here, "
+                    f"recorded by {m['peers']}/{m['total']} runs"
+                )
+        lines.append(
+            "  -> this record was probably produced by a different launch path\n"
+            "     (a hand-run notebook, a stale script, a missing env var),\n"
+            "     not by an experiment that genuinely had no such value."
+        )
+    else:
+        lines.append("no odd-one-out capture gaps")
+
+    spots = blind_spots(runs)
+    bad = unattributable_groups(runs)
+    lines.append("")
+    if spots and bad:
+        names = ", ".join(s["field"] for s in spots)
+        lines.append("BLIND SPOTS, AND THEY MATTER HERE")
+        lines.append(f"  never recorded by any run in this project: {names}")
+        lines.append(
+            f"  and {len(bad)} fingerprint group(s) show metric spread that the\n"
+            f"  record cannot explain -- widest {bad[0]['metric']} CV "
+            f"{bad[0]['cv']:.2%} over {bad[0]['count']} runs."
+        )
+        lines.append(
+            "  -> an unrecorded field is a candidate explanation by construction.\n"
+            "     Capture these before hunting for subtler causes."
+        )
+    elif spots:
+        names = ", ".join(s["field"] for s in spots)
+        lines.append(f"blind spots (never recorded): {names}")
+        lines.append("  -> no unexplained spread in this project, so nothing to chase.")
+    else:
+        lines.append("no blind spots: every capturable field is recorded somewhere")
+    return "\n".join(lines)

--- a/examples/churn/ledger.py
+++ b/examples/churn/ledger.py
@@ -1,0 +1,149 @@
+"""A minimal, standard-library ledger client for this example.
+
+`python/runledger` is the real client and is what training code should use.
+This example deliberately does not import it, for two reasons:
+
+1. It would need `pip install -e ./python` before the example demonstrated
+   anything, and the point of the example is to be runnable immediately.
+2. `Run.start()` captures device and framework provenance automatically.
+   This example needs to *withhold* some of that, on purpose, to show what
+   an under-captured record looks like -- see scenario D.
+
+So this is a thin POST wrapper, not a second implementation of anything.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+DEFAULT_SERVER = "http://localhost:8080"
+
+
+def server() -> str:
+    return os.environ.get("RUNLEDGER_ADDR", DEFAULT_SERVER).rstrip("/")
+
+
+def _git(*args: str) -> str:
+    try:
+        return subprocess.run(
+            ["git", *args], capture_output=True, text=True, check=True
+        ).stdout.strip()
+    except (OSError, subprocess.CalledProcessError):
+        return ""
+
+
+def git_commit() -> str:
+    return _git("rev-parse", "HEAD")
+
+
+def git_dirty() -> bool:
+    return bool(_git("status", "--porcelain"))
+
+
+def config_hash(config: Dict[str, Any]) -> str:
+    """Content hash of the run's configuration.
+
+    This is the fix for the bug the example demonstrates, and it is worth
+    being explicit about why: a knob that is not in this dict is not in the
+    fingerprint, and a knob that is not in the fingerprint cannot explain a
+    difference between two runs. "Put the knob in the config and hash the
+    config" is what turns an unrecorded variable into a recorded one.
+
+    Sorted keys, because two configs that differ only in key order are the
+    same config -- the same reason lineage.Run.Compute sorts params.
+    """
+    canonical = json.dumps(config, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode()).hexdigest()[:16]
+
+
+def record(
+    *,
+    project: str,
+    seed: int,
+    params: Dict[str, Any],
+    cfg_hash: str,
+    metrics: Dict[str, float],
+    dataset_version: str = "",
+    model_version: str = "",
+    device: str = "",
+    framework_version: str = "",
+    host: str = "",
+    status: str = "succeeded",
+) -> str:
+    """POST one finished run. Returns its server-assigned run id.
+
+    Every field here is sent as a string or number the server understands;
+    the server assigns `run_id` and `fingerprint` itself (ADR 0001), so
+    neither appears in this body.
+    """
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+    body: Dict[str, Any] = {
+        "project": project,
+        "git_commit": git_commit(),
+        "git_dirty": git_dirty(),
+        "config_hash": cfg_hash,
+        "dataset_version": dataset_version,
+        "model_version": model_version,
+        "seed": seed,
+        "params": {k: str(v) for k, v in params.items()},
+        "host": host,
+        "device": device,
+        "framework_version": framework_version,
+        "status": status,
+        "started_at": now,
+        "ended_at": now,
+        "metrics": metrics,
+    }
+    req = urllib.request.Request(
+        f"{server()}/v1/runs",
+        data=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return json.load(resp)["run_id"]
+    except urllib.error.HTTPError as exc:
+        raise RuntimeError(f"ledger refused the run: {exc.read().decode()}") from exc
+
+
+def get(path: str) -> Any:
+    with urllib.request.urlopen(f"{server()}{path}", timeout=10) as resp:
+        return json.load(resp)
+
+
+def compare(a: str, b: str) -> Dict[str, Any]:
+    return get(f"/v1/comparisons?a={a}&b={b}")
+
+
+def fingerprints(project: str) -> Any:
+    return get(f"/v1/fingerprints?project={project}")
+
+
+def runs(project: str, limit: int = 500) -> Any:
+    return get(f"/v1/runs?project={project}&limit={limit}")
+
+
+def wait_until_up(timeout: float = 10.0) -> None:
+    """Block until the ledger answers /healthz, or give a useful error."""
+    import time
+
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            urllib.request.urlopen(f"{server()}/healthz", timeout=1).read()
+            return
+        except OSError:
+            time.sleep(0.2)
+    raise SystemExit(
+        f"no ledger at {server()}\n"
+        "  start one with:  make build && ./bin/runledger &\n"
+        "  or run the whole example with:  make example"
+    )

--- a/examples/churn/scenario.py
+++ b/examples/churn/scenario.py
@@ -1,0 +1,209 @@
+"""The worked example: a real bug, found from the ledger record alone.
+
+Four scenarios, in the order a person would actually hit them.
+
+  A. Repeat one experiment four times. The ledger says the results are
+     unattributable -- same experiment, different numbers.
+  B. Go looking, as the ledger just told you to. Find the unseeded split.
+     Put it in the config, which puts it in the fingerprint. Repeat four
+     more times. The ledger goes quiet.
+  C. Change a hyperparameter for real. Different fingerprint, no alarm --
+     the tool stays silent when silence is correct.
+  D. Record one run through a sloppier path. The capture report flags it
+     without anyone having said it was different.
+
+Run with `make example`, or against a ledger you already have up:
+
+    RUNLEDGER_ADDR=http://localhost:8080 python3 examples/churn/scenario.py
+"""
+
+from __future__ import annotations
+
+import sys
+
+import completeness
+import ledger
+import train
+
+PROJECT = "churn-model"
+DATASET = "synthetic-churn-2026-08-01"
+MODEL = "logreg-gd-1.0"
+REPEATS = 4
+BASE_SEED = 7
+EPOCHS = 150
+
+
+def rule(title: str) -> None:
+    print(f"\n{'=' * 72}\n{title}\n{'=' * 72}")
+
+
+def record_repeats(*, cfg, params, split_seed, device, label) -> list:
+    """Run the same experiment REPEATS times and record each one."""
+    cfg_hash = ledger.config_hash(cfg)
+    ids = []
+    for i in range(REPEATS):
+        metrics = train.run_experiment(
+            seed=BASE_SEED,
+            lr=cfg["lr"],
+            epochs=cfg["epochs"],
+            # None here is the bug; an int is the fix.
+            split_seed=split_seed,
+        )
+        run_id = ledger.record(
+            project=PROJECT,
+            seed=BASE_SEED,
+            params=params,
+            cfg_hash=cfg_hash,
+            metrics=metrics,
+            dataset_version=DATASET,
+            model_version=MODEL,
+            device=device,
+            framework_version=f"python {sys.version_info.major}.{sys.version_info.minor}",
+            host="workstation-1",
+        )
+        ids.append(run_id)
+        print(f"  {label} run {i + 1}/{REPEATS}  auc={metrics['auc']:.4f}  "
+              f"log_loss={metrics['log_loss']:.4f}  {run_id}")
+    return ids
+
+
+def show_group(fingerprint: str) -> None:
+    g = ledger.get(f"/v1/fingerprints/{fingerprint}")
+    if g.get("no_repeats"):
+        print("  no repeats -- nothing to compare")
+        return
+    print(f"  {'METRIC':<12}{'COUNT':>6}{'MIN':>11}{'MAX':>11}{'MEAN':>11}{'STDDEV':>11}{'CV':>10}")
+    for name, s in sorted(g["metrics"].items()):
+        cv = abs(s["stddev"] / s["mean"]) if s["mean"] else 0.0
+        print(f"  {name:<12}{s['count']:>6}{s['min']:>11.4f}{s['max']:>11.4f}"
+              f"{s['mean']:>11.4f}{s['stddev']:>11.4f}{cv:>9.2%}")
+
+
+def _short(v: str) -> str:
+    """Metric values arrive as full float repr; 6 significant figures is
+    plenty to see a difference and keeps the columns aligned."""
+    try:
+        return f"{float(v):g}"
+    except (TypeError, ValueError):
+        return v if len(v) <= 18 else v[:17] + "\u2026"
+
+
+def verdict(a: str, b: str) -> None:
+    res = ledger.compare(a, b)
+    if res["same_experiment"]:
+        print("  fingerprints MATCH -- the ledger says these are the same experiment")
+    else:
+        print("  fingerprints DIFFER -- the ledger says these are different experiments")
+    for f in res["fields"] or []:
+        print(f"    {f['name']:<20}{f['kind']:<12}"
+              f"{_short(f['a']):<20}{_short(f['b'])}")
+    if res["unattributable"]:
+        print("  UNATTRIBUTABLE: same experiment, different results.")
+        print("  Something that affected the outcome is not in the record.")
+    else:
+        print("  not unattributable -- nothing here the record cannot explain")
+
+
+def main() -> None:
+    ledger.wait_until_up()
+
+    rule("A. The same experiment, four times")
+    print("""
+Identical identity every time: same project, commit, config hash, dataset,
+model, seed, and params. If the record is complete, the numbers should be
+identical too.
+""")
+    buggy_cfg = {"lr": 0.5, "epochs": EPOCHS, "standardize": True}
+    params = {"lr": "0.5", "epochs": str(EPOCHS)}
+    buggy = record_repeats(
+        cfg=buggy_cfg, params=params, split_seed=None, device="cpu", label="A"
+    )
+    print("\nWhat the ledger makes of the first two:")
+    verdict(buggy[0], buggy[1])
+    print("\nAnd across all four repeats:")
+    buggy_fp = ledger.get(f"/v1/runs/{buggy[0]}")["fingerprint"]
+    show_group(buggy_fp)
+    print("""
+That AUC range is the whole finding. Nothing in the record moved, and the
+model got measurably better or worse anyway. The ledger cannot say why --
+it can only say the explanation is not in what you recorded.
+""")
+
+    rule("B. Find the cause, record it, repeat")
+    print("""
+Going looking, as the verdict above says to: train.split_indices draws the
+train/test partition from an unseeded RNG. The recorded `seed` covers weight
+initialization only, so every run above trained and evaluated on a different
+partition of the same data.
+
+The fix is not just to seed it -- it is to make the seed part of the
+configuration, so it lands in config_hash and therefore in the fingerprint.
+An unrecorded knob cannot explain anything; a recorded one can.
+""")
+    fixed_cfg = {**buggy_cfg, "split_seed": 4242}
+    fixed = record_repeats(
+        cfg=fixed_cfg, params=params, split_seed=4242, device="cpu", label="B"
+    )
+    print("\nThe same two-run comparison, after the fix:")
+    verdict(fixed[0], fixed[1])
+    print("\nAnd across all four:")
+    fixed_fp = ledger.get(f"/v1/runs/{fixed[0]}")["fingerprint"]
+    show_group(fixed_fp)
+
+    rule("C. A change that is supposed to change the answer")
+    print("""
+Dropping the learning rate from 0.5 to 0.02. This *should* move the
+metrics, and the ledger should stay quiet about it -- a tool that cries wolf on legitimate work is
+worse than no tool.
+""")
+    lr_cfg = {**fixed_cfg, "lr": 0.02}
+    lr_params = {"lr": "0.02", "epochs": str(EPOCHS)}
+    changed = record_repeats(
+        cfg=lr_cfg, params=lr_params, split_seed=4242, device="cpu", label="C"
+    )
+    print("\nFixed baseline vs the new learning rate:")
+    verdict(fixed[0], changed[0])
+
+    rule("D. One run recorded through a sloppier path")
+    print("""
+The same experiment as B, but submitted by something that did not capture
+dataset_version, framework_version, or host -- a notebook run by hand, a
+script missing an env var. The ledger accepts it: every one of those fields
+is allowed to be empty, and an empty string is indistinguishable from "not
+recorded" on the wire.
+
+Nobody tells the report that this run is different. It infers it.
+""")
+    sloppy = ledger.record(
+        project=PROJECT,
+        seed=BASE_SEED,
+        params=params,
+        cfg_hash=ledger.config_hash(fixed_cfg),
+        metrics=train.run_experiment(
+            seed=BASE_SEED, lr=0.5, epochs=EPOCHS, split_seed=4242
+        ),
+        device="cpu",
+        # dataset_version, model_version, framework_version, host all omitted.
+    )
+    print(f"  recorded {sloppy}")
+
+    rule("The capture report")
+    all_runs = ledger.runs(PROJECT)["runs"]
+    print()
+    print(completeness.report(all_runs))
+
+    rule("Summary")
+    print(f"""
+  A  {REPEATS} runs, identical identity, metrics scattered  -> UNATTRIBUTABLE
+  B  the split seed moved into the config           -> quiet, CV 0.00%
+  C  a real hyperparameter change                   -> different experiment, quiet
+  D  one run missing what its peers record          -> flagged as likely client fault
+
+The ledger never knew about the unseeded split. It only knew the record
+claimed two runs were the same and the numbers disagreed -- which was
+enough to send someone to look in the right place.
+""")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/churn/test_completeness.py
+++ b/examples/churn/test_completeness.py
@@ -1,0 +1,110 @@
+"""Tests for the capture detector.
+
+The interesting cases are the ones the scenario cannot stage without
+contorting itself: a project with a genuine blind spot, and the guards that
+stop the detector firing on too little evidence. A detector that cries wolf
+would be worse than none, so the negative cases matter more than the
+positive one.
+
+    python3 -m unittest discover examples/churn
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import completeness
+
+
+def run(run_id: str, **fields) -> dict:
+    """A run record with everything captured, minus whatever is overridden."""
+    base = {
+        "run_id": run_id,
+        "fingerprint": "fp0",
+        "config_hash": "cfg",
+        "dataset_version": "ds-1",
+        "model_version": "m-1",
+        "host": "h1",
+        "device": "cpu",
+        "framework_version": "python 3.14",
+        "metrics": {"auc": 0.8},
+    }
+    base.update(fields)
+    return base
+
+
+class OddOneOut(unittest.TestCase):
+    def test_flags_a_run_missing_what_peers_record(self):
+        runs = [run(f"r{i}") for i in range(5)] + [run("odd", dataset_version="")]
+        [finding] = completeness.odd_ones_out(runs)
+        self.assertEqual(finding["run_id"], "odd")
+        self.assertEqual([m["field"] for m in finding["missing"]], ["dataset_version"])
+        self.assertEqual(finding["missing"][0]["kind"], "identity")
+
+    def test_silent_when_too_few_peers_record_it(self):
+        # 2 of 3 clears the 60% share but not the 3-peer floor: two runs
+        # agreeing is a coincidence, not a convention.
+        runs = [run("a"), run("b"), run("c", dataset_version="")]
+        self.assertEqual(completeness.odd_ones_out(runs), [])
+
+    def test_silent_when_the_field_is_rare_among_peers(self):
+        # Only 1 of 5 records it, so its absence is the norm, not the outlier.
+        runs = [run(f"r{i}", dataset_version="") for i in range(4)] + [run("has")]
+        self.assertEqual(completeness.odd_ones_out(runs), [])
+
+    def test_a_fully_captured_project_is_quiet(self):
+        self.assertEqual(completeness.odd_ones_out([run(f"r{i}") for i in range(6)]), [])
+
+
+class BlindSpots(unittest.TestCase):
+    def test_field_no_run_ever_records(self):
+        runs = [run(f"r{i}", framework_version="") for i in range(5)]
+        self.assertEqual(
+            [s["field"] for s in completeness.blind_spots(runs)], ["framework_version"]
+        )
+
+    def test_a_blind_spot_is_not_an_odd_one_out(self):
+        # Nobody records it, so no single run is the outlier. The two
+        # signals must not double-report the same absence.
+        runs = [run(f"r{i}", host="") for i in range(5)]
+        self.assertTrue(completeness.blind_spots(runs))
+        self.assertEqual(completeness.odd_ones_out(runs), [])
+
+    def test_report_escalates_a_blind_spot_only_alongside_spread(self):
+        quiet = [run(f"r{i}", host="", metrics={"auc": 0.8}) for i in range(4)]
+        self.assertIn("nothing to chase", completeness.report(quiet))
+
+        noisy = [
+            run(f"r{i}", host="", metrics={"auc": auc})
+            for i, auc in enumerate((0.70, 0.80, 0.90, 0.75))
+        ]
+        self.assertIn("BLIND SPOTS, AND THEY MATTER HERE", completeness.report(noisy))
+
+
+class UnattributableGroups(unittest.TestCase):
+    def test_identical_metrics_are_not_spread(self):
+        runs = [run(f"r{i}", metrics={"auc": 0.8}) for i in range(4)]
+        self.assertEqual(completeness.unattributable_groups(runs), [])
+
+    def test_a_lone_run_is_not_a_group(self):
+        self.assertEqual(completeness.unattributable_groups([run("solo")]), [])
+
+    def test_ranks_by_coefficient_of_variation_not_raw_stddev(self):
+        # loss moves less in absolute terms than auc, but far more
+        # relative to its own mean -- that is the one to surface.
+        runs = [
+            run(f"r{i}", metrics={"auc": auc, "loss": loss})
+            for i, (auc, loss) in enumerate(
+                ((0.90, 0.010), (0.88, 0.050), (0.92, 0.005), (0.89, 0.040))
+            )
+        ]
+        [group] = completeness.unattributable_groups(runs)
+        self.assertEqual(group["metric"], "loss")
+
+    def test_skips_a_metric_whose_mean_is_zero(self):
+        runs = [run(f"r{i}", metrics={"centered": v}) for i, v in enumerate((-1.0, 1.0))]
+        self.assertEqual(completeness.unattributable_groups(runs), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/churn/train.py
+++ b/examples/churn/train.py
@@ -1,0 +1,175 @@
+"""A small churn model: the thing being experimented on.
+
+Pure standard library, on purpose. The ledger's pitch is "one binary, no
+external dependencies to try it," and an example that needs a numpy/sklearn
+install before it demonstrates anything undercuts that.
+
+This module contains one *real* reproducibility bug, in `split_indices`. It
+is not decoration: the whole point of the example is that run-ledger finds
+it from the record alone, without being told it is there.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+from typing import Dict, List, Sequence, Tuple
+
+FEATURES = ("tenure_months", "monthly_charges", "support_tickets")
+
+Row = Tuple[List[float], int]
+
+
+def make_dataset(n: int = 1000, *, dataset_seed: int = 20260801) -> List[Row]:
+    """Synthetic monthly-subscription churn data.
+
+    Seeded from a fixed constant, and that constant is what the run records
+    as `dataset_version`: the dataset is a stable, named input to the
+    experiment, not a source of run-to-run variation. If this were real data
+    the version would be a snapshot id or a content hash of the extract.
+    """
+    rng = random.Random(dataset_seed)
+    rows: List[Row] = []
+    for _ in range(n):
+        tenure = rng.uniform(0.0, 72.0)
+        charges = rng.uniform(20.0, 120.0)
+        tickets = rng.expovariate(1 / 2.0)
+        # Latent churn propensity: long tenure protects, high charges and
+        # support contact predict churn.
+        z = -1.2 - 0.045 * tenure + 0.022 * charges + 0.35 * tickets
+        p = 1.0 / (1.0 + math.exp(-z))
+        rows.append(([tenure, charges, tickets], 1 if rng.random() < p else 0))
+    return rows
+
+
+def split_indices(n: int, *, split_seed: int | None) -> Tuple[List[int], List[int]]:
+    """Partition row indices into train and test.
+
+    `split_seed=None` is the bug this example exists to demonstrate. A
+    `random.Random(None)` seeds itself from OS entropy, so every run trains
+    and evaluates on a *different* partition of the same data -- while the
+    run's recorded identity (project, commit, config hash, dataset, model,
+    seed, params) stays byte-for-byte identical, because nothing in the
+    record mentions the split at all.
+
+    That is the exact shape of failure the ledger is built to catch: the
+    numbers move and the record says they shouldn't have.
+    """
+    rng = random.Random(split_seed)
+    idx = list(range(n))
+    rng.shuffle(idx)
+    cut = int(n * 0.75)
+    return idx[:cut], idx[cut:]
+
+
+def _standardizer(rows: Sequence[Row], idx: Sequence[int]):
+    """Per-feature mean/stddev, fit on the training fold only."""
+    k = len(FEATURES)
+    means = [0.0] * k
+    for i in idx:
+        for j in range(k):
+            means[j] += rows[i][0][j]
+    means = [m / len(idx) for m in means]
+    var = [0.0] * k
+    for i in idx:
+        for j in range(k):
+            d = rows[i][0][j] - means[j]
+            var[j] += d * d
+    stds = [math.sqrt(v / len(idx)) or 1.0 for v in var]
+
+    def apply(x: Sequence[float]) -> List[float]:
+        return [(x[j] - means[j]) / stds[j] for j in range(k)]
+
+    return apply
+
+
+def _sigmoid(z: float) -> float:
+    # Branch to avoid math.exp overflow on large-magnitude logits.
+    if z >= 0:
+        return 1.0 / (1.0 + math.exp(-z))
+    e = math.exp(z)
+    return e / (1.0 + e)
+
+
+def train(
+    rows: Sequence[Row],
+    train_idx: Sequence[int],
+    *,
+    seed: int,
+    lr: float,
+    epochs: int,
+) -> Tuple[List[float], float, object]:
+    """Full-batch gradient descent on logistic regression.
+
+    `seed` initializes the weights -- and it is the seed the run records.
+    Note what it does *not* cover: the data split. A reader of the lineage
+    record sees "seed=7" and reasonably assumes the run is pinned.
+    """
+    norm = _standardizer(rows, train_idx)
+    rng = random.Random(seed)
+    w = [rng.gauss(0.0, 0.01) for _ in FEATURES]
+    b = 0.0
+    n = len(train_idx)
+    for _ in range(epochs):
+        gw = [0.0] * len(FEATURES)
+        gb = 0.0
+        for i in train_idx:
+            x = norm(rows[i][0])
+            err = _sigmoid(sum(wj * xj for wj, xj in zip(w, x)) + b) - rows[i][1]
+            for j in range(len(FEATURES)):
+                gw[j] += err * x[j]
+            gb += err
+        for j in range(len(FEATURES)):
+            w[j] -= lr * gw[j] / n
+        b -= lr * gb / n
+    return w, b, norm
+
+
+def evaluate(rows, test_idx, w, b, norm) -> Dict[str, float]:
+    """Test-set AUC and log loss."""
+    scores, labels = [], []
+    for i in test_idx:
+        x = norm(rows[i][0])
+        scores.append(_sigmoid(sum(wj * xj for wj, xj in zip(w, x)) + b))
+        labels.append(rows[i][1])
+    return {"auc": _auc(scores, labels), "log_loss": _log_loss(scores, labels)}
+
+
+def _auc(scores: Sequence[float], labels: Sequence[int]) -> float:
+    """Rank-based (Mann-Whitney) AUC, with average ranks for ties."""
+    pos = sum(labels)
+    neg = len(labels) - pos
+    if pos == 0 or neg == 0:
+        return float("nan")
+    order = sorted(range(len(scores)), key=lambda i: scores[i])
+    ranks = [0.0] * len(scores)
+    i = 0
+    while i < len(order):
+        j = i
+        while j + 1 < len(order) and scores[order[j + 1]] == scores[order[i]]:
+            j += 1
+        avg = (i + j) / 2.0 + 1.0
+        for k in range(i, j + 1):
+            ranks[order[k]] = avg
+        i = j + 1
+    rank_sum = sum(r for r, y in zip(ranks, labels) if y == 1)
+    return (rank_sum - pos * (pos + 1) / 2.0) / (pos * neg)
+
+
+def _log_loss(scores: Sequence[float], labels: Sequence[int]) -> float:
+    eps = 1e-12
+    total = 0.0
+    for p, y in zip(scores, labels):
+        p = min(max(p, eps), 1 - eps)
+        total += -(y * math.log(p) + (1 - y) * math.log(1 - p))
+    return total / len(labels)
+
+
+def run_experiment(
+    *, seed: int, lr: float, epochs: int, split_seed: int | None, n: int = 1000
+) -> Dict[str, float]:
+    """One end-to-end training run. Returns the metrics it measured."""
+    rows = make_dataset(n)
+    train_idx, test_idx = split_indices(len(rows), split_seed=split_seed)
+    w, b, norm = train(rows, train_idx, seed=seed, lr=lr, epochs=epochs)
+    return evaluate(rows, test_idx, w, b, norm)


### PR DESCRIPTION
Two related changes. The example folder is what surfaced the bug, and the
example's README documents the gap the fix half-closes, so they travel
together. Happy to split if you'd rather review them apart.

## 1. `rlctl diff` could state the opposite of what the server said

`cmdDiff` printed **"the two records are identical"** whenever the
comparison came back with no fields, before it ever consulted
`SameExperiment`. Those two can disagree.

Reproducing case — two runs identical except that one has `params: {}` and
the other `params: {"foo": ""}`:

```
$ rlctl diff <a> <b>
the two records are identical
```

while `GET /v1/comparisons` had just answered:

```json
{"same_experiment": false, "fields": null, "unattributable": false}
```

They fingerprint differently because `lineage.Run.Compute` writes only the
keys that are present, but `compare.Runs` reads both sides through a map
index that yields `""` for a missing key, so it emits no field at all.

After:

```
$ rlctl diff <a> <b>
different experiments (fingerprints differ)

No field differs in this view. For fingerprints that differ, that
means a param is absent on one run and set to the empty string on
the other: those hash differently but render the same here. Run
`rlctl show` on each id to see which.
```

The verdict now comes from `SameExperiment` in every case. A genuinely
identical pair still prints exactly what it printed before. Rendering moved
into `renderDiff(io.Writer, compare.Result)` so the verdict logic is
testable without a live server — `cmd/rlctl` had no tests; it now has five.

**This is only the CLI half.** `compare.Runs` still cannot tell an absent
param from an empty one, so a diff cannot yet name *which* param it was.
That is the same root cause as the known `""`-versus-not-recorded gap the
struct comment in `internal/lineage/run.go` already acknowledges, and
fixing it properly means representing absence on the wire.

## 2. `examples/churn` — a real bug for the ledger to find

`python/examples/reproducibility.ipynb` demonstrates the API against numbers
chosen to illustrate it. This is the other kind of example: an actual model
with an actual reproducibility bug, discovered from the record alone.

`train.py` is a logistic regression in ~150 lines of pure Python whose
`split_indices` draws the train/test partition from an unseeded RNG. The
recorded `seed` covers weight initialization only, so the split appears
nowhere in the lineage record.

`scenario.py` walks the path a person actually walks:

| | | |
|---|---|---|
| **A** | Repeat one experiment 4× | AUC scatters 0.746–0.814 on a byte-identical identity record → `unattributable` |
| **B** | Move the split seed into the config | `config_hash` changes → new fingerprint → spread collapses to **exactly 0.00%** |
| **C** | Change the learning rate for real | Different fingerprint, metrics move, no alarm |
| **D** | Record one run through a sloppier path | Capture report flags it without being told |

A is the finding and B is the lesson: the fix is not merely to seed the
split, it is to make the seed part of the configuration so it lands in
`config_hash` and therefore in the fingerprint. An unrecorded knob cannot
explain a difference; a recorded one can. C earns its place too — a tool
that cried wolf on a legitimate hyperparameter change would be worse than
no tool.

### `completeness.py` — flagging a likely client fault

A different question from "what changed": is the record itself trustworthy?

A lineage record cannot distinguish "this run genuinely had no
`dataset_version`" from "the client dropped it" — both arrive as the empty
string, and intent is unrecoverable from one record. Across a *project* it
is recoverable statistically, and this needs no schema change and no new
field. It reads what `GET /v1/runs` already returns.

- **Odd-one-out** — well covered by peers, empty here. Points at one bad
  launch: a hand-run notebook, a missing env var, a stale script.
- **Blind spot** — empty for every run in the project. Points at the
  pipeline. Reported quietly on its own, escalated only when a fingerprint
  group also shows unexplained spread, because an uncaptured field is then
  a candidate explanation by construction.

Both are guarded by a share floor (60%) and a peer-count floor (3): two runs
agreeing is a coincidence, not a convention. It says "likely", never "is" —
it is a prior supplied by the peer group, not a fact recovered from the
record. Representing absence on the wire is what would upgrade it.

```
LIKELY CLIENT FAULT -- a run is missing what its peers record
  03b66aac0a75dfb9-dl1k0e2o0pqo-8eadb35a3f
    dataset_version    identity   empty here, recorded by 12/13 runs
    model_version      identity   empty here, recorded by 12/13 runs
    host               provenance empty here, recorded by 12/13 runs
    framework_version  provenance empty here, recorded by 12/13 runs
```

### Notes

Standard library only, including no dependency on this repo's own Python
client — an example needing a `pip install` before it demonstrated anything
would undercut "no external dependencies to try it". It also withholds
provenance on purpose for scenario D, which `Run.start()` captures
automatically.

`make example` runs the scenario against an ephemeral ledger on `:8125` and
then the unit tests. CI runs the 11 unit tests alone (no install step
needed); the scenario is not in CI since it needs a running server.

## Checks

- `go test -race ./...` green, `gofmt` clean, `go vet` clean
- `make example` green end to end
- Five new Go tests in `cmd/rlctl`, 11 new Python tests in `examples/churn`
- Six of the Python tests are negative cases — a detector that fires on thin
  evidence would train people to ignore it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
