### PR TITLE
python: device_name() must not assert a device it never observed

### DIFF
--- a/python/runledger/_provenance.py
+++ b/python/runledger/_provenance.py
@@ -27,32 +27,53 @@ def framework_version() -> str:
 
 
 def device_name() -> str:
-    """The active accelerator's name; "cpu" if a library checked and found
-    none; "" if neither library could be asked.
+    """The active accelerator's name; "cpu" if a library was asked and
+    answered "none"; "" if nothing could be asked, or the asking itself
+    failed.
 
-    ADR 0011: "" means "not recorded". Returning "cpu" when neither
-    ``torch`` nor ``jax`` imports would assert an observation this process
-    never made -- and it would be indistinguishable downstream from a run
-    that genuinely imported one of them and got told there was no
-    accelerator. Only the latter earns "cpu": at least one library
-    imported and answered, and the answer was no.
+    ADR 0011: "" means "not recorded". Returning "cpu" whenever neither
+    library imports would assert an observation this process never made.
+    The same fabrication can happen one level deeper than "did it import":
+    a library can import fine and still fail to answer -- a CUDA
+    driver/runtime mismatch is a real-world case where ``is_available()``
+    or ``get_device_name()`` raises instead of returning. That failure
+    carries no information about the device either, and is exactly the
+    case a broken-driver machine hits, so it must not read as "cpu" any
+    more than a missing import does.
+
+    "cpu" is earned only at the point a query *returns* an answer of "no
+    accelerator" -- ``torch.cuda.is_available()`` returning ``False``, or
+    ``jax.devices()`` returning empty -- not merely at import. Import
+    failure and query failure both fall through to the next library, and
+    if nothing ever returns an answer, the result is "".
     """
     observed = False
+
     try:
         import torch  # type: ignore
-
-        observed = True
-        if torch.cuda.is_available():
-            return torch.cuda.get_device_name(0)
     except Exception:
-        pass
+        torch = None  # type: ignore
+
+    if torch is not None:
+        try:
+            if torch.cuda.is_available():
+                return torch.cuda.get_device_name(0)
+            observed = True  # asked, and it answered: no CUDA device
+        except Exception:
+            pass  # asked, but the query itself failed -- no answer to trust
+
     try:
         import jax  # type: ignore
-
-        observed = True
-        devices = jax.devices()
-        if devices:
-            return str(devices[0])
     except Exception:
-        pass
+        jax = None  # type: ignore
+
+    if jax is not None:
+        try:
+            devices = jax.devices()
+            if devices:
+                return str(devices[0])
+            observed = True  # asked, and it answered: no device
+        except Exception:
+            pass  # asked, but the query itself failed -- no answer to trust
+
     return "cpu" if observed else ""

--- a/python/runledger/_provenance.py
+++ b/python/runledger/_provenance.py
@@ -27,10 +27,21 @@ def framework_version() -> str:
 
 
 def device_name() -> str:
-    """The active accelerator's name, or "cpu" if none is visible."""
+    """The active accelerator's name; "cpu" if a library checked and found
+    none; "" if neither library could be asked.
+
+    ADR 0011: "" means "not recorded". Returning "cpu" when neither
+    ``torch`` nor ``jax`` imports would assert an observation this process
+    never made -- and it would be indistinguishable downstream from a run
+    that genuinely imported one of them and got told there was no
+    accelerator. Only the latter earns "cpu": at least one library
+    imported and answered, and the answer was no.
+    """
+    observed = False
     try:
         import torch  # type: ignore
 
+        observed = True
         if torch.cuda.is_available():
             return torch.cuda.get_device_name(0)
     except Exception:
@@ -38,9 +49,10 @@ def device_name() -> str:
     try:
         import jax  # type: ignore
 
+        observed = True
         devices = jax.devices()
         if devices:
             return str(devices[0])
     except Exception:
         pass
-    return "cpu"
+    return "cpu" if observed else ""

