### PR TITLE
compare: fix the root cause behind the diff verdict bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,24 @@ have to be true to revisit each one — lives in [`docs/adr/`](docs/adr/).
   not replaced, so a long run can report as it goes; re-reporting an existing
   key overwrites just that key.
 - **An absent metric is not a zero.** They print differently and diff
-  differently.
+  differently. The same rule now holds for an absent param: `{}` and
+  `{"foo": ""}` fingerprint differently, because `Compute` hashes only the
+  keys present, so the diff reports the two sides distinctly rather than
+  reading both through a map index that yields `""` for a missing key.
+- **For the scalar fields, an empty string *means* "not recorded".**
+  `config_hash`, `dataset_version`, `model_version`, `host`, `device`,
+  `framework_version`, and `checkpoint_uri` have no meaningful empty value,
+  so `""` is one spelling of absence rather than a distinction the record
+  failed to capture. That keeps the fields as plain strings, leaves the
+  fingerprint contract untouched, and stops a client that switches from
+  sending `""` to omitting a key from silently changing every fingerprint
+  it produces. `params` is exempt — presence there is real and already
+  hashed. ([ADR 0011](docs/adr/0011-empty-string-means-not-recorded.md))
+- **A comparison reads the stored fingerprint, not a fresh one.** Recomputing
+  it in `compare` gave a second, independent answer to the question
+  `spread` already answers from the stored value. The two agree only while
+  `Compute` never changes, and [ADR 0004](docs/adr/0004-fingerprint-input-is-a-versioned-contract.md)
+  exists because one day it will.
 - **Hashed fields are length-prefixed** so `("ab","c")` and `("a","bc")` cannot
   collide, and **params are sorted before hashing** because Go randomizes map
   iteration — without that, the same experiment fingerprints differently between

