### PR TITLE
Filter /v1/fingerprints by status so an in-flight run cannot pollute a group's spread

### DIFF
--- a/docs/adr/0012-spread-excludes-in-flight-runs-unconditionally.md
+++ b/docs/adr/0012-spread-excludes-in-flight-runs-unconditionally.md
@@ -1,0 +1,143 @@
+# ADR 0012: Spread excludes in-flight runs unconditionally, and reports their count instead
+
+Status: Accepted
+Date: 2026-08-29
+
+> **`spread.One` and `spread.Compute` summarize only terminal
+> (`succeeded`/`failed`/`cancelled`) runs, with no query parameter or flag
+> to see it any other way.** A fingerprint's in-flight (`created`/`running`)
+> runs are not silently dropped, though: `spread.Group` gains `InFlight
+> int`, the count of them, reported beside the terminal-only `Count`. `GET
+> /v1/fingerprints/{fingerprint}` stops 404ing for a fingerprint whose only
+> runs are in-flight, since that fingerprint does exist — it just has
+> nothing measured yet — and now says so with `count: 0, no_repeats: true,
+> in_flight: N` instead of pretending not to have heard of it.
+
+## Context
+
+ADR 0005's "Revisited" section named this precisely: `spreadList` and
+`spreadOne` (`internal/api/api.go`) handed every run for a project or
+fingerprint to `spread.Compute`/`spread.One` without regard to `Status`, so
+a `running` record's mid-training metric was counted as a *repeat
+measurement*. Its half-finished loss widened the group's spread and could
+rank that fingerprint top of "which experiments reproduce worst" — a false
+positive on the one claim this ledger exists to make (same fingerprint,
+different metrics, therefore something affecting the result went
+unrecorded), produced by a run that had simply not finished yet.
+
+Issue #23 fixed the first half of this already (`31f5199`): both handlers
+filter to `lineage.Terminal` runs before computing spread, and a
+fingerprint with zero terminal runs 404s. That much is correct and this
+record does not reopen it. What #23 left undone, and issue #65 asks for, is
+the second half: an in-flight run is excluded from the *numbers*, but it
+still exists, and a caller staring at `count: 3` with no way to tell "and a
+4th run is still going" is missing something real. `rlctl` polling a
+fingerprint mid-sweep, or a dashboard rendering it, cannot distinguish "3
+runs, done" from "3 finished, more coming" without this.
+
+Two design questions had to be settled before writing the code:
+
+1. Should the filter be unconditional, or should a caller be able to opt
+   into (or out of) seeing non-terminal runs in the numbers?
+2. Where does the terminal/in-flight split happen, given `spread.One` is
+   called with runs already fetched for one fingerprint
+   (`Store.List(Query{Fingerprint: fp})`), and `spread.Compute` groups a
+   wider listing (`Store.List(Query{Project: p})`) and calls `One` per
+   group internally? Both have to agree, and "both have to agree" is
+   exactly the kind of requirement that drifts if it is satisfied by two
+   independent call sites remembering the same rule.
+
+## Decision
+
+### No opt-out, no query parameter
+
+`spread.One` and `spread.Compute` always exclude non-terminal runs from
+`Count`, `Metrics`, `Provenance`, and `RunIDs`. There is no
+`include_in_flight=true` or similar to ask for the old, unsafe reading.
+
+The alternative — a query parameter defaulting to the safe (terminal-only)
+behavior, with an explicit opt-in to include everything — was rejected.
+Issue #65 was explicit that whichever way this went, the default had to be
+the safe one, since the unsafe reading is what produces the false positive.
+Once the default is safe, the only thing an opt-in parameter would add is a
+way to *deliberately* reproduce the false positive. Nothing in this ledger
+needs that: a running run's metric is not a competing valid interpretation
+of "the group's spread" that some caller might legitimately prefer, the way
+`min_runs` genuinely does need to be adjustable (deciding what counts as
+"a repeat" is a real, disputable threshold). It is a category of data —
+unfinished measurements — that never belongs in a finished-measurement
+statistic, so there is no request that opt-in would serve honestly. Adding
+one anyway would mean a hazard this ADR exists to close is still one query
+parameter away, waiting for a future caller who does not know why it is
+dangerous.
+
+`InFlight` covers the actual reason someone would have reached for a
+"show me the in-flight ones too" flag: visibility into what is still
+running. It gives that without also reopening the numbers.
+
+### The split lives in `spread.One`, once
+
+Both handlers now pass unfiltered runs (of any status) straight to
+`spread.Compute`/`spread.One`. The terminal/in-flight split happens inside
+`One`, and `Compute` calls `One` once per fingerprint group internally
+(unchanged from before this record). That means `spreadList` and
+`spreadOne` cannot disagree on the filter by construction — there is
+exactly one place status is inspected, not two call sites each expected to
+remember to pre-filter before calling in. Before this change,
+`internal/api/api.go` had its own `terminalRuns` helper that both handlers
+called before handing runs to `spread`; that duplicated the same status
+check the `spread` package now owns, immediately outside the boundary of
+what `spread`'s own tests can verify. Moving it inside `spread` means the
+tests in `internal/spread/spread_test.go` — not just
+`internal/api/api_test.go` — pin the exclusion and the count.
+
+### `GET /fingerprints/{fingerprint}` 404s only when no run at all carries the fingerprint
+
+`spreadOne` previously 404d whenever the terminal-filtered run list was
+empty, which included the case of a fingerprint that exists only as
+in-flight runs (issue #23's second case, `TestFingerprintOneAllNonTerminalIs404`
+prior to this change). That reading conflicts with `GET /v1/fingerprints`
+itself: a `min_runs=0` (or `1`) request already lists a fingerprint the
+moment `spread.Compute` produces a group for it, and a group now exists
+for any fingerprint with at least one run of any status. Leaving the item
+endpoint 404ing for that same fingerprint would be exactly the "two
+disagreeing notions of the fingerprints" the collection endpoint's own
+`min_runs` doc comment already treats as a bug to avoid — it would just be
+reintroducing it at a different boundary (terminal-only existence) instead
+of the one already fixed (repeat-only existence).
+
+`spreadOne` now 404s only when `Store.List(Query{Fingerprint: fp})` returns
+no runs at all. A fingerprint with only in-flight runs returns 200 with
+`count: 0, no_repeats: true, in_flight: N` — genuinely nothing measured
+yet, stated as such, rather than reported as though the fingerprint were
+unknown to the store.
+
+## Consequences
+
+- `spread.Group` gains `in_flight`, a required field in the OpenAPI
+  `SpreadGroup` schema (`docs/openapi.yaml`) and checked by
+  `TestSchemasMatchGoTypes`.
+- A group's `run_ids` and `count` describe terminal runs only; an in-flight
+  run is visible solely via `in_flight`, never by run ID. Nothing today
+  needs to know *which* run is still going from this endpoint — `GET
+  /v1/runs?fingerprint=...` already answers that with full records,
+  status included.
+- `GET /v1/fingerprints/{fingerprint}` for a fingerprint with only in-flight
+  runs changes from 404 to 200 (`TestFingerprintOneAllInFlightIsNoRepeatsNotNotFound`
+  supersedes the old `TestFingerprintOneAllNonTerminalIs404`). 404 is now
+  reserved for a fingerprint no stored run carries at all.
+- `min_runs` at `GET /v1/fingerprints` continues to compare against the
+  terminal-only `Count`, unchanged: a fingerprint with one finished run and
+  three still running does not pass `min_runs=2` on runs that have not
+  produced a measurement.
+- Nothing changes for a project where every run finishes before the next
+  one starts — the default behavior these endpoints already had for that
+  case is exactly what this record keeps.
+
+Revisiting the "no opt-out" half of this decision would need a caller with
+a legitimate reason to see an in-flight run's metric folded into a
+finished-run statistic. Debugging is not that reason: `GET
+/v1/runs?fingerprint=...` already returns every run, in-flight included,
+with its own status and metrics intact — nothing is hidden, only kept out
+of one specific aggregate that exists to answer a narrower question than
+"what happened."

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -23,6 +23,7 @@ section is a summary of these; this folder is the account.
 | [0009](0009-url-path-versioning-for-the-http-api.md) | URL path versioning (`/v1`) for the HTTP API, excluding health/readiness/metrics | Accepted |
 | [0010](0010-comparisons-is-a-resource-not-a-verb.md) | `/comparisons` is a resource, not a verb | Accepted |
 | [0011](0011-empty-string-means-not-recorded.md) | An empty string means "not recorded" | Accepted |