--- a/python/tests/test_provenance.py
+++ b/python/tests/test_provenance.py
@@ -1,11 +1,17 @@
 """Tests for runledger._provenance.device_name().
 
 ADR 0011 makes "" mean "not recorded" for the scalar provenance fields, and
-device_name() is the one function that had not caught up: it returned the
-literal "cpu" whether or not any library was actually asked. These tests
-pin the two cases apart -- neither library importable ("") vs. torch
-imported and reporting no CUDA device ("cpu") -- using sys.modules
-substitution so the suite doesn't need torch or jax installed.
+device_name() is the function that had not caught up: it returned the
+literal "cpu" whether or not any library was actually asked, and -- one
+level deeper -- whether or not a library that did import ever managed to
+answer. A CUDA driver/runtime mismatch is a real case where
+`torch.cuda.is_available()` or `get_device_name()` raises instead of
+returning; that must read as "no answer", the same as torch not importing
+at all, not as a fabricated "cpu" on a machine that may well have a GPU.
+
+These tests use sys.modules substitution and MagicMock stand-ins so the
+suite doesn't need torch or jax installed, and doesn't depend on the
+machine it runs on actually having (or lacking) a GPU.
 """
 
 from __future__ import annotations
@@ -70,6 +76,48 @@ class DeviceNameTests(unittest.TestCase):
             "jax"
         ):
             self.assertEqual(_provenance.device_name(), "NVIDIA H100")
+
+    def test_is_available_raising_is_not_reported_as_cpu(self):
+        # A CUDA driver/runtime mismatch makes is_available() raise on a
+        # real GPU machine. That is a failed query, not an answer of "no
+        # device" -- reporting "cpu" here would be the exact fabrication
+        # the issue is about, just one level deeper than a missing import.
+        fake_torch = mock.MagicMock()
+        fake_torch.cuda.is_available.side_effect = RuntimeError(
+            "CUDA driver/runtime version mismatch"
+        )
+        with mock.patch.dict(sys.modules, {"torch": fake_torch}), _unimportable(
+            "jax"
+        ):
+            self.assertEqual(_provenance.device_name(), "")
+
+    def test_get_device_name_raising_after_is_available_true_is_not_cpu(self):
+        # is_available() answered True (a device exists), but the follow-up
+        # query to name it raised -- also a failed query, and also not
+        # grounds to fall back to "cpu": there is a device, it's simply
+        # unnamed, so nothing licenses "cpu" as the answer either.
+        fake_torch = mock.MagicMock()
+        fake_torch.cuda.is_available.return_value = True
+        fake_torch.cuda.get_device_name.side_effect = RuntimeError(
+            "CUDA error: no kernel image is available for execution"
+        )
+        with mock.patch.dict(sys.modules, {"torch": fake_torch}), _unimportable(
+            "jax"
+        ):
+            self.assertEqual(_provenance.device_name(), "")
+
+    def test_torch_query_failure_falls_through_to_a_working_jax(self):
+        # torch importing but failing to answer shouldn't block jax from
+        # being asked -- the two libraries are independent sources, and a
+        # failed torch query is not evidence about what jax would say.
+        fake_torch = mock.MagicMock()
+        fake_torch.cuda.is_available.side_effect = RuntimeError("driver mismatch")
+        fake_jax = mock.MagicMock()
+        fake_jax.devices.return_value = ["TPU v4"]
+        with mock.patch.dict(
+            sys.modules, {"torch": fake_torch, "jax": fake_jax}
+        ):
+            self.assertEqual(_provenance.device_name(), "TPU v4")
 
 
 if __name__ == "__main__":