--- a/cmd/rlctl/main.go
+++ b/cmd/rlctl/main.go
@@ -337,18 +337,20 @@ func renderDiff(w io.Writer, res compare.Result) {
 		fmt.Fprintln(w, "different experiments (fingerprints differ)")
 	}
 	if len(res.Fields) == 0 {
-		// Differing fingerprints with nothing to show. Every other hashed
-		// field is compared as a string and would have rendered, so an
-		// absent-versus-empty param is what is left.
-		fmt.Fprintln(w, "\nNo field differs in this view. For fingerprints that differ, that")
-		fmt.Fprintln(w, "means a param is absent on one run and set to the empty string on")
-		fmt.Fprintln(w, "the other: those hash differently but render the same here. Run")
-		fmt.Fprintln(w, "`rlctl show` on each id to see which.")
+		// Fingerprints differ and nothing rendered. compare.Runs covers
+		// every input lineage.Run.Compute hashes, so reaching this means
+		// the two have drifted apart -- not something a reader can act on,
+		// but far better said out loud than papered over with a verdict of
+		// "identical". It was reachable until params were compared by
+		// presence rather than through a map index.
+		fmt.Fprintln(w, "\nNo field differs, which should not be possible for fingerprints")
+		fmt.Fprintln(w, "that differ: the diff covers every field the fingerprint hashes.")
+		fmt.Fprintln(w, "Please report this, with the output of `rlctl show` for each id.")
 		return
 	}
 	fmt.Fprintf(w, "\n%-24s  %-12s  %-20s  %s\n", "FIELD", "KIND", "A", "B")
 	for _, f := range res.Fields {
-		fmt.Fprintf(w, "%-24s  %-12s  %-20s  %s\n", f.Name, f.Kind, or(f.A, "—"), or(f.B, "—"))
+		fmt.Fprintf(w, "%-24s  %-12s  %-20s  %s\n", f.Name, f.Kind, cell(f.A), cell(f.B))
 	}
 	if res.Unattributable {
 		fmt.Fprintln(w, "\nThese runs describe the same experiment but measured differently.")
@@ -504,9 +506,16 @@ func trunc(s string, n int) string {
 	return s[:n]
 }
 
-func or(s, def string) string {
-	if s == "" {
-		return def
+// cell renders one side of a diff row. A nil value was never recorded; a
+// pointer to "" is a value the run actually carried, which only a param
+// can currently be (ADR 0011). The two used to print the same em dash.
+func cell(v *string) string {
+	switch {
+	case v == nil:
+		return "—"
+	case *v == "":
+		return `""`
+	default:
+		return *v
 	}
-	return s
 }

--- a/cmd/rlctl/main_test.go
+++ b/cmd/rlctl/main_test.go
@@ -13,7 +13,7 @@ import (
 // TestRenderDiffDifferentExperimentWithNoRenderedFields -- and the earlier
 // ordering reported the opposite of what the server said.
 func TestRenderDiffVerdictFollowsSameExperiment(t *testing.T) {
-	field := []compare.Field{{Name: "seed", Kind: compare.KindIdentity, A: "1", B: "2"}}
+	field := []compare.Field{{Name: "seed", Kind: compare.KindIdentity, A: ptr("1"), B: ptr("2")}}
 
 	for _, tc := range []struct {
 		name   string
@@ -72,10 +72,11 @@ func TestRenderDiffDifferentExperimentWithNoRenderedFields(t *testing.T) {
 	if !strings.Contains(out, "different experiments (fingerprints differ)") {
 		t.Errorf("want the differing-fingerprint verdict, got:\n%s", out)
 	}
-	// The empty table would be useless on its own; the reader needs to know
-	// why a real difference has nothing to show.
-	if !strings.Contains(out, "empty string") {
-		t.Errorf("want an explanation of the absent-versus-empty param case, got:\n%s", out)
+	// An empty table would be useless on its own. Since compare.Runs covers
+	// every hashed field, reaching this state is a bug in the ledger, and
+	// saying so is more use to the reader than a bare verdict.
+	if !strings.Contains(out, "should not be possible") {
+		t.Errorf("want the invariant violation called out, got:\n%s", out)
 	}
 	if strings.Contains(out, "FIELD") {
 		t.Errorf("no rows to show, so no table header should print:\n%s", out)
@@ -83,7 +84,7 @@ func TestRenderDiffDifferentExperimentWithNoRenderedFields(t *testing.T) {
 }
 
 func TestRenderDiffUnattributableNoteOnlyWhenFlagged(t *testing.T) {
-	metric := []compare.Field{{Name: "metrics.loss", Kind: compare.KindMetric, A: "0.42", B: "0.51"}}
+	metric := []compare.Field{{Name: "metrics.loss", Kind: compare.KindMetric, A: ptr("0.42"), B: ptr("0.51")}}
 	const note = "not captured in the record"
 
 	var flagged bytes.Buffer
@@ -99,15 +100,28 @@ func TestRenderDiffUnattributableNoteOnlyWhenFlagged(t *testing.T) {
 	}
 }
 
-// An absent value renders as an em dash so it is not mistaken for a value
-// the run actually had.
-func TestRenderDiffMarksAbsentValues(t *testing.T) {
+// A value the run never recorded and a value it recorded as empty are
+// different claims, and must not print the same glyph. Before Field
+// carried presence, both arrived as "" and both rendered as an em dash.
+func TestRenderDiffDistinguishesAbsentFromEmpty(t *testing.T) {
 	var buf bytes.Buffer
 	renderDiff(&buf, compare.Result{
 		SameExperiment: true,
-		Fields:         []compare.Field{{Name: "metrics.auc", Kind: compare.KindMetric, A: "0.94", B: ""}},
+		Fields: []compare.Field{
+			{Name: "metrics.auc", Kind: compare.KindMetric, A: ptr("0.94"), B: nil},
+			{Name: "params.tag", Kind: compare.KindIdentity, A: nil, B: ptr("")},
+		},
 	})
-	if !strings.Contains(buf.String(), "—") {
-		t.Errorf("want an em dash for the absent metric, got:\n%s", buf.String())
+	out := buf.String()
+	for _, want := range []string{"metrics.auc", "0.94", "—", `params.tag`, `""`} {
+		if !strings.Contains(out, want) {
+			t.Errorf("want %q in output, got:\n%s", want, out)
+		}
+	}
+	// The absent side and the empty side must not read alike.
+	if strings.Count(out, "—") != 2 {
+		t.Errorf("want exactly the two absent cells marked, got:\n%s", out)
 	}
 }
+
+func ptr(s string) *string { return &s }

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -168,6 +168,7 @@ def _(mo, runs):
 def _(a_picker, b_picker, mo, server_input):
     from runledger import LedgerError as _LedgerError
 
+    from runledger_dashboard import diff_cell as _cell
     from runledger_dashboard import pair_diff
 
     if a_picker.value == b_picker.value:
@@ -188,7 +189,20 @@ def _(a_picker, b_picker, mo, server_input):
         [
             mo.md(verdict),
             mo.ui.table(
-                [{"field": f["name"], "kind": f["kind"], "a": f["a"], "b": f["b"]} for f in diff["fields"]],
+                [
+                    {
+                        "field": f["name"],
+                        "kind": f["kind"],
+                        # null means the run never recorded the field; ""
+                        # means it recorded an empty value. Passing null
+                        # straight through renders a blank cell, which reads
+                        # as the empty value it is not -- the same
+                        # conflation rlctl's `cell` avoids. See ADR 0011.
+                        "a": _cell(f["a"]),
+                        "b": _cell(f["b"]),
+                    }
+                    for f in diff["fields"]
+                ],
                 selection=None,
             )
             if diff["fields"]

--- a/dashboard/runledger_dashboard/__init__.py
+++ b/dashboard/runledger_dashboard/__init__.py
@@ -11,7 +11,14 @@ view here needs something the client cannot express, that is a gap in
 ``runledger``, not something to work around with a hand-rolled HTTP call.
 """
 
-from ._data import group_runs, list_projects, pair_diff, ranked_groups, widest_spread
+from ._data import (
+    diff_cell,
+    group_runs,
+    list_projects,
+    pair_diff,
+    ranked_groups,
+    widest_spread,
+)
 
 __all__ = [
     "list_projects",
@@ -19,4 +26,5 @@ __all__ = [
     "widest_spread",
     "group_runs",
     "pair_diff",
+    "diff_cell",
 ]

--- a/dashboard/runledger_dashboard/_data.py
+++ b/dashboard/runledger_dashboard/_data.py
@@ -122,3 +122,19 @@ def pair_diff(
     :raises runledger.LedgerUnreachableError: if the ledger cannot be reached.
     """
     return runledger.compare(a, b, server=server, timeout=timeout)
+
+
+def diff_cell(value: Optional[str]) -> str:
+    """Render one side of a ``pair_diff`` field for display.
+
+    ``None`` means the run never recorded the field; ``""`` means it
+    recorded an empty value, which only a param can be (ADR 0011). Passing
+    ``None`` straight into a table renders a blank cell, which reads as the
+    empty value it is not -- the same conflation ``rlctl``'s ``cell``
+    avoids, and the reason both spellings used to be indistinguishable.
+    """
+    if value is None:
+        return "\u2014"
+    if value == "":
+        return '""'
+    return value

--- a/dashboard/tests/test_data.py
+++ b/dashboard/tests/test_data.py
@@ -24,6 +24,7 @@ sys.path.insert(0, os.path.join(_HERE, ".."))
 
 import runledger  # noqa: E402
 from runledger_dashboard import (  # noqa: E402
+    diff_cell,
     group_runs,
     list_projects,
     pair_diff,
@@ -253,3 +254,20 @@ class ErrorsPropagateTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class DiffCell(unittest.TestCase):
+    """A field the run never recorded and one it recorded as empty are
+    different claims, and must not render alike. See ADR 0011."""
+
+    def test_absent_renders_as_an_em_dash(self):
+        self.assertEqual(diff_cell(None), "—")
+
+    def test_empty_renders_as_visible_quotes(self):
+        self.assertEqual(diff_cell(""), '""')
+
+    def test_absent_and_empty_do_not_collide(self):
+        self.assertNotEqual(diff_cell(None), diff_cell(""))
+
+    def test_a_value_passes_through(self):
+        self.assertEqual(diff_cell("cuda"), "cuda")

--- a/docs/adr/0011-empty-string-means-not-recorded.md
+++ b/docs/adr/0011-empty-string-means-not-recorded.md
@@ -1,0 +1,107 @@
+# ADR 0011: An empty string means "not recorded"
+
+Status: Accepted
+Date: 2026-08-29
+
+> **For the scalar fields where an empty string is not a meaningful value —
+> `config_hash`, `dataset_version`, `model_version`, `host`, `device`,
+> `framework_version`, and `checkpoint_uri` — `""` and "not recorded" are
+> the same claim.** The ledger stops treating them as a distinction it
+> failed to capture and starts treating them as one spelling of one
+> meaning. `params` is excluded: a param key can be genuinely present with
+> an empty value, the map already carries that difference, and
+> `lineage.Run.Compute` already hashes the two differently.
+
+## Context
+
+`lineage.Run` types those seven fields as `string`, so a run that arrives
+with `"dataset_version": ""` and one that omits the key entirely are
+indistinguishable once decoded. The struct comment has acknowledged this as
+a known gap since the type was written, describing it as something that
+"can misrepresent a run that genuinely ran with none of these set," and
+proposing pointers as the eventual fix.
+
+Pointers would work mechanically. `encoding/json` already distinguishes an
+absent key from an empty one when decoding into `*string`, and the
+`schema_migrations` table in `internal/store/duckdb.go` is there to make
+the column change. The cost is the part worth stating: roughly fifty call
+sites across nine files, nullable columns in the DuckDB schema, a matching
+change in the Python client and the OpenAPI spec, and — because three of
+the seven are identity fields — a new version of the fingerprint contract
+under ADR 0004, with every fingerprint recorded to date orphaned or
+grandfathered.
+
+That is a large price, and it was only ever worth paying if the
+distinction buys something. It does not, for these seven fields, and the
+question that settles it is simple: **is there an experiment whose
+`dataset_version` is genuinely the empty string?**
+
+There is not. An empty config hash *is* no config hash. A host always has a
+name; if the record has no name for it, the client did not capture one. The
+same holds for every field in the list. `""` is not a value competing with
+absence — it is a second way of writing absence, produced by clients that
+serialize every key rather than omitting the unset ones. This repository's
+own Python client is one of them.
+
+That reframes the problem. It is not two meanings the type cannot separate.
+It is one meaning with two spellings, and nothing requires keeping both.
+
+A second consideration argues the same way, and against pointers
+specifically. If absence became identity-bearing, a client that switched
+from sending `""` to omitting the key would silently change every
+fingerprint it produces — a client version bump orphaning records, with no
+server change involved. That makes the fingerprint a function of how a
+client serializes rather than of what the experimenter chose, which is a
+bad property for the ledger's most load-bearing promise.
+
+`params` is genuinely different and is excluded for that reason. Param keys
+are caller-defined, `--param foo=` is expressible and can mean something,
+and `Compute` writes only the keys that are present — so an absent param
+and an empty one already produce different fingerprints. There the
+distinction is real and already identity-bearing; the bug was that
+`compare.Runs` read both sides through a map index, which yields `""` for a
+missing key, and so reported no difference at all. That is fixed by reading
+presence from the map, not by changing any type.
+
+## Decision
+
+For the seven fields listed above, `""` means "not recorded". This is now a
+stated invariant rather than an accident of the type.
+
+- The fields stay `string`. No pointers, no nullable columns, no migration.
+- The fingerprint input is unchanged, so ADR 0004 is not triggered and no
+  recorded fingerprint changes meaning.
+- Consumers may rely on `"" == absent` for these fields. `compare.Runs`
+  does: it normalizes an empty value to a null side in the diff, so the API
+  and `rlctl` report "not recorded" rather than a value of `""`.
+- `params` is exempt. Presence there is read from the map and reported
+  distinctly, matching what `Compute` already hashes.
+
+## Consequences
+
+The ambiguity is gone by construction rather than by capture: there is now
+one spelling of "no value," and every layer can rely on it. `rlctl`'s
+existing behaviour of rendering an empty scalar as an em dash becomes
+correct rather than a conflation.
+
+What is genuinely given up is the ability to record "this run had an
+explicitly empty dataset version." Nothing needs that, which is the
+premise of the decision — but it is a real loss and it is why this record
+exists rather than the change being made silently.
+
+The question pointers were reached for does not disappear; it turns out to
+be a different question. "Did this client fail to capture `device`, or did
+this run have none?" is a fact about the recording process, not about the
+experiment, and a nullable value field is the wrong place to put it —
+that is a category error, not a representation gap. Recording it properly
+means recording what the client attempted: a capture declaration alongside
+the run, kept out of the fingerprint. Nothing in the ledger asks for that
+today. `examples/churn/completeness.py` approximates the same signal by
+comparing a run against its peers within a project, and that is a
+reasonable place to stop until something needs better.
+
+Revisiting this record would take a field where an empty string is a
+meaningful value distinct from absence. Such a field should not be added
+to the list above; it should be typed so that its own representation says
+so, and this decision left to cover the seven where the collapse is
+correct.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,6 +22,7 @@ section is a summary of these; this folder is the account.
 | [0008](0008-replay-raises-quarantines-and-tracks-a-read-offset.md) | `replay_spool()` raises on an unreachable ledger, quarantines permanent rejections, and rewrites the spool by tracked read offset | Accepted |
 | [0009](0009-url-path-versioning-for-the-http-api.md) | URL path versioning (`/v1`) for the HTTP API, excluding health/readiness/metrics | Accepted |
 | [0010](0010-comparisons-is-a-resource-not-a-verb.md) | `/comparisons` is a resource, not a verb | Accepted |
+| [0011](0011-empty-string-means-not-recorded.md) | An empty string means "not recorded" | Accepted |
 
 ## Adding a record
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -771,8 +771,17 @@ components:
           enum: [identity, provenance, metric]
         a:
           type: string
+          nullable: true
+          description: >
+            The first run's value, or null if the run did not record this
+            field. Null and "" are different answers: null means the field
+            was never set, "" means it was set to the empty string. Only a
+            param can be the latter -- for the scalar fields an empty value
+            is not meaningful, so it is reported as null. See ADR 0011.
         b:
           type: string
+          nullable: true
+          description: The second run's value, on the same terms as `a`.
 
     CompareResult:
       type: object

--- a/examples/README.md
+++ b/examples/README.md
@@ -108,30 +108,34 @@ that fires on thin evidence would train people to ignore it.
 
 ## What this example is evidence for
 
-Running it makes two gaps in the current data model concrete:
+Running it makes two things concrete.
 
-1. **`""` and "not recorded" are the same value on the wire**, for
-   `config_hash`, `dataset_version`, `model_version`, `host`, `device`, and
-   `framework_version` — a known gap the struct comment in
-   [`internal/lineage/run.go`](../internal/lineage/run.go) already
-   acknowledges. For the three identity fields it is worse than cosmetic: a
-   run that genuinely had no dataset version and one whose client dropped it
-   produce the *same fingerprint*, so they are grouped as the same
-   experiment and their metric difference is reported as unattributable.
-   That is a false positive on the single claim this ledger makes.
+1. **A capture gap is invisible from one record.** For `config_hash`,
+   `dataset_version`, `model_version`, `host`, `device`, and
+   `framework_version`, an empty value means "not recorded" — that is now a
+   stated invariant
+   ([ADR 0011](../docs/adr/0011-empty-string-means-not-recorded.md)), not a
+   gap, because none of those fields has a meaningful empty value. So *was
+   this captured?* is answerable exactly. What is not answerable from the
+   record alone is *why* it is empty: a run that genuinely had no dataset
+   version and one whose client dropped it look the same. That is a fact
+   about the recording process, not about the experiment, which is why the
+   detector here reaches for the peer group rather than for the field.
 
-2. **The same conflation reaches the diff.** Two runs whose params are `{}`
-   and `{"foo": ""}` fingerprint differently — `Compute` writes only the
-   keys that are present — but `compare.Runs` renders both sides of
-   `params.foo` as `""`, so no field is emitted. `GET /v1/comparisons`
-   answers `same_experiment: false` with `fields: null`.
+2. **Params are the case where presence is real.** A param key can be
+   genuinely present with an empty value, and `lineage.Run.Compute` already
+   hashes `{}` and `{"foo": ""}` differently. `compare.Runs` used to read
+   both sides through a map index that yields `""` for a missing key, so it
+   emitted no field: `GET /v1/comparisons` answered `same_experiment: false`
+   with `fields: null`, and `rlctl diff` printed **"the two records are
+   identical"** — the opposite of what the server had said.
 
-   `rlctl diff` used to key its verdict off `len(Fields)` and printed **"the
-   two records are identical"** for that pair — the opposite of what the
-   server had just said. That half is fixed: the verdict now comes from
-   `SameExperiment`, and the no-rows case explains why a real difference has
-   nothing to show. The underlying conflation in `compare.Runs` remains, and
-   is the same gap as (1): a diff still cannot name which param it was.
+   Both halves are fixed. The diff reads presence from the map and reports
+   `params.foo` as `—` against `""`; the API returns `"a": null, "b": ""`;
+   and the verdict now comes from `SameExperiment` rather than from whether
+   any field happened to render.
 
-The detector in this folder is the best available answer while both hold.
-It is a workaround for (1), not a substitute for fixing it.
+The detector remains a heuristic for (1), and says "likely" rather than
+"is". Making it exact would mean recording what the client *attempted* to
+capture — a declaration alongside the run, kept out of the fingerprint —
+which nothing in the ledger asks for yet.

--- a/examples/churn/completeness.py
+++ b/examples/churn/completeness.py
@@ -7,9 +7,16 @@ schema change and no new field: compare a run against its peers.
 
 The reasoning
 -------------
-A lineage record has no way to distinguish "this run genuinely had no
-dataset version" from "the client forgot to send one" -- both arrive as the
-empty string. Intent is unrecoverable from a single record.
+ADR 0011 settled what an empty value means: for these fields "" and "not
+recorded" are the same claim, because none of them has a meaningful empty
+value. So "was this captured?" is now answerable exactly -- an empty field
+was not captured, full stop.
+
+What stays unanswerable from a single record is *why*: whether this run
+genuinely had no dataset version, or the client that submitted it failed
+to send one. That is a fact about the recording process rather than about
+the experiment, and no amount of widening the field's type would recover
+it.
 
 Across a *project*, though, it is recoverable statistically. If 11 of 12
 runs in a project record `framework_version` and one does not, the odds that
@@ -38,9 +45,10 @@ from __future__ import annotations
 import statistics
 from typing import Any, Dict, List, Sequence
 
-# The six fields where "" and "not recorded" are indistinguishable on the
-# wire. Identity fields are marked because a missing one is strictly worse:
-# it silently changes what experiment the run is recorded as being.
+# The six fields where an empty value means "not recorded" (ADR 0011) and
+# a client is therefore capable of silently omitting one. Identity fields
+# are marked because a gap there is worse: it changes which experiment the
+# run is grouped with, not just how well it is described.
 CAPTURABLE = [
     ("config_hash", "identity"),
     ("dataset_version", "identity"),

--- a/internal/compare/compare.go
+++ b/internal/compare/compare.go
@@ -23,11 +23,51 @@ const (
 )
 
 // Field is one difference between two runs.
+//
+// A and B are nil when the run did not record the field at all, and point
+// at "" when it recorded an empty value. Only params can currently be the
+// latter: for the seven scalar fields where an empty string is not a
+// meaningful value, "" is normalized to nil here -- see ADR 0011.
+//
+// Carrying pointers makes Field unsafe to compare with ==, which would
+// test pointer identity rather than the values. Use reflect.DeepEqual.
 type Field struct {
-	Name string `json:"name"`
-	Kind Kind   `json:"kind"`
-	A    string `json:"a"`
-	B    string `json:"b"`
+	Name string  `json:"name"`
+	Kind Kind    `json:"kind"`
+	A    *string `json:"a"`
+	B    *string `json:"b"`
+}
+
+// value marks a field the run recorded, whatever it recorded.
+func value(s string) *string { return &s }
+
+// optional marks a field where "" and "not recorded" are the same claim,
+// so an empty value is reported as absent rather than as a value of "".
+// ADR 0011 is what makes that a fact about the data rather than a guess.
+func optional(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
+// lookup distinguishes a param the run did not set from one it set to "".
+// The map already carries that difference and lineage.Run.Compute already
+// hashes the two differently -- reading through a bare map index, which
+// yields "" for a missing key, was what discarded it.
+func lookup(m map[string]string, k string) *string {
+	v, ok := m[k]
+	if !ok {
+		return nil
+	}
+	return &v
+}
+
+func equal(x, y *string) bool {
+	if x == nil || y == nil {
+		return x == nil && y == nil
+	}
+	return *x == *y
 }
 
 // Result is the structured diff of two runs.
@@ -46,34 +86,58 @@ type Result struct {
 	Unattributable bool `json:"unattributable"`
 }
 
+// SameExperiment reports whether two runs are the same experiment.
+//
+// The stored fingerprint is authoritative whenever both runs carry one. It
+// is what the server computed at record time (ADR 0001) and what
+// spread.Compute groups by, so reading it here keeps one answer to the
+// question rather than two. Recomputing unconditionally -- which this used
+// to do -- is indistinguishable from that today, and stops being so the
+// moment lineage.Run.Compute changes: a record written under the old
+// contract would keep its stored fingerprint while being rehashed under
+// the new rules at read time, so spread would group two runs that compare
+// called different experiments. ADR 0004 anticipates exactly that change.
+//
+// Compute remains the fallback for runs that have not been through a
+// store, which is how callers construct them in tests.
+func SameExperiment(a, b lineage.Run) bool {
+	if a.Fingerprint != "" && b.Fingerprint != "" {
+		return a.Fingerprint == b.Fingerprint
+	}
+	return a.Compute() == b.Compute()
+}
+
 // Runs diffs two run records.
 func Runs(a, b lineage.Run) Result {
-	res := Result{A: a.RunID, B: b.RunID, SameExperiment: a.Compute() == b.Compute()}
-	add := func(name string, kind Kind, x, y string) {
-		if x != y {
-			res.Fields = append(res.Fields, Field{Name: name, Kind: kind, A: x, B: y})
-			if res.SameExperiment && kind == KindMetric {
-				res.Unattributable = true
-			}
+	res := Result{A: a.RunID, B: b.RunID, SameExperiment: SameExperiment(a, b)}
+	add := func(name string, kind Kind, x, y *string) {
+		if equal(x, y) {
+			return
+		}
+		res.Fields = append(res.Fields, Field{Name: name, Kind: kind, A: x, B: y})
+		if res.SameExperiment && kind == KindMetric {
+			res.Unattributable = true
 		}
 	}
 
-	add("project", KindIdentity, a.Project, b.Project)
-	add("git_commit", KindIdentity, a.GitCommit, b.GitCommit)
-	add("git_dirty", KindIdentity, fmt.Sprint(a.GitDirty), fmt.Sprint(b.GitDirty))
-	add("config_hash", KindIdentity, a.ConfigHash, b.ConfigHash)
-	add("dataset_version", KindIdentity, a.DatasetVersion, b.DatasetVersion)
-	add("model_version", KindIdentity, a.ModelVersion, b.ModelVersion)
-	add("seed", KindIdentity, fmt.Sprint(a.Seed), fmt.Sprint(b.Seed))
+	// project and git_commit are required by Run.Validate, and git_dirty
+	// and seed always have a value, so all four are always recorded.
+	add("project", KindIdentity, value(a.Project), value(b.Project))
+	add("git_commit", KindIdentity, value(a.GitCommit), value(b.GitCommit))
+	add("git_dirty", KindIdentity, value(fmt.Sprint(a.GitDirty)), value(fmt.Sprint(b.GitDirty)))
+	add("config_hash", KindIdentity, optional(a.ConfigHash), optional(b.ConfigHash))
+	add("dataset_version", KindIdentity, optional(a.DatasetVersion), optional(b.DatasetVersion))
+	add("model_version", KindIdentity, optional(a.ModelVersion), optional(b.ModelVersion))
+	add("seed", KindIdentity, value(fmt.Sprint(a.Seed)), value(fmt.Sprint(b.Seed)))
 	for _, k := range unionKeys(a.Params, b.Params) {
-		add("params."+k, KindIdentity, a.Params[k], b.Params[k])
+		add("params."+k, KindIdentity, lookup(a.Params, k), lookup(b.Params, k))
 	}
 
-	add("host", KindProvenance, a.Host, b.Host)
-	add("device", KindProvenance, a.Device, b.Device)
-	add("framework_version", KindProvenance, a.FrameworkVersion, b.FrameworkVersion)
-	add("status", KindProvenance, string(a.Status), string(b.Status))
-	add("checkpoint_uri", KindProvenance, a.CheckpointURI, b.CheckpointURI)
+	add("host", KindProvenance, optional(a.Host), optional(b.Host))
+	add("device", KindProvenance, optional(a.Device), optional(b.Device))
+	add("framework_version", KindProvenance, optional(a.FrameworkVersion), optional(b.FrameworkVersion))
+	add("status", KindProvenance, optional(string(a.Status)), optional(string(b.Status)))
+	add("checkpoint_uri", KindProvenance, optional(a.CheckpointURI), optional(b.CheckpointURI))
 
 	for _, k := range unionKeysF(a.Metrics, b.Metrics) {
 		add("metrics."+k, KindMetric, fmtMetric(a.Metrics, k), fmtMetric(b.Metrics, k))
@@ -81,12 +145,14 @@ func Runs(a, b lineage.Run) Result {
 	return res
 }
 
-func fmtMetric(m map[string]float64, k string) string {
+// fmtMetric returns nil for a metric the run did not report, which is
+// distinct from a metric it reported as zero.
+func fmtMetric(m map[string]float64, k string) *string {
 	v, ok := m[k]
 	if !ok {
-		return "" // absent, which is distinct from zero
+		return nil
 	}
-	return fmt.Sprintf("%g", v)
+	return value(fmt.Sprintf("%g", v))
 }
 
 func unionKeys(a, b map[string]string) []string {

--- a/internal/compare/compare_test.go
+++ b/internal/compare/compare_test.go
@@ -2,6 +2,7 @@ package compare
 
 import (
 	"encoding/json"
+	"reflect"
 	"testing"
 
 	"github.com/kornsour/run-ledger/internal/lineage"
@@ -61,8 +62,11 @@ func TestAbsentMetricIsNotZero(t *testing.T) {
 	if len(res.Fields) != 1 {
 		t.Fatalf("want one difference, got %+v", res.Fields)
 	}
-	if res.Fields[0].A != "0" || res.Fields[0].B != "" {
-		t.Fatalf("a recorded zero must not read the same as an absent metric: %+v", res.Fields[0])
+	if got := res.Fields[0].A; got == nil || *got != "0" {
+		t.Fatalf("a recorded zero must render as a value: %+v", res.Fields[0])
+	}
+	if res.Fields[0].B != nil {
+		t.Fatalf("an absent metric must be nil, not a value: %+v", res.Fields[0])
 	}
 }
 
@@ -100,9 +104,86 @@ func TestFieldOrderIsDeterministic(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		got := Runs(a, b).Fields
 		for j := range first {
-			if got[j] != first[j] {
+			// reflect.DeepEqual, not ==: Field carries *string, so ==
+			// would compare pointer identity and fail on every call.
+			if !reflect.DeepEqual(got[j], first[j]) {
 				t.Fatal("diff field order is not deterministic")
 			}
 		}
+	}
+}
+
+// The bug this presence handling exists for. Two runs whose params are {}
+// and {"foo": ""} fingerprint differently, because Run.Compute writes only
+// the keys that are present. Reading both sides through a bare map index
+// yielded "" for each and emitted no field at all, so the API answered
+// same_experiment:false with fields:null and rlctl called them identical.
+func TestParamAbsentIsNotParamEmpty(t *testing.T) {
+	a, b := run("a"), run("b")
+	a.Params = nil
+	b.Params = map[string]string{"foo": ""}
+
+	res := Runs(a, b)
+	if res.SameExperiment {
+		t.Fatal("an absent param and an empty one hash differently, so these are different experiments")
+	}
+	var got *Field
+	for i := range res.Fields {
+		if res.Fields[i].Name == "params.foo" {
+			got = &res.Fields[i]
+		}
+	}
+	if got == nil {
+		t.Fatalf("want params.foo reported as a difference, got %+v", res.Fields)
+	}
+	if got.A != nil {
+		t.Errorf("a run that never set the param must report nil, got %q", *got.A)
+	}
+	if got.B == nil || *got.B != "" {
+		t.Errorf("a run that set the param to empty must report a value, got %v", got.B)
+	}
+}
+
+// "" and "not recorded" are the same claim for the scalar fields, so the
+// diff reports the empty one as absent rather than as a value of "".
+// ADR 0011 is what licenses that normalization.
+func TestEmptyScalarFieldsReportAsAbsent(t *testing.T) {
+	a, b := run("a"), run("b")
+	a.Device = "cuda"
+	b.Device = ""
+
+	for _, f := range Runs(a, b).Fields {
+		if f.Name != "device" {
+			continue
+		}
+		if f.B != nil {
+			t.Fatalf("an unrecorded device must report nil, got %q", *f.B)
+		}
+		return
+	}
+	t.Fatal("want device reported as a difference")
+}
+
+// compare must not answer "same experiment" independently of the stored
+// fingerprint the rest of the ledger groups by. Recomputing here gave a
+// second answer to the same question, which stays invisible only while
+// Run.Compute never changes -- and ADR 0004 exists because it will.
+func TestSameExperimentPrefersTheStoredFingerprint(t *testing.T) {
+	a, b := run("a"), run("b")
+	a.Fingerprint, b.Fingerprint = "stored-fp", "stored-fp"
+	a.Seed, b.Seed = 1, 2 // Compute would disagree; the store is authoritative.
+
+	if !SameExperiment(a, b) {
+		t.Error("want the stored fingerprint to decide when both runs carry one")
+	}
+	if !Runs(a, b).SameExperiment {
+		t.Error("Runs must use the same source of truth as SameExperiment")
+	}
+
+	// A run that has not been through a store has no fingerprint to trust.
+	c, d := run("c"), run("d")
+	d.Seed = 99
+	if SameExperiment(c, d) {
+		t.Error("want Compute as the fallback when a fingerprint is missing")
 	}
 }

--- a/python/runledger/read.py
+++ b/python/runledger/read.py
@@ -267,6 +267,13 @@ def compare(
     true when the runs are the same experiment (``same_experiment``) but
     still measured differently, so nothing in the record explains the gap.
 
+    A field's ``a`` and ``b`` are ``None`` when that run did not record the
+    field, and ``""`` when it recorded an empty value. Only a param can be
+    the latter: for the scalar fields an empty string is not a meaningful
+    value, so it is reported as ``None`` (ADR 0011). Rendering the two the
+    same way loses the distinction -- ``runledger_dashboard.diff_cell``
+    shows one way to keep it.
+
     :raises RunNotFoundError: if ``a`` or ``b`` matches no recorded run. The
         message names which one -- the server distinguishes them.
     :raises LedgerUnreachableError: if the ledger cannot be reached.


### PR DESCRIPTION
Follow-up to #61, which fixed the symptom in `rlctl`. This fixes what caused
it. Three changes, in dependency order.

## 1. One source of truth for "same experiment"

`compare.Runs` recomputed `a.Compute() == b.Compute()`, while
`spread.Compute` groups by the **stored** `Fingerprint`. Two independent
answers to one question, identical only for as long as `Run.Compute` never
changes — and [ADR 0004](docs/adr/0004-fingerprint-input-is-a-versioned-contract.md)
exists because one day it will. After such a change, a record written under
the old contract would keep its stored fingerprint while being rehashed
under the new rules at read time, so `spread` would group two runs that
`compare` called different experiments. The ledger contradicting itself is
the failure ADR 0001 exists to prevent, arriving self-inflicted.

`compare` now reads the stored fingerprint when both runs carry one, and
falls back to `Compute` only for runs that have not been through a store.
Nothing observable changes today; it is what makes a future contract change
survivable.

## 2. ADR 0011: an empty string means "not recorded"

The known gap in `lineage.Run` — that `""` and an omitted key are
indistinguishable for `config_hash`, `dataset_version`, `model_version`,
`host`, `device`, `framework_version`, and `checkpoint_uri` — was headed for
pointers, a nullable schema, and a new fingerprint contract version.

That price is only worth paying if the distinction buys something, and the
question that settles it is: **is there an experiment whose `dataset_version`
is genuinely the empty string?** There is not, for any of the seven. An empty
config hash *is* no config hash; a host always has a name. `""` is not a
value competing with absence — it is a second spelling of absence, produced
by clients that serialize every key rather than omitting unset ones. This
repo's own Python client is one of them.

So the ambiguity is removed by collapsing the two spellings, not by widening
the type:

- The fields stay `string`. No pointers, no nullable columns, no migration.
- **No recorded fingerprint changes meaning.** ADR 0004 is not triggered.
- It also avoids a hazard the pointer route carried: if absence became
  identity-bearing, a client that switched from sending `""` to omitting a
  key would silently change every fingerprint it produces — making the
  fingerprint a function of how a client serializes rather than of what the
  experimenter chose.

What is genuinely given up is the ability to record "this run had an
explicitly empty dataset version." Nothing needs that, which is the premise
— but the ADR says so out loud rather than letting the change pass silently.

## 3. Params presence — the actual root cause

Params are the case where presence is real: keys are caller-defined,
`--param foo=` is expressible, and `Compute` writes only the keys present,
so `{}` and `{"foo": ""}` already fingerprint differently. `compare.Runs`
read both sides through `a.Params[k]`, which yields `""` for a missing key,
and so emitted no field at all.

`compare.Field` now carries `*string` — nil for a field the run never
recorded, a pointer to `""` for one it recorded as empty:

```
$ rlctl diff <a> <b>
different experiments (fingerprints differ)

FIELD                     KIND          A                     B
params.foo                identity      —                     ""
```

```json
{"same_experiment": false,
 "fields": [{"name": "params.foo", "kind": "identity", "a": null, "b": ""}]}
```

The "fingerprints differ, nothing rendered" branch added in #61 becomes
unreachable. It is kept and reworded as the invariant violation it now would
be, rather than deleted.

## The same conflation at a third layer

`dashboard/app.py` passed the raw values into a table, where `None` renders
as a blank cell that reads as the empty value it is not — the same mistake
as `or(s, "—")` in the CLI. Fixed with `runledger_dashboard.diff_cell`,
placed in the tested module rather than in the notebook.

## Checks

- `go test -race ./...`, `gofmt`, `go vet` clean
- `TestSchemasMatchGoTypes` kept `docs/openapi.yaml` honest — `a`/`b` are now
  documented `nullable`
- New: `TestParamAbsentIsNotParamEmpty`,
  `TestEmptyScalarFieldsReportAsAbsent`,
  `TestSameExperimentPrefersTheStoredFingerprint`,
  `TestRenderDiffDistinguishesAbsentFromEmpty`, 4 for `diff_cell`
- `make example` green; 65 Python client tests, 18 dashboard, 11 example

### One note for reviewers

`compare.Field` now carries pointers, so it is **no longer safe to compare
with `==`** — that would test pointer identity. `TestFieldOrderIsDeterministic`
was doing exactly that and now uses `reflect.DeepEqual`; the hazard is
documented on the type. I checked for other `==` uses on `Field` and found
none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
