### PR TITLE
Position run-ledger against metric trackers; document and address the unattributable/dataset_version bound

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,20 @@ Nondeterminism, an unpinned dependency, different hardware, a data race. The
 ledger cannot tell you which — but it can tell you that the explanation is not in
 the record, which is the point at which you go looking.
 
+That verdict is only as trustworthy as the identity fields feeding it.
+`dataset_version`, `model_version`, and `config_hash` are free strings the
+caller supplies — the server hashes them into the fingerprint exactly as
+given, and has no way to check that a run labelled `"v1"` saw the same bytes
+as another run labelled `"v1"`; it never sees the dataset, the weights, or
+the config file, only the label. So before chasing nondeterminism, rule out
+the cheaper explanation first: a relabeled or re-exported dataset under an
+unchanged label produces the exact same signature as real nondeterminism —
+same fingerprint, different metrics, `unattributable`. The explanation was
+in the record; the record was just wrong. See
+[`runledger.hash_dataset()`](python/README.md#deriving-dataset_version) if
+you want `dataset_version` derived from the data's own bytes instead of
+typed by hand.
+
 ## Try it
 
 ```bash
@@ -223,7 +237,7 @@ import runledger
 with runledger.Run.start(project="demo", seed=1, params={"lr": 3e-4}) as run:
     for step in range(steps):
         loss = train_step()
-        run.log_metric("loss", loss)
+        run.log_metric("loss", loss)  # overwrites -- only the final value is kept
 ```
 
 It captures the same git context `rlctl record` does — commit, dirty flag —
@@ -237,6 +251,19 @@ worked example (wrap a loop, raise partway through, see the run recorded as
 `failed` with the metrics it got to) and why the client makes exactly one
 HTTP call, at the end, rather than one at each end of the run
 ([ADR 0005](docs/adr/0005-python-client-writes-once-at-the-end.md)).
+
+**This is not a metric tracker, and does not try to be one.** `log_metric`
+overwrites — calling it every step, as above, keeps only the value from the
+last call for a given name, not a curve. run-ledger records what a run
+**was**: identity plus the final outcome, for deciding whether two runs
+were the same experiment. A tracker (W&B, MLflow, TensorBoard) records how a
+run **went**: the step-by-step curve, for watching training happen. Most
+setups want both, pointed at the same run — log the curve to a tracker,
+record the fingerprint and final metrics here. The boundary is what each
+side needs to answer its own question: a fingerprint only has to include
+what must match for two runs to count as the same experiment, and everything
+you want to watch move belongs on a dashboard instead, precisely because the
+fingerprint must not be sensitive to it.
 
 ```bash
 pip install -e ./python
@@ -314,6 +341,15 @@ have to be true to revisit each one — lives in [`docs/adr/`](docs/adr/).
   sending `""` to omitting a key from silently changing every fingerprint
   it produces. `params` is exempt — presence there is real and already
   hashed. ([ADR 0011](docs/adr/0011-empty-string-means-not-recorded.md))
+- **`unattributable` assumes the identity strings are honest.** `dataset_version`,
+  `model_version`, and `config_hash` are free strings the caller supplies; the
+  server has no way to verify that two runs labelled the same value actually
+  saw the same bytes, so a mislabelled or re-exported dataset produces the
+  identical signature as real nondeterminism — same fingerprint, different
+  metrics. Rule that out first. `runledger.hash_dataset()` derives
+  `dataset_version` from a dataset's own content instead of a typed label,
+  for callers who want that check to be possible — opt-in, client-side only,
+  no fingerprint contract change.
 - **A comparison reads the stored fingerprint, not a fresh one.** Recomputing
   it in `compare` gave a second, independent answer to the question
   `spread` already answers from the stored value. The two agree only while

--- a/python/README.md
+++ b/python/README.md
@@ -21,8 +21,19 @@ import runledger
 with runledger.Run.start(project="demo", seed=1, params={"lr": 3e-4}) as run:
     for step in range(steps):
         loss = train_step()
-        run.log_metric("loss", loss)
+        run.log_metric("loss", loss)  # overwrites -- only the final value is kept
 ```
+
+**This is not a metric tracker.** `Run` stores what a run **was** — identity
+plus a final outcome, for deciding whether two runs were the same
+experiment — not how a run **went**. `log_metric` overwrites, so calling it
+every step, as above, is fine to write but does not build a curve; the
+record keeps whichever call happened last for each name. If you want the
+curve, log it to a tracker (W&B, MLflow, TensorBoard) the same step you call
+`log_metric` here — most training setups want both, and they answer
+different questions: a metric belongs in the fingerprint's neighborhood only
+if it is the final number you'd use to decide whether this run reproduced;
+everything you want to watch move over time belongs on a dashboard instead.
 
 > **Run this from inside a git checkout.** `Run.start()` captures the commit
 > before the `with` body runs and raises `runledger.NoGitCommitError` if there
@@ -295,6 +306,43 @@ are captured automatically — `framework_version` becomes e.g. `"torch
 2.4.0"`, and `device` becomes the CUDA device name or JAX device string.
 Neither is required; a run with neither installed records `device="cpu"`
 and an empty `framework_version`.
+
+## Deriving `dataset_version`
+
+`dataset_version` is a free string — the server hashes it into the
+fingerprint exactly as given and has no way to check that two runs labelled
+the same string actually saw the same bytes (see the root README's note on
+what that costs the `unattributable` verdict). `hash_dataset()` lets a
+caller who wants the label to mean something derive it from the data
+instead of typing it:
+
+```python
+import runledger
+
+digest = runledger.hash_dataset("data/train")  # hex sha256, deterministic
+
+with runledger.Run.start(project="demo", seed=1, dataset_version=digest) as run:
+    ...
+```
+
+It hashes a manifest of `(relative path, size, content digest)` per file,
+sorted by path — so the result does not depend on directory listing order,
+the machine it runs on, or where the tree happens to live on disk.
+Deliberately excluded: absolute paths, mtimes, and permissions, none of
+which are the data and all of which change on a plain copy or checkout
+without the bytes changing. An empty directory hashes to a fixed, defined
+value rather than raising; a missing path raises `FileNotFoundError`; a
+symlink anywhere in the tree raises `SymlinkNotSupportedError` rather than
+guessing whether the manifest should describe the link or whatever it
+currently resolves to. Files are hashed streaming, in chunks (`chunk_size=`,
+default 1 MiB), so a multi-gigabyte file never has to fit in memory at once.
+
+This is entirely client-side and opt-in: the server goes on storing
+whatever string it is given as `dataset_version`, unchanged. Nothing about
+the wire schema or the fingerprint contract
+([ADR 0004](../docs/adr/0004-fingerprint-input-is-a-versioned-contract.md))
+is affected — `hash_dataset()` just gives a caller a principled way to
+produce that string instead of typing `"v1"` by hand.
 
 ## Reference
 

--- a/python/runledger/__init__.py
+++ b/python/runledger/__init__.py
@@ -34,6 +34,15 @@ purpose, and lives in ``replay``:
 
 or from a shell: ``python -m runledger.replay``. See ``replay.py`` for why
 this is safe to interrupt and re-run.
+
+``dataset_version`` is a free string the ledger never verifies; a caller who
+wants it to mean something can derive it from the data instead of typing it:
+
+    digest = runledger.hash_dataset("data/train")
+    with runledger.Run.start(project="demo", dataset_version=digest) as run:
+        ...
+
+Opt-in and entirely client-side -- see ``content_hash.py``.
 """
 
 from .read import (
@@ -46,6 +55,7 @@ from .read import (
     spread,
 )
 from ._run import DirtyTreeError, NoGitCommitError, Run, UnreconstructibleRunError
+from .content_hash import SymlinkNotSupportedError, hash_dataset
 from .replay import ReplayResult, replay_spool
 
 __all__ = [
@@ -65,6 +75,9 @@ __all__ = [
     # recovering a spool
     "replay_spool",
     "ReplayResult",
+    # deriving dataset_version
+    "hash_dataset",
+    "SymlinkNotSupportedError",
 ]
 
 __version__ = "0.1.0"

--- a/python/runledger/content_hash.py
+++ b/python/runledger/content_hash.py
@@ -1,0 +1,177 @@
+"""hash_dataset(): content-address a dataset so dataset_version can be derived.
+
+Design note -- why this exists
+-------------------------------
+``dataset_version`` (and ``model_version``, ``config_hash``) are free strings
+a caller supplies; the server hashes them into the fingerprint exactly as
+given and has no way to check that a run labelled ``"v1"`` saw the same bytes
+as another run labelled ``"v1"`` -- it never sees the dataset at all, only
+the label. That is not a gap the server can close: ADR 0001's reasoning
+against trusting a caller-asserted *run* fingerprint does not extend here,
+because the caller is the only party who can observe the dataset in the
+first place. See the root README's note on the ``unattributable`` verdict
+for what this costs -- a relabeled or re-exported dataset under an unchanged
+label produces the identical signature as real nondeterminism.
+
+``hash_dataset()`` gives a caller who wants the label to mean something a way
+to derive it instead of typing it: point it at a file or directory and get
+back a hash of its content, so two runs only share a ``dataset_version`` when
+they provably saw the same bytes, and relabeling a snapshot without touching
+its contents does not change the hash.
+
+This is opt-in and entirely client-side. Nothing here touches the wire
+schema, ``internal/lineage``, or the fingerprint contract in ADR 0004 -- the
+server goes on storing whatever string it is given, unchanged. Calling this
+is a choice a caller makes instead of typing ``dataset_version="v1"`` by
+hand; nothing in the client or the server requires it.
+
+Design note -- what is in the manifest, and what is deliberately not
+-----------------------------------------------------------------------
+The hash is over a manifest of ``(relative path, size, content digest)`` per
+file, sorted by path. Specifically excluded, on purpose:
+
+- **Absolute paths.** The same tree checked out to two different locations,
+  or on two different machines, must hash the same -- only the path
+  *relative to the root being hashed* goes into the manifest.
+- **mtimes, permissions, ownership.** These change on copy, checkout, or a
+  bare ``chmod`` without the bytes changing, and would make the hash flap
+  for reasons that have nothing to do with the data.
+- **Directory entries themselves.** An empty directory contributes nothing
+  to the manifest -- only files carry content, so a tree that is nothing but
+  empty directories hashes the same as a genuinely empty one.
+- **Symlinks.** Resolving one is ambiguous input for a content hash: does
+  the manifest describe the link or its target, and what happens when the
+  target lives outside the tree, differs in size on another machine, or is
+  simply broken there? Rather than guess, ``hash_dataset()`` refuses --
+  see :class:`SymlinkNotSupportedError`.
+
+File content is hashed streaming, ``chunk_size`` bytes at a time, so a
+multi-gigabyte file is never read into memory whole.
+
+Manifest entries are sorted by relative path before hashing, so the walk
+order ``os.walk`` happens to produce on a given filesystem (which is
+unspecified, and differs across platforms) cannot change the result -- see
+``sorted(...)`` in :func:`hash_dataset` below.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from pathlib import Path
+from typing import Iterator, Tuple, Union
+
+PathLike = Union[str, "os.PathLike[str]"]
+
+DEFAULT_CHUNK_SIZE = 1 << 20  # 1 MiB: large enough to be efficient, small
+# enough that hashing a multi-gigabyte file never holds more than one chunk
+# in memory at a time.
+
+# Folded into every hash so a future change to what the manifest contains,
+# or how entries are delimited, is never silently indistinguishable from a
+# change in the data itself -- the same reason ADR 0004 versions the
+# server's fingerprint input. There is no migration path implied by this:
+# a caller who upgrades and gets a different digest for the same bytes was
+# always going to, since the digest was never a promise to stay stable
+# across releases of this helper -- only across machines and directory
+# listing orders for one given release.
+_MANIFEST_VERSION = b"runledger-dataset-hash-v1"
+
+
+class SymlinkNotSupportedError(ValueError):
+    """``hash_dataset()`` found a symlink and refuses to guess what it means.
+
+    A symlink is exactly the case where "the data" is ambiguous -- the link
+    itself, or whatever it currently resolves to, possibly outside the tree
+    being hashed and possibly not even present on another machine. Resolve
+    it to a real file, copy the target into the tree, or exclude the path,
+    whichever actually reflects what the dataset is -- then hash that.
+    """
+
+
+def hash_dataset(path: PathLike, *, chunk_size: int = DEFAULT_CHUNK_SIZE) -> str:
+    """Content-addresses a file or directory tree; returns a hex digest.
+
+    Deterministic across machines and across runs on the same machine: two
+    trees with the same files (same relative paths, same bytes) hash the
+    same regardless of where they live on disk, what order the filesystem
+    happens to list them in, or what their mtimes/permissions are. Two
+    trees that differ in any file's content, size, name, or relative
+    location hash differently.
+
+    An empty directory hashes to a fixed, defined value (the manifest is
+    simply empty) rather than raising -- "the dataset has no files" is a
+    legitimate, representable state, distinct from "the path does not
+    exist".
+
+    :param path: File or directory to hash.
+    :param chunk_size: Bytes read per chunk while hashing file content.
+        The default (1 MiB) bounds peak memory regardless of file size;
+        raise it for a modest speed gain on very large files at the cost of
+        a larger read buffer.
+    :raises FileNotFoundError: ``path`` does not exist.
+    :raises SymlinkNotSupportedError: a symlink -- ``path`` itself, or
+        anything under it -- was found.
+    """
+    root = Path(path)
+    if root.is_symlink():
+        raise SymlinkNotSupportedError(str(root))
+    if not root.exists():
+        raise FileNotFoundError(f"hash_dataset: no such path: {path}")
+
+    manifest = hashlib.sha256()
+    manifest.update(_MANIFEST_VERSION)
+
+    # sorted() forces the whole generator to run before hashing starts, so
+    # every file is hashed and its (path, size, digest) known before the
+    # manifest order is fixed -- entries then go into the running hash in
+    # relative-path order, independent of the filesystem's own walk order.
+    for rel, size, digest in sorted(_entries(root, chunk_size=chunk_size)):
+        rel_bytes = rel.encode("utf-8")
+        # Length-prefixed so ("ab", "c...") and ("a", "bc...") cannot
+        # collide by simple concatenation -- the same reasoning
+        # internal/lineage's Compute uses for the server-side fingerprint
+        # (see the root README's "Hashed fields are length-prefixed" note).
+        manifest.update(len(rel_bytes).to_bytes(8, "big"))
+        manifest.update(rel_bytes)
+        manifest.update(size.to_bytes(8, "big"))
+        manifest.update(digest.encode("ascii"))
+
+    return manifest.hexdigest()
+
+
+def _entries(root: Path, *, chunk_size: int) -> Iterator[Tuple[str, int, str]]:
+    """Yields (relative posix path, size, hex digest) for every file under root.
+
+    ``root`` itself may be a single file, so a caller can content-address
+    one file (e.g. a single parquet snapshot) the same way as a directory.
+    """
+    if root.is_file():
+        yield _hash_file(root, root.name, chunk_size)
+        return
+
+    # followlinks=False so os.walk never descends into a symlinked
+    # directory; that alone would silently drop everything under it from
+    # the manifest, which is exactly the kind of quiet omission this
+    # function refuses to make -- the explicit checks below turn that
+    # silent skip into a raised SymlinkNotSupportedError instead.
+    for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
+        for name in dirnames:
+            if (Path(dirpath) / name).is_symlink():
+                raise SymlinkNotSupportedError(str(Path(dirpath) / name))
+        for name in filenames:
+            full = Path(dirpath) / name
+            if full.is_symlink():
+                raise SymlinkNotSupportedError(str(full))
+            rel = full.relative_to(root).as_posix()
+            yield _hash_file(full, rel, chunk_size)
+
+
+def _hash_file(full: Path, rel: str, chunk_size: int) -> Tuple[str, int, str]:
+    h = hashlib.sha256()
+    size = 0
+    with open(full, "rb") as fh:
+        for chunk in iter(lambda: fh.read(chunk_size), b""):
+            size += len(chunk)
+            h.update(chunk)
+    return (rel, size, h.hexdigest())

--- a/python/tests/test_content_hash.py
+++ b/python/tests/test_content_hash.py
@@ -1,0 +1,222 @@
+"""Tests for runledger.hash_dataset().
+
+All against real tmp directories (tempfile.mkdtemp), not mocks -- the whole
+point of this helper is what actually happens on a real filesystem: walk
+order, path separators, and where a symlink shows up.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import runledger  # noqa: E402
+from runledger.content_hash import hash_dataset, SymlinkNotSupportedError  # noqa: E402
+
+
+def _write(root: str, rel: str, content: bytes) -> None:
+    full = os.path.join(root, rel)
+    os.makedirs(os.path.dirname(full), exist_ok=True)
+    with open(full, "wb") as fh:
+        fh.write(content)
+
+
+class HashDatasetTest(unittest.TestCase):
+    def setUp(self):
+        self._tmpdirs = []
+
+    def tearDown(self):
+        for d in self._tmpdirs:
+            # ignore_errors: a test that raises partway through symlink
+            # setup can leave a dangling link tempfile's own cleanup trips
+            # over on some platforms; the tmp dir itself is disposable.
+            import shutil
+
+            shutil.rmtree(d, ignore_errors=True)
+
+    def _mkdir(self) -> str:
+        d = tempfile.mkdtemp(prefix="runledger-hash-test-")
+        self._tmpdirs.append(d)
+        return d
+
+    def test_exported_from_top_level_package(self):
+        # hash_dataset and its error are meant to be reached as
+        # runledger.hash_dataset(...), not by importing the submodule.
+        self.assertIs(runledger.hash_dataset, hash_dataset)
+        self.assertIs(runledger.SymlinkNotSupportedError, SymlinkNotSupportedError)
+
+    def test_same_content_same_hash(self):
+        a = self._mkdir()
+        b = self._mkdir()
+        for root in (a, b):
+            _write(root, "images/cat.png", b"cat-bytes")
+            _write(root, "labels.csv", b"cat,1\ndog,0\n")
+
+        self.assertEqual(hash_dataset(a), hash_dataset(b))
+
+    def test_different_content_different_hash(self):
+        a = self._mkdir()
+        b = self._mkdir()
+        _write(a, "labels.csv", b"cat,1\ndog,0\n")
+        _write(b, "labels.csv", b"cat,1\ndog,1\n")  # one byte differs
+
+        self.assertNotEqual(hash_dataset(a), hash_dataset(b))
+
+    def test_different_size_different_hash(self):
+        a = self._mkdir()
+        b = self._mkdir()
+        _write(a, "data.bin", b"x" * 100)
+        _write(b, "data.bin", b"x" * 101)
+
+        self.assertNotEqual(hash_dataset(a), hash_dataset(b))
+
+    def test_file_order_irrelevant(self):
+        # os.walk's per-directory listing order is filesystem-dependent
+        # and not something a test can force directly, so this asserts
+        # the property the implementation is supposed to guarantee
+        # (sorting before hashing) by building two trees whose files are
+        # written in opposite order and checking they still agree.
+        a = self._mkdir()
+        b = self._mkdir()
+        for rel, content in [("a.txt", b"1"), ("m.txt", b"2"), ("z.txt", b"3")]:
+            _write(a, rel, content)
+        for rel, content in reversed(
+            [("a.txt", b"1"), ("m.txt", b"2"), ("z.txt", b"3")]
+        ):
+            _write(b, rel, content)
+
+        self.assertEqual(hash_dataset(a), hash_dataset(b))
+
+    def test_path_location_irrelevant(self):
+        # The same tree, nested at different depths / parent names, must
+        # hash the same -- only paths relative to the hashed root count.
+        a = self._mkdir()
+        nested = os.path.join(self._mkdir(), "some", "deeper", "parent")
+        os.makedirs(nested)
+        for root in (a, nested):
+            _write(root, "train/part-0.parquet", b"parquet-bytes")
+            _write(root, "README.txt", b"about this dataset")
+
+        self.assertEqual(hash_dataset(a), hash_dataset(nested))
+
+    def test_renaming_a_file_changes_the_hash(self):
+        # A relative path is part of the manifest, so renaming a file is a
+        # real change to what the dataset is, not noise to ignore.
+        a = self._mkdir()
+        b = self._mkdir()
+        _write(a, "train.csv", b"same-bytes")
+        _write(b, "training.csv", b"same-bytes")
+
+        self.assertNotEqual(hash_dataset(a), hash_dataset(b))
+
+    def test_nested_directories(self):
+        a = self._mkdir()
+        _write(a, "train/images/0001.png", b"one")
+        _write(a, "train/images/0002.png", b"two")
+        _write(a, "train/labels.csv", b"labels")
+        _write(a, "val/images/0001.png", b"three")
+
+        # Just needs to run without raising and be stable across calls.
+        self.assertEqual(hash_dataset(a), hash_dataset(a))
+
+    def test_empty_directory_hashes_to_a_fixed_defined_value(self):
+        a = self._mkdir()
+        b = self._mkdir()
+
+        digest = hash_dataset(a)
+        self.assertEqual(len(digest), 64)  # hex sha256
+        self.assertEqual(digest, hash_dataset(b))
+
+    def test_directory_of_only_empty_subdirectories_matches_empty(self):
+        a = self._mkdir()
+        os.makedirs(os.path.join(a, "empty", "also-empty"))
+        b = self._mkdir()
+
+        self.assertEqual(hash_dataset(a), hash_dataset(b))
+
+    def test_missing_path_raises_file_not_found(self):
+        a = self._mkdir()
+        with self.assertRaises(FileNotFoundError):
+            hash_dataset(os.path.join(a, "does-not-exist"))
+
+    def test_symlinked_file_raises(self):
+        a = self._mkdir()
+        _write(a, "real.bin", b"content")
+        link = os.path.join(a, "link.bin")
+        try:
+            os.symlink(os.path.join(a, "real.bin"), link)
+        except (OSError, NotImplementedError):
+            self.skipTest("symlinks not supported on this filesystem/platform")
+
+        with self.assertRaises(SymlinkNotSupportedError):
+            hash_dataset(a)
+
+    def test_symlinked_directory_raises(self):
+        a = self._mkdir()
+        target = self._mkdir()
+        _write(target, "file.bin", b"content")
+        link = os.path.join(a, "link-dir")
+        try:
+            os.symlink(target, link, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            self.skipTest("symlinks not supported on this filesystem/platform")
+
+        with self.assertRaises(SymlinkNotSupportedError):
+            hash_dataset(a)
+
+    def test_root_itself_a_symlink_raises(self):
+        target = self._mkdir()
+        _write(target, "file.bin", b"content")
+        parent = self._mkdir()
+        link = os.path.join(parent, "link-root")
+        try:
+            os.symlink(target, link, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            self.skipTest("symlinks not supported on this filesystem/platform")
+
+        with self.assertRaises(SymlinkNotSupportedError):
+            hash_dataset(link)
+
+    def test_single_file_path(self):
+        a = self._mkdir()
+        _write(a, "only.bin", b"just one file")
+
+        digest = hash_dataset(os.path.join(a, "only.bin"))
+        self.assertEqual(len(digest), 64)
+
+    def test_single_file_matches_directory_containing_only_that_file(self):
+        a = self._mkdir()
+        _write(a, "only.bin", b"just one file")
+        b = self._mkdir()
+        _write(b, "only.bin", b"just one file")
+
+        self.assertEqual(hash_dataset(os.path.join(a, "only.bin")), hash_dataset(b))
+
+    def test_large_file_is_streamed_not_read_whole(self):
+        # Exercise the chunked read path with a small chunk_size so this
+        # test doesn't need an actually enormous file to prove streaming
+        # is happening, then check two files whose bytes differ only past
+        # the first chunk are still told apart.
+        a = self._mkdir()
+        b = self._mkdir()
+        _write(a, "big.bin", b"x" * 10_000 + b"A")
+        _write(b, "big.bin", b"x" * 10_000 + b"B")
+
+        self.assertNotEqual(
+            hash_dataset(a, chunk_size=64), hash_dataset(b, chunk_size=64)
+        )
+        # And chunk_size is purely a performance knob -- it must not affect
+        # the result for identical content.
+        _write(a, "same.bin", b"y" * 5_000)
+        _write(b, "same.bin", b"y" * 5_000)
+        self.assertEqual(
+            hash_dataset(a, chunk_size=1), hash_dataset(a, chunk_size=1 << 20)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Combines #69 and #70 since both edit `README.md` and would otherwise conflict.

**#70 (documentation only).** `Run.log_metric` overwrites -- a run stores a final value, not a curve. That's correct and intentional, but the README's Python example calls it inside a training loop, which reads like step-wise logging. This PR:
- Comments the overwrite semantics at the call site in both `README.md` and `python/README.md`.
- States the relationship explicitly: run-ledger records what a run **was**; a metric tracker records how it **went**. Most users want both.
- Adds a line on where the boundary sits: what belongs in a fingerprint vs. what belongs on a dashboard.

**#69, level 1 (documentation).** `dataset_version`, `model_version`, and `config_hash` are free strings the caller supplies, hashed into the fingerprint as-is. The server cannot verify that two runs labelled the same value saw the same bytes, so a mislabelled or re-exported dataset produces the identical signature as real nondeterminism -- same fingerprint, different metrics, `unattributable`. This bound is now documented plainly in `README.md`, both in the narrative "The idea" section and the "Decisions worth knowing" list: a mislabelled dataset is the first explanation to rule out before hunting nondeterminism.

**#69, level 2 (code).** Adds `runledger.hash_dataset()`, an opt-in, client-side helper (`python/runledger/content_hash.py`) that content-addresses a file or directory so `dataset_version` can be *derived* instead of typed:
- Hashes a manifest of `(relative path, size, content digest)` per file, sorted by path -- deterministic across machines and directory-listing order (no absolute paths, mtimes, or permissions in the hash, since none of those are the data).
- Handles the obvious edge cases deliberately: an empty directory (a fixed, defined hash, not an error), a missing path (`FileNotFoundError`), a symlink anywhere in the tree (`SymlinkNotSupportedError` -- resolving one is ambiguous input for a content hash), and a very large file (streamed in chunks, never read whole).
- No server or wire-schema change: the server keeps treating `dataset_version` as an opaque string. Purely opt-in.
- Exported from `runledger` (`python/runledger/__init__.py`) and documented in `python/README.md` under "Deriving `dataset_version`".

## Test plan

- [x] `go build ./... && go vet ./... && go test -race ./...`
- [x] `test -z "$(gofmt -l .)"`
- [x] `python3 -m unittest discover -s python/tests` (82 tests, including 17 new ones in `test_content_hash.py`: same-content/same-hash, different-content/different-hash, file-order irrelevance, path-location irrelevance, renaming changes the hash, empty directory, missing path, symlinked file/dir/root, single-file path, large-file streaming)
- [x] `python3 -m unittest discover -s dashboard/tests`
- [x] `python3 -m unittest discover -s examples/churn`

Fixes #69
Fixes #70

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>