--- a/python/tests/test_provenance.py
+++ b/python/tests/test_provenance.py
@@ -1,0 +1,76 @@
+"""Tests for runledger._provenance.device_name().
+
+ADR 0011 makes "" mean "not recorded" for the scalar provenance fields, and
+device_name() is the one function that had not caught up: it returned the
+literal "cpu" whether or not any library was actually asked. These tests
+pin the two cases apart -- neither library importable ("") vs. torch
+imported and reporting no CUDA device ("cpu") -- using sys.modules
+substitution so the suite doesn't need torch or jax installed.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from runledger import _provenance  # noqa: E402
+
+
+def _unimportable(name: str) -> mock._patch:
+    """Make `import <name>` raise ImportError, whether or not it's installed.
+
+    CPython's import machinery treats `sys.modules[name] is None` as a
+    standing "this name is known not to import" marker and raises
+    ImportError for it, so this forces the "could not find out" branch
+    without needing torch or jax actually absent from the test environment.
+    """
+    return mock.patch.dict(sys.modules, {name: None})
+
+
+class DeviceNameTests(unittest.TestCase):
+    def test_neither_library_importable_returns_empty_string(self):
+        with _unimportable("torch"), _unimportable("jax"):
+            self.assertEqual(_provenance.device_name(), "")
+
+    def test_torch_present_without_cuda_returns_cpu(self):
+        fake_torch = mock.MagicMock()
+        fake_torch.cuda.is_available.return_value = False
+        with mock.patch.dict(sys.modules, {"torch": fake_torch}), _unimportable(
+            "jax"
+        ):
+            self.assertEqual(_provenance.device_name(), "cpu")
+
+    def test_unobserved_and_observed_cpu_are_distinguishable(self):
+        # The whole point of the fix: these two cases must not collapse to
+        # the same string, or a caller can no longer tell "no library
+        # checked" apart from "checked, no accelerator found".
+        with _unimportable("torch"), _unimportable("jax"):
+            unobserved = _provenance.device_name()
+
+        fake_torch = mock.MagicMock()
+        fake_torch.cuda.is_available.return_value = False
+        with mock.patch.dict(sys.modules, {"torch": fake_torch}), _unimportable(
+            "jax"
+        ):
+            observed_cpu = _provenance.device_name()
+
+        self.assertNotEqual(unobserved, observed_cpu)
+        self.assertEqual(unobserved, "")
+        self.assertEqual(observed_cpu, "cpu")
+
+    def test_torch_reports_cuda_device_takes_priority(self):
+        fake_torch = mock.MagicMock()
+        fake_torch.cuda.is_available.return_value = True
+        fake_torch.cuda.get_device_name.return_value = "NVIDIA H100"
+        with mock.patch.dict(sys.modules, {"torch": fake_torch}), _unimportable(
+            "jax"
+        ):
+            self.assertEqual(_provenance.device_name(), "NVIDIA H100")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #66

## What
`device_name()` returned the literal `"cpu"` whenever neither `torch` nor
`jax` could be imported -- asserting a device it never checked. Its sibling
`framework_version()` already returns `""` for the same "could not find
out" case, and under ADR 0011 (`docs/adr/0011-empty-string-means-not-recorded.md`),
`""` is the ledger's spelling of "not recorded" for exactly this kind of
field.

## Why it matters
- `spread.provenanceDiffs` was reading "every run says cpu" as the group
  agreeing on device, hiding a real device difference between runs that
  never actually checked.
- `examples/churn/completeness.py` was reading the same "cpu" as 100%
  coverage for `device`, so it never surfaced as a blind spot -- the exact
  gap that signal exists to catch.

## Change
`device_name()` now tracks whether a library was asked **and answered**,
not merely whether it imported:
- Neither `torch` nor `jax` importable -> `""` (not recorded).
- A library imports but its query itself raises (e.g. a CUDA
  driver/runtime mismatch making `is_available()` or `get_device_name()`
  throw) -> falls through to the next library, and to `""` if nothing ever
  answers. This was found in review after the first pass: setting
  `observed = True` right after a successful `import torch` -- before the
  CUDA query ran -- meant a query failure on a real GPU machine still
  reported `"cpu"`, the same fabrication one level deeper.
- `torch` imports and `torch.cuda.is_available()` *returns* `False` ->
  still `"cpu"` -- that's a genuine, successfully-obtained answer.
- Either library's query returns an accelerator -> its name, unchanged. A
  torch query failure no longer blocks a working `jax` from answering.

Docstring updated to state which case is which and why.

## Testing
`python/tests/test_provenance.py` covers:
- neither library importable -> `""`
- torch present without CUDA -> `"cpu"`
- the two cases above are distinguishable (not collapsed to one string)
- torch reporting a CUDA device still takes priority
- `is_available()` raising -> `""`, not `"cpu"`
- `get_device_name()` raising after `is_available()` returned `True` ->
  `""`, not `"cpu"`
- a torch query failure still lets a working `jax` answer

Uses `sys.modules[name] = None` to force `ImportError` and `MagicMock`
stand-ins (including `side_effect` for the raising cases), so the suite
doesn't need torch or jax installed and doesn't depend on the test
machine's actual GPU state.

All required checks pass locally:
- `go build ./...`, `go vet ./...`, `go test -race ./...`
- `test -z "$(gofmt -l .)"`
- `python3 -m unittest discover -s python/tests`
- `python3 -m unittest discover -s dashboard/tests`
- `python3 -m unittest discover -s examples/churn`

Only touched `python/runledger/_provenance.py` and
`python/tests/test_provenance.py`, per the issue's scope.