+| [0012](0012-spread-excludes-in-flight-runs-unconditionally.md) | Spread excludes in-flight runs unconditionally, and reports their count instead | Accepted |
 
 ## Adding a record
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -359,8 +359,8 @@ paths:
         rather than silently ignored. Only terminal runs (succeeded, failed,
         cancelled) count toward a fingerprint's group or its min_runs
         threshold -- a created or running run has not produced a finished
-        measurement yet, so it is excluded rather than being counted as a
-        repeat.
+        measurement yet, so it does not count as a repeat, but it is not
+        dropped either: it is reported on the group's in_flight count.
       security:
         - bearerAuth: []
         - {}
@@ -437,9 +437,13 @@ paths:
       responses:
         "200":
           description: >
-            The spread group for this fingerprint, including no_repeats for
-            a lone run. Only terminal runs (succeeded, failed, cancelled)
-            count -- a created or running run is not a finished measurement.
+            The spread group for this fingerprint, including no_repeats when
+            fewer than two terminal runs share it -- which includes a
+            fingerprint whose only runs are still created or running:
+            count 0, no_repeats true, in_flight set. Only terminal runs
+            (succeeded, failed, cancelled) count toward count, metrics, and
+            provenance; a created or running run is not a finished
+            measurement, so it is reported only via in_flight.
           content:
             application/json:
               schema:
@@ -452,9 +456,11 @@ paths:
                 $ref: "#/components/schemas/Error"
         "404":
           description: >
-            No finished (terminal-status) run recorded with this
-            fingerprint -- including when every run recorded under it is
-            still created or running.
+            No run at all -- of any status -- recorded with this
+            fingerprint. A fingerprint that has at least one run, even a
+            still-running one with no finished measurement yet, is a 200
+            (see above), for consistency with GET /v1/fingerprints's
+            min_runs=0 listing it.
           content:
             application/json:
               schema:
@@ -834,7 +840,7 @@ components:
 
     SpreadGroup:
       type: object
-      required: [fingerprint, run_ids, count, no_repeats]
+      required: [fingerprint, run_ids, count, no_repeats, in_flight]
       properties:
         fingerprint:
           type: string
@@ -842,11 +848,22 @@ components:
           type: array
           items:
             type: string
+          description: >
+            Terminal (succeeded, failed, cancelled) runs only -- an
+            in-flight run is counted in in_flight, not listed here.
         count:
           type: integer
+          description: Number of terminal runs with this fingerprint.
         no_repeats:
           type: boolean
-          description: True when exactly one run has this fingerprint; metrics is omitted in that case.
+          description: True when fewer than two terminal runs have this fingerprint; metrics is omitted in that case.
+        in_flight:
+          type: integer
+          description: >
+            Number of this fingerprint's runs that are not yet terminal
+            (created or running). Reported so a run still in progress is
+            visible rather than either silently dropped or miscounted as a
+            finished repeat.
         metrics:
           type: object
           additionalProperties:

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -711,6 +711,11 @@ func (s *Server) spreadList(w http.ResponseWriter, r *http.Request) {
 
 	// Limit: 0 is intentionally unbounded here -- spread has to see every
 	// run for a fingerprint to report its true spread, not just one page.
+	//
+	// page.Runs is not pre-filtered by status: spread.Compute does that
+	// itself (via spread.One, per group), so this endpoint and spreadOne
+	// below share one filtering decision instead of each remembering to
+	// apply it.
 	page, err := s.store.List(r.Context(), store.Query{Project: q.Get("project")})
 	if err != nil {
 		s.metrics.StoreError("internal")
@@ -719,8 +724,13 @@ func (s *Server) spreadList(w http.ResponseWriter, r *http.Request) {
 	}
 	// A nil slice serializes as JSON null; an empty result must still come
 	// back as [], the same rule list already follows via page.Runs.
+	//
+	// min_runs still compares against g.Count, which counts only terminal
+	// runs -- a fingerprint with one finished run and three still running
+	// must not pass min_runs=2 on the strength of runs that have not
+	// produced a measurement yet.
 	groups := []spread.Group{}
-	for _, g := range spread.Compute(terminalRuns(page.Runs)) {
+	for _, g := range spread.Compute(page.Runs) {
 		if g.Count >= minRuns {
 			groups = append(groups, g)
 		}
@@ -810,7 +820,18 @@ func decodeSpreadCursor(s string) (string, error) {
 
 // spreadOne answers "how much do this experiment's own repeats vary?" for
 // one fingerprint, including a group of size one -- reported as no repeats
-// rather than a misleadingly perfect standard deviation of zero.
+// rather than a misleadingly perfect standard deviation of zero -- and a
+// group made up entirely of in-flight runs, reported as no repeats with
+// Count 0 and InFlight set rather than 404.
+//
+// That last case used to 404 (issue #23): a fingerprint with no terminal
+// run had, in that reading, nothing to report. ADR 0012 changes it, for
+// consistency with spreadList -- a min_runs=0 request there already lists a
+// fingerprint the moment any run carries it, terminal or not, so an item
+// lookup that instead claims the same fingerprint does not exist is the
+// "two disagreeing notions of the fingerprints" spreadList's own min_runs
+// doc comment already treats as a bug. 404 remains reserved for a
+// fingerprint no stored run carries at all.
 func (s *Server) spreadOne(w http.ResponseWriter, r *http.Request) {
 	fp := r.PathValue("fingerprint")
 	page, err := s.store.List(r.Context(), store.Query{Fingerprint: fp})
@@ -819,29 +840,12 @@ func (s *Server) spreadOne(w http.ResponseWriter, r *http.Request) {
 		writeErr(w, http.StatusInternalServerError, "internal", err)
 		return
 	}
-	runs := terminalRuns(page.Runs)
-	if len(runs) == 0 {
+	if len(page.Runs) == 0 {
 		s.metrics.StoreError("not_found")
-		writeErr(w, http.StatusNotFound, "not_found", fmt.Errorf("no finished run recorded with fingerprint %q", fp))
+		writeErr(w, http.StatusNotFound, "not_found", fmt.Errorf("no run recorded with fingerprint %q", fp))
 		return
 	}
-	writeJSON(w, http.StatusOK, spread.One(fp, runs))
-}
-
-// terminalRuns filters to the runs whose status is terminal -- succeeded,
-// failed, or cancelled. A running or created run carries whatever metrics
-// happen to be logged so far, not a finished measurement: counting it toward
-// a fingerprint's spread would let an in-flight run masquerade as a repeat,
-// join a group's min/max/mean/stddev with a mid-run value, and even outrank
-// genuinely divergent experiments on Group.Widest(). See ADR 0005.
-func terminalRuns(runs []lineage.Run) []lineage.Run {
-	out := make([]lineage.Run, 0, len(runs))
-	for _, r := range runs {
-		if lineage.Terminal(r.Status) {
-			out = append(out, r)
-		}
-	}
-	return out
+	writeJSON(w, http.StatusOK, spread.One(fp, page.Runs))
 }
 
 // parseLimit resolves the effective page size for GET /runs: DefaultListLimit

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -899,6 +899,7 @@ func TestFingerprintOneIgnoresNonTerminalRuns(t *testing.T) {
 	var out struct {
 		Count     int  `json:"count"`
 		NoRepeats bool `json:"no_repeats"`
+		InFlight  int  `json:"in_flight"`
 		Metrics   map[string]struct {
 			Count int     `json:"count"`
 			Mean  float64 `json:"mean"`
@@ -909,6 +910,9 @@ func TestFingerprintOneIgnoresNonTerminalRuns(t *testing.T) {
 	}
 	if !out.NoRepeats || out.Count != 1 {
 		t.Fatalf("running run must not count as a repeat, got %+v", out)
+	}
+	if out.InFlight != 1 {
+		t.Fatalf("the running run must still be reported via in_flight, got %+v", out)
 	}
 	if loss, ok := out.Metrics["loss"]; ok {
 		t.Fatalf("running run's metric must not enter the group's stats, got %+v", loss)
@@ -926,6 +930,7 @@ func TestFingerprintOneIgnoresNonTerminalRuns(t *testing.T) {
 			Fingerprint string `json:"fingerprint"`
 			Count       int    `json:"count"`
 			NoRepeats   bool   `json:"no_repeats"`
+			InFlight    int    `json:"in_flight"`
 		} `json:"groups"`
 	}
 	if err := json.Unmarshal(w.Body.Bytes(), &list); err != nil {
@@ -934,23 +939,47 @@ func TestFingerprintOneIgnoresNonTerminalRuns(t *testing.T) {
 	if len(list.Groups) != 1 || list.Groups[0].Fingerprint != fp || list.Groups[0].Count != 1 || !list.Groups[0].NoRepeats {
 		t.Fatalf("want a single no_repeats group of count 1, got %+v", list.Groups)
 	}
+	if list.Groups[0].InFlight != 1 {
+		t.Fatalf("want the running run reported via in_flight, got %+v", list.Groups[0])
+	}
 }
 
-// TestFingerprintOneAllNonTerminalIs404 pins the other side of issue #23: a
-// fingerprint that exists only as a created/running run has not been
-// measured yet, so it must not be reported as a (misleadingly empty)
-// no_repeats group -- it must 404, the same as a fingerprint never seen.
-func TestFingerprintOneAllNonTerminalIs404(t *testing.T) {
+// TestFingerprintOneAllInFlightIsNoRepeatsNotNotFound pins ADR 0012's
+// revision of issue #23's other side: a fingerprint that exists only as a
+// created/running run has not been measured yet, but it does exist -- the
+// store has run records for it. It reports as a no_repeats group with
+// count 0 and in_flight set, not 404. 404 is reserved for a fingerprint no
+// run carries at all (TestFingerprintUnknownIs404); treating "exists, zero
+// finished" the same as "does not exist" would disagree with
+// GET /fingerprints?min_runs=0, which already lists this fingerprint (see
+// TestFingerprintOneIgnoresNonTerminalRuns's min_runs=1 case above for the
+// list side of that consistency requirement).
+func TestFingerprintOneAllInFlightIsNoRepeatsNotNotFound(t *testing.T) {
 	h := srv(t)
 	w := post(t, h, `{"project":"p","git_commit":"abc","config_hash":"cfg","seed":1,"status":"running","metrics":{"loss":3.9}}`)
 	var run map[string]any
 	_ = json.Unmarshal(w.Body.Bytes(), &run)
 	fp := run["fingerprint"].(string)
+	post(t, h, `{"project":"p","git_commit":"abc","config_hash":"cfg","seed":1,"status":"created"}`)
 
 	w = httptest.NewRecorder()
 	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v1/fingerprints/"+fp, nil))
-	if w.Code != http.StatusNotFound {
-		t.Fatalf("want 404 for a fingerprint with no finished run, got %d: %s", w.Code, w.Body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200 for a fingerprint with only in-flight runs, got %d: %s", w.Code, w.Body)
+	}
+	var out struct {
+		Count     int  `json:"count"`
+		NoRepeats bool `json:"no_repeats"`
+		InFlight  int  `json:"in_flight"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
+		t.Fatal(err)
+	}
+	if out.Count != 0 || !out.NoRepeats {
+		t.Fatalf("want count 0 and no_repeats true, got %+v", out)
+	}
+	if out.InFlight != 2 {
+		t.Fatalf("want both in-flight runs reported, got %+v", out)
 	}
 }
 

--- a/internal/spread/spread.go
+++ b/internal/spread/spread.go
@@ -5,6 +5,14 @@
 // how much the measured result actually moved. That number is a project's
 // reproducibility floor: it is what tells you whether a later improvement is
 // real or inside the noise these repeats already show.
+//
+// A run that has not finished (lineage.Terminal reports false) is excluded
+// from that summary: its metrics are whatever happened to be logged
+// mid-training, not a finished measurement, and letting one in would widen
+// a group's spread with a number that has nothing to do with reproducing
+// the experiment. See ADR 0012. One and Compute both take runs of any
+// status and do this filtering themselves -- see One's doc comment for why
+// the filtering lives there rather than in each caller.
 package spread
 
 import (
@@ -37,14 +45,27 @@ type ProvenanceDiff struct {
 }
 
 // Group is the spread summary for every recorded run of one fingerprint.
+//
+// RunIDs, Count, NoRepeats, Metrics, and Provenance all describe only the
+// group's terminal runs -- a run still in flight has no finished
+// measurement to contribute. InFlight is where those excluded runs are
+// not silently dropped: a fingerprint with three finished runs and one
+// still running reports Count 3, InFlight 1, not a group of three that
+// looks like no fourth run exists.
 type Group struct {
 	Fingerprint string   `json:"fingerprint"`
 	RunIDs      []string `json:"run_ids"`
 	Count       int      `json:"count"`
-	// NoRepeats is true when exactly one run has this fingerprint. Metrics is
-	// left empty rather than reporting a standard deviation of zero, which
-	// would claim a reproducibility this group was never asked to show.
-	NoRepeats  bool                  `json:"no_repeats"`
+	// NoRepeats is true when fewer than two terminal runs have this
+	// fingerprint. Metrics is left empty rather than reporting a standard
+	// deviation of zero, which would claim a reproducibility this group was
+	// never asked to show.
+	NoRepeats bool `json:"no_repeats"`
+	// InFlight is how many of this fingerprint's runs are not yet terminal
+	// (lineage.Terminal is false: created or running). It is a count, not a
+	// list of run IDs -- the group has nothing to say about an unfinished
+	// run beyond the fact that it exists and has not been measured yet.
+	InFlight   int                   `json:"in_flight"`
 	Metrics    map[string]MetricStat `json:"metrics,omitempty"`
 	Provenance []ProvenanceDiff      `json:"provenance,omitempty"`
 }
@@ -81,7 +102,9 @@ var provenanceFields = []struct {
 }
 
 // Compute groups runs by fingerprint and summarizes each group. runs need
-// not already be grouped, sorted, or limited to one fingerprint or project.
+// not already be grouped, sorted, or limited to one fingerprint, project, or
+// status -- status filtering happens once, inside One, so a caller cannot
+// forget it for one of the two entry points and not the other.
 func Compute(runs []lineage.Run) []Group {
 	byFP := map[string][]lineage.Run{}
 	var order []string
@@ -98,24 +121,40 @@ func Compute(runs []lineage.Run) []Group {
 	return groups
 }
 
-// One summarizes a single fingerprint's runs. It is exported separately from
-// Compute so GET /fingerprints/{fingerprint} -- which already has exactly the
-// runs of one group, via Store.List(Query{Fingerprint: fp}) -- does not need
-// to re-derive the grouping Compute exists to do over a wider listing.
+// One summarizes a single fingerprint's runs, of any status. It is exported
+// separately from Compute so GET /fingerprints/{fingerprint} -- which
+// already has exactly the runs of one group, via
+// Store.List(Query{Fingerprint: fp}) -- does not need to re-derive the
+// grouping Compute exists to do over a wider listing.
+//
+// The terminal/in-flight split happens here rather than in each caller so
+// GET /fingerprints and GET /fingerprints/{fingerprint} cannot drift apart
+// on it: Compute calls this per group, so both endpoints run the exact same
+// filter by construction, not by two call sites happening to agree today.
 func One(fingerprint string, runs []lineage.Run) Group {
-	ids := make([]string, len(runs))
-	for i, r := range runs {
+	var terminal []lineage.Run
+	inFlight := 0
+	for _, r := range runs {
+		if lineage.Terminal(r.Status) {
+			terminal = append(terminal, r)
+		} else {
+			inFlight++
+		}
+	}
+
+	ids := make([]string, len(terminal))
+	for i, r := range terminal {
 		ids[i] = r.RunID
 	}
 	sort.Strings(ids)
 
-	g := Group{Fingerprint: fingerprint, RunIDs: ids, Count: len(runs)}
-	if len(runs) < 2 {
+	g := Group{Fingerprint: fingerprint, RunIDs: ids, Count: len(terminal), InFlight: inFlight}
+	if len(terminal) < 2 {
 		g.NoRepeats = true
 		return g
 	}
-	g.Metrics = metricStats(runs)
-	g.Provenance = provenanceDiffs(runs)
+	g.Metrics = metricStats(terminal)
+	g.Provenance = provenanceDiffs(terminal)
 	return g
 }
 

--- a/internal/spread/spread_test.go
+++ b/internal/spread/spread_test.go
@@ -7,8 +7,11 @@ import (
 	"github.com/kornsour/run-ledger/internal/lineage"
 )
 
+// run builds a terminal (succeeded) run: the common case these tests want,
+// now that One excludes anything else. Tests of the in-flight/terminal
+// split itself override Status explicitly.
 func run(id string, metrics map[string]float64) lineage.Run {
-	r := lineage.Run{Project: "p", GitCommit: "abc", ConfigHash: "cfg", Seed: 1, RunID: id, Metrics: metrics}
+	r := lineage.Run{Project: "p", GitCommit: "abc", ConfigHash: "cfg", Seed: 1, RunID: id, Status: lineage.StatusSucceeded, Metrics: metrics}
 	r.Fingerprint = r.Compute()
 	return r
 }
@@ -103,6 +106,103 @@ func TestProvenanceDiffsEmptyWhenConstant(t *testing.T) {
 	g := One("fp", []lineage.Run{a, b})
 	if len(g.Provenance) != 0 {
 		t.Fatalf("no provenance field differs, want none flagged, got %+v", g.Provenance)
+	}
+}
+
+// TestInFlightRunExcludedFromStats pins ADR 0012: a non-terminal run's
+// metric must not join the group's min/max/mean/stddev, even though the
+// finished runs beside it still report a repeat.
+func TestInFlightRunExcludedFromStats(t *testing.T) {
+	a := run("a", map[string]float64{"loss": 0.40})
+	b := run("b", map[string]float64{"loss": 0.50})
+	c := run("c", map[string]float64{"loss": 99.0})
+	c.Status = lineage.StatusRunning
+	a.Fingerprint, b.Fingerprint, c.Fingerprint = "fp", "fp", "fp"
+
+	g := One("fp", []lineage.Run{a, b, c})
+	m, ok := g.Metrics["loss"]
+	if !ok {
+		t.Fatal("want a loss entry")
+	}
+	if m.Count != 2 {
+		t.Fatalf("the running run's metric must not be counted, want count 2, got %d", m.Count)
+	}
+	if m.Max != 0.50 {
+		t.Fatalf("the running run's 99.0 must not enter the stats, got max %v", m.Max)
+	}
+}
+
+// TestInFlightCountReported checks the other half of ADR 0012: the
+// in-flight runs excluded from stats are not dropped silently, they are
+// reported as a count alongside the terminal group.
+func TestInFlightCountReported(t *testing.T) {
+	a := run("a", map[string]float64{"loss": 0.40})
+	b := run("b", map[string]float64{"loss": 0.50})
+	c := run("c", map[string]float64{"loss": 0.60})
+	c.Status = lineage.StatusCreated
+	d := run("d", map[string]float64{"loss": 0.70})
+	d.Status = lineage.StatusRunning
+	a.Fingerprint, b.Fingerprint, c.Fingerprint, d.Fingerprint = "fp", "fp", "fp", "fp"
+
+	g := One("fp", []lineage.Run{a, b, c, d})
+	if g.Count != 2 {
+		t.Fatalf("want 2 terminal runs counted, got %d", g.Count)
+	}
+	if g.InFlight != 2 {
+		t.Fatalf("want 2 in-flight runs reported, got %d", g.InFlight)
+	}
+}
+
+// TestGroupOfOnlyInFlightRuns checks a fingerprint that has not produced a
+// single finished measurement yet: it must not error or panic, it reports
+// no_repeats (0 terminal runs is fewer than 2) with the in-flight runs
+// still visible via InFlight rather than vanishing entirely.
+func TestGroupOfOnlyInFlightRuns(t *testing.T) {
+	a := run("a", map[string]float64{"loss": 0.40})
+	a.Status = lineage.StatusRunning
+	b := run("b", map[string]float64{"loss": 0.50})
+	b.Status = lineage.StatusCreated
+	a.Fingerprint, b.Fingerprint = "fp", "fp"
+
+	g := One("fp", []lineage.Run{a, b})
+	if g.Count != 0 {
+		t.Fatalf("want 0 terminal runs, got %d", g.Count)
+	}
+	if g.InFlight != 2 {
+		t.Fatalf("want both in-flight runs reported, got %d", g.InFlight)
+	}
+	if !g.NoRepeats {
+		t.Fatal("a group with no finished runs has nothing measurable, want no_repeats")
+	}
+	if g.Metrics != nil {
+		t.Fatalf("no terminal runs means no stats to report, got %+v", g.Metrics)
+	}
+	if len(g.RunIDs) != 0 {
+		t.Fatalf("run_ids tracks only terminal runs, got %v", g.RunIDs)
+	}
+}
+
+// TestInFlightRunReducesGroupBelowTwoStillNoRepeats checks that filtering
+// by status, not just raw run count, decides no_repeats: two runs recorded
+// under one fingerprint is not a repeat once only one of them is terminal.
+func TestInFlightRunReducesGroupBelowTwoStillNoRepeats(t *testing.T) {
+	a := run("a", map[string]float64{"loss": 0.40})
+	b := run("b", map[string]float64{"loss": 0.50})
+	b.Status = lineage.StatusRunning
+	a.Fingerprint, b.Fingerprint = "fp", "fp"
+
+	g := One("fp", []lineage.Run{a, b})
+	if !g.NoRepeats {
+		t.Fatal("2 raw runs but only 1 terminal is not a repeat, want no_repeats")
+	}
+	if g.Count != 1 {
+		t.Fatalf("want 1 terminal run counted, got %d", g.Count)
+	}
+	if g.InFlight != 1 {
+		t.Fatalf("want the running run reported as in-flight, got %d", g.InFlight)
+	}
+	if g.Metrics != nil {
+		t.Fatalf("a no-repeats group must not report metric stats, got %+v", g.Metrics)
 	}
 }
 


### PR DESCRIPTION
Fixes #65

## What changed

`spreadList` and `spreadOne` already excluded non-terminal runs from a fingerprint's spread numbers (#52, fixing #23, per ADR 0005) -- but the exclusion was silent. A fingerprint with 3 finished runs and 1 still running looked identical to a group of 3; there was no way to tell "done" from "more coming."

- `spread.Group` gains `InFlight int` (`json:"in_flight"`): the count of the fingerprint's non-terminal (`created`/`running`) runs, reported beside the terminal-only `Count`/`Metrics`/`RunIDs`.
- The terminal/in-flight split moves from an `api.go`-local `terminalRuns` helper into `spread.One` itself. `spread.Compute` already calls `One` once per fingerprint group, so `GET /fingerprints` and `GET /fingerprints/{fingerprint}` now share one filtering decision by construction, rather than two call sites each remembering to pre-filter.
- No query parameter or opt-out exposes the unfiltered (unsafe) reading. See the ADR for why -- short version: nothing needs it, `GET /runs?fingerprint=...` already exposes every run's own status and metrics, and an opt-in that reproduces this ledger's one false-positive hazard on request isn't a feature.
- `GET /fingerprints/{fingerprint}` for a fingerprint whose only runs are in-flight changes from 404 to 200 (`count: 0, no_repeats: true, in_flight: N`). The old 404 disagreed with the collection endpoint, which already lists such a fingerprint under `min_runs=0`; 404 is now reserved for a fingerprint no stored run carries at all.

Full reasoning, including the alternatives considered for the default-vs-opt-out question the issue asked to be settled: `docs/adr/0012-spread-excludes-in-flight-runs-unconditionally.md`.

## Test plan
- [x] `go build ./... && go vet ./... && go test -race ./...`
- [x] `gofmt -l .` clean
- [x] `python3 -m unittest discover -s python/tests`
- [x] `python3 -m unittest discover -s dashboard/tests`
- [x] `python3 -m unittest discover -s examples/churn`
- [x] New tests in `internal/spread/spread_test.go`: in-flight run excluded from stats, in-flight count reported, a group of only in-flight runs, no_repeats holding when the filter reduces a group below 2.
- [x] New/updated tests in `internal/api/api_test.go` for the same, plus the 404→200 behavior change at the item endpoint.
- [x] `docs/openapi.yaml` updated (`in_flight` field, revised 404/200 descriptions) and checked by `TestSchemasMatchGoTypes`/`TestRoutesMatchSpec`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)