### PR TITLE
lineage: normalize numeric param spellings before hashing

### DIFF
--- a/docs/adr/0012-param-values-are-normalized-before-hashing.md
+++ b/docs/adr/0012-param-values-are-normalized-before-hashing.md
@@ -1,0 +1,251 @@
+# ADR 0012: Param values are normalized before hashing, and the fingerprint is now versioned
+
+Status: Accepted
+Date: 2026-08-29
+
+> **A param value that parses as a finite decimal number is rewritten to a
+> canonical spelling before it is hashed into the fingerprint.** "3e-4",
+> "0.0003", and "0.00030" are the same learning rate and must fingerprint
+> identically; before this change they did not, and nothing detected it.
+> This changes what `Compute` hashes, so per ADR 0004 it ships with a
+> `fingerprint_version` field on every run and existing records are
+> migrated to version 1 rather than silently reinterpreted.
+
+## Context
+
+`lineage.Run.Compute` hashed each param value as the exact string it
+arrived as. Two clients disagree about how to spell the same number:
+`rlctl --param lr=3e-4` sends the literal `"3e-4"` a user typed, while the
+Python client's `Run.start(params={"lr": 3e-4})` sends `str(3e-4)`, which
+is `"0.0003"` (see the dict comprehension in `python/runledger/_run.py`).
+The same experiment, recorded from the CLI once and from training code
+once, produced two different fingerprints:
+
+```
+lr="3e-4"    -> eb26d16282d557d91b3b
+lr="0.0003"  -> 77e0335cc066b1a38273
+lr="0.00030" -> 4771e6d266eb039f2641
+```
+
+This is a false *negative*, and that makes it worse than it looks. The
+ledger's one claim is "same fingerprint means same experiment," made
+positively every time `spread` groups two runs together and
+`compare.Result.Unattributable` fires. A false negative here doesn't
+produce a wrong answer that someone goes and checks -- it produces no
+answer at all. `spread` never sees a repeat, `unattributable` never fires,
+and nothing about the recorded data says a claim was missed. Silence is
+the failure mode, and it is the one this ledger exists to prevent for
+exactly this kind of case: a hyperparameter genuinely re-run, whose
+repeat measurement never gets to inform anything.
+
+## Decision
+
+### Normalize server-side, in `Compute`
+
+`normalizeParamValue` (`internal/lineage/run.go`) runs inside `Compute`,
+not in either client. ADR 0001 already settled where identity decisions
+belong: the server computes the fingerprint so a client cannot assert
+identity that isn't real. A fix that instead relied on every client
+formatting its numbers the same way would repeat exactly the mistake ADR
+0001 exists to prevent -- it would just move "whose spelling wins" from an
+accident of who wrote to the ledger first to an accident of which client
+library got updated first. `rlctl` and the Python client need no change
+for correctness; both already send some string, and the server now treats
+equivalent strings equivalently regardless of source. (`python/runledger/_run.py`
+gets one comment, not a behavior change -- see below.)
+
+### What counts as "numeric," and how it canonicalizes
+
+A value is normalized only if it matches `numericParamPattern`: an
+optional sign, a JSON-number-shaped integer part or a bare leading decimal
+point, an optional fractional part, an optional exponent. A match is then
+parsed with `strconv.ParseFloat` and re-emitted with
+`strconv.FormatFloat(f, 'g', -1, 64)` -- shortest decimal that round-trips
+back to the same `float64`. Anything that does not match, or that
+`ParseFloat` cannot represent, passes through **byte-for-byte unchanged**.
+That last property matters as much as the normalization itself: this
+function is either a no-op or a like-for-like rewrite, never a way to
+discard information it has no basis to discard.
+
+The pattern is deliberately narrower than what `strconv.ParseFloat` itself
+accepts, because two things ParseFloat is lenient about would misfire if
+fed to it unfiltered:
+
+- **`1_000`.** `ParseFloat` accepts underscores as Go's numeric-literal
+  digit separator and would parse this as `1000`. A param value is
+  arbitrary CLI/JSON/Python input, not Go source -- nothing else on this
+  system's surface treats `1_000` as a spelling of one thousand, so
+  letting Go's leniency decide would be `Compute` inventing an equivalence
+  no client asked for.
+- **`007`.** `ParseFloat` parses leading zeros as an ordinary decimal
+  (`007 == 7`). A zero-padded string is at least as likely to be an opaque
+  identifier -- a shard id, a padded run suffix -- as a number whose
+  leading zeros don't matter, and this package has no way to tell which.
+  JSON's own number grammar excludes leading zeros for the same reason;
+  the pattern follows it.
+
+Two more cases needed a deliberate answer rather than an implicit one from
+whatever `ParseFloat` happened to do:
+
+- **`1e400` (overflow).** Syntactically a number, but too large for
+  `float64`; `ParseFloat` returns `+Inf` *and* an error. Formatting the
+  `+Inf` would collapse every magnitude beyond `float64`'s range onto one
+  canonical spelling -- a far bigger identity change than reconciling
+  spellings of an in-range number. On this error, `normalizeParamValue`
+  returns `v` unchanged.
+- **`1e-400` (underflow) -- found while testing the overflow case, not
+  called out in the original bug report.** `ParseFloat` silently
+  underflows this to exactly `0`, with **no error at all** -- there is no
+  `ErrRange` to catch it by, unlike overflow. Left unhandled, this would
+  quietly conflate a nonzero (if unrepresentable) magnitude with an actual
+  zero. `normalizeParamValue` detects it by checking whether the original
+  string's significant digits were already all zero (`isZeroLiteral`); if
+  a supposedly-zero result came from a string with a nonzero digit in it,
+  that's underflow, not zero, and the value is left unchanged too.
+
+`"NaN"`, `"Inf"`, `"-Inf"`, and `"Infinity"` never reach `ParseFloat` at
+all -- they contain letters the pattern doesn't allow outside the `e`/`E`
+exponent marker, so they fail the shape check structurally. This is
+deliberate, not incidental: `ParseFloat` itself accepts all four
+case-insensitively with no error, so excluding them took an explicit
+choice, not the pattern's default behavior. Unlike a finite number, there
+is no single spelling that every "Inf" necessarily means the same thing
+by, and NaN is not equal to itself, which would make folding every NaN
+spelling into one canonical string actively misleading as an identity key
+rather than merely unnormalized.
+
+One case gets normalized beyond simply reconciling spellings: `"-0"`,
+`"-0.0"`, and `"0"` all canonicalize to `"0"`. `FormatFloat` renders a
+parsed negative zero back out as `"-0"`, which would otherwise keep signed
+and unsigned zero apart from each other for a distinction nothing about a
+hyperparameter measures.
+
+### The fingerprint is now a versioned contract (`FingerprintVersion`)
+
+This changes what `Compute` hashes for any param whose spelling was not
+already canonical, which is exactly the case ADR 0004 exists for: *"Fixing
+a bug in `Compute`... is still a hash-input change by this rule, even
+though it reads as a 'fix.'"* `lineage.Run` gains a `FingerprintVersion`
+field (`fingerprint_version` on the wire), stamped by `api.record`
+alongside `Fingerprint` -- never independently, since a fingerprint's
+meaning depends on which contract produced it. `FingerprintVersionLegacy`
+(1) names the pre-normalization contract; `CurrentFingerprintVersion` (2)
+names this one.
+
+`FingerprintVersion` is provenance, not identity: it is recorded
+alongside `Fingerprint` but is **not** itself hashed into it, for the same
+reason `Fingerprint` doesn't hash itself -- that would be circular. It
+also means a version-1 record and a version-2 record whose params were
+*already* canonically spelled (no exponents, no trailing zeros, nothing
+`normalizeParamValue` would touch) fingerprint identically, and correctly
+so: `Compute`'s param-hashing loop runs the same code either way, so two
+runs with the same real content produce the same hash regardless of which
+contract's era recorded them. Versioning here doesn't force every old
+record apart from every new one; it only distinguishes them where the
+normalization rule actually changed what got hashed, and it makes the
+distinction visible to a reader instead of silent.
+
+`Store` persists whatever `FingerprintVersion` arrives with a run, the
+same way it already persists `Fingerprint`, and never recomputes either.
+DuckDB's schema gets one new migration, appended to the existing
+`migrations` slice rather than editing the original `CREATE TABLE`
+(matching that file's own stated convention): `ALTER TABLE runs ADD COLUMN
+fingerprint_version INTEGER DEFAULT 1`. `DEFAULT 1` backfills every row
+that already exists at migration time to `FingerprintVersionLegacy` in the
+same statement that adds the column -- there is no window where a
+pre-migration row reads back with an undefined version. (The column is
+not declared `NOT NULL`: this repository's DuckDB version rejects `ADD
+COLUMN` with an inline column constraint. `DEFAULT` alone still backfills
+every existing row to a real value, and every future insert supplies an
+explicit `FingerprintVersion`, so `NOT NULL` would only have caught a bug
+that had already written bad data -- it would not have prevented one.)
+
+`internal/compare.SameExperiment` needed no change for this to be
+consistent. It already prefers the *stored* fingerprint over recomputing
+whenever both runs have one (a decision this ADR's own reasoning is
+called out in that function's doc comment as anticipating): reading the
+stored value, rather than recomputing under whichever contract `Compute`
+implements today, is exactly what keeps a version-1 fingerprint meaning
+what it meant when it was recorded. `Compute` remains the fallback only
+for runs that never went through a store -- e.g. two `lineage.Run` values
+built directly in a test -- and it always implements
+`CurrentFingerprintVersion`; there is no way to ask it for the legacy
+behavior, because nothing should ever need to.
+
+### Why this can't be solved the way ADR 0011 solved a similar-looking problem
+
+ADR 0011 collapsed `""` and "not recorded" into one meaning for seven
+scalar fields, and did it **without** triggering ADR 0004, because it
+established that the two spellings were never in real conflict: nothing
+needed `""` to mean anything other than absence, so declaring one
+canonical spelling retroactively changed nothing about what any existing
+record actually meant.
+
+That move doesn't apply here, and the difference is worth being explicit
+about because the two bugs look similar on the surface (a field with more
+than one way to spell the same value): **existing param records already
+carry whichever spelling their client happened to send, and both
+spellings are values a real client actually sent on purpose.** A dataset
+with `lr="3e-4"` recorded by `rlctl` and `lr="0.0003"` recorded by the
+Python client are not "one meaning, two accidental spellings of a gap" the
+way `""` and an omitted key were -- they are two clients disagreeing about
+formatting, and every fingerprint already computed from either spelling
+is a real, load-bearing value some other record might already match
+against. There is no canonical spelling to declare after the fact that
+doesn't change what at least one already-recorded fingerprint means.
+That's precisely the situation ADR 0004 exists for, and precisely why this
+change carries a version field and a migration instead of a one-line fix
+to `Compute`.
+
+## Consequences
+
+- Two runs recorded with different spellings of the same numeric param now
+  fingerprint identically going forward, closing the false negative this
+  ADR opens with. `spread` will start grouping repeats it previously
+  missed, and `unattributable` can now fire for pairs it previously
+  couldn't see as related.
+- Every fingerprint already recorded keeps its stored value and reads back
+  tagged `FingerprintVersionLegacy`. None of them are silently reinterpreted,
+  and none of them retroactively start (or stop) matching anything they
+  didn't already match, because nothing recomputes them.
+- A version-1 and a version-2 run of the *same* experiment, recorded with
+  an unnormalized spelling on one side, will **not** fingerprint
+  identically even though they're the same experiment -- the version-1
+  fingerprint was permanently computed under the old contract before this
+  change existed. This is the real, visible cost of "never reinterpret a
+  stored fingerprint": some pre-existing false negatives are fixed only
+  for runs recorded from now on, not retroactively for old data. Closing
+  that gap for historical data would need an explicit backfill (recompute
+  every legacy row's params under the new contract, store the result
+  alongside the old value, bump its version) which is a larger, separately
+  scoped migration project, not a byproduct of this fix.
+- `docs/openapi.yaml`'s `Run` and `RunInput` schemas, and
+  `internal/api/spec_test.go`'s coverage of them, gained
+  `fingerprint_version` for free by construction, since both schemas are
+  checked directly against `lineage.Run`'s JSON tags.
+- `python/runledger/_run.py` needed no functional change: it already sends
+  `str(v)` for each param, and the server now normalizes whatever it
+  receives. The file has a comment recording why duplicating
+  `normalizeParamValue`'s canonicalization logic client-side would be
+  redundant, not why it would be wrong -- it would still work, just add a
+  second place the two rules can drift apart. `cmd/rlctl/main.go` needed no
+  change for the same reason: it already forwards whatever string the
+  `--param` flag was given.
+
+## What would have to be true to revisit this
+
+**The normalization boundary.** If a real param value turns out to need
+the leniency this pattern deliberately excludes -- a workflow that
+genuinely wants `1_000` treated as `1000`, say -- widening
+`numericParamPattern` is a `CurrentFingerprintVersion` bump like this one,
+not a patch to the existing pattern; ADR 0004 applies to every future
+change here exactly as it applied to this one.
+
+**Backfilling historical fingerprints.** If false negatives in the
+existing (pre-this-change) data turn out to matter enough to justify it,
+a batch job that recomputes every `FingerprintVersionLegacy` run's
+`Compute()` under the current contract, records the result as a *new*
+fingerprint value alongside (never replacing) the original, and stamps it
+`CurrentFingerprintVersion` would close the historical gap the last
+Consequences bullet describes. That is new, deliberate work with its own
+migration story, not something this record already does implicitly.

--- a/docs/adr/0013-param-values-are-normalized-before-hashing.md
+++ b/docs/adr/0013-param-values-are-normalized-before-hashing.md
@@ -1,4 +1,4 @@
-# ADR 0012: Param values are normalized before hashing, and the fingerprint is now versioned
+# ADR 0013: Param values are normalized before hashing, and the fingerprint is now versioned
 
 Status: Accepted
 Date: 2026-08-29

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -23,7 +23,7 @@ section is a summary of these; this folder is the account.
 | [0009](0009-url-path-versioning-for-the-http-api.md) | URL path versioning (`/v1`) for the HTTP API, excluding health/readiness/metrics | Accepted |
 | [0010](0010-comparisons-is-a-resource-not-a-verb.md) | `/comparisons` is a resource, not a verb | Accepted |
 | [0011](0011-empty-string-means-not-recorded.md) | An empty string means "not recorded" | Accepted |
-| [0012](0012-param-values-are-normalized-before-hashing.md) | Param values are normalized before hashing, and the fingerprint is now versioned | Accepted |
+| [0013](0013-param-values-are-normalized-before-hashing.md) | Param values are normalized before hashing, and the fingerprint is now versioned | Accepted |
 
 ## Adding a record
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -23,6 +23,7 @@ section is a summary of these; this folder is the account.
 | [0009](0009-url-path-versioning-for-the-http-api.md) | URL path versioning (`/v1`) for the HTTP API, excluding health/readiness/metrics | Accepted |
 | [0010](0010-comparisons-is-a-resource-not-a-verb.md) | `/comparisons` is a resource, not a verb | Accepted |
 | [0011](0011-empty-string-means-not-recorded.md) | An empty string means "not recorded" | Accepted |
+| [0012](0012-param-values-are-normalized-before-hashing.md) | Param values are normalized before hashing, and the fingerprint is now versioned | Accepted |
 
 ## Adding a record
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -588,6 +588,14 @@ components:
             the server always overwrites it with the identity fields' own
             computed hash. There is no way to assert a fingerprint from the
             client.
+        fingerprint_version:
+          type: integer
+          description: >
+            Accepted but ignored, the same as fingerprint: the server always
+            overwrites it with the version of the hashing contract that
+            actually produced the fingerprint it just computed. There is no
+            way to assert an old contract's fingerprint was produced by
+            today's.
         host:
           type: string
         device:
@@ -634,6 +642,7 @@ components:
         - seed
         - run_id
         - fingerprint
+        - fingerprint_version
         - host
         - device
         - framework_version
@@ -668,6 +677,21 @@ components:
           type: string
           readOnly: true
           description: Content-addressed hash of the identity fields, computed by the server.
+        fingerprint_version:
+          type: integer
+          readOnly: true
+          description: >
+            Which version of the fingerprint hashing contract produced
+            fingerprint -- see the fingerprint-input-is-a-versioned-contract
+            and param-normalization ADRs. 1 identifies a run recorded before
+            params were normalized before hashing: its fingerprint hashes
+            each param's literal string spelling, so "3e-4" and "0.0003"
+            fingerprinted as different experiments. 2 identifies a run
+            recorded after: a param value that parses as a finite decimal
+            number is normalized to a canonical spelling before hashing, so
+            those two spellings fingerprint identically. A version-1
+            fingerprint is never recomputed under the version-2 contract --
+            it keeps meaning exactly what it meant when it was recorded.
         host:
           type: string
         device:

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -401,7 +401,7 @@ func (s *Server) record(w http.ResponseWriter, r *http.Request) {
 	run.Fingerprint = run.Compute()
 	// FingerprintVersion is stamped in the same breath as Fingerprint, never
 	// independently: Compute always implements CurrentFingerprintVersion
-	// (see lineage.Run.Compute's doc and ADR 0012), so any Fingerprint this
+	// (see lineage.Run.Compute's doc and ADR 0013), so any Fingerprint this
 	// line just produced is, by construction, a CurrentFingerprintVersion
 	// fingerprint. A client-supplied fingerprint_version is discarded the
 	// same way a client-supplied fingerprint is -- ADR 0001's rule ("the

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -399,6 +399,16 @@ func (s *Server) record(w http.ResponseWriter, r *http.Request) {
 	// The server computes the fingerprint; a client-supplied one would let a
 	// caller assert that two different experiments were the same.
 	run.Fingerprint = run.Compute()
+	// FingerprintVersion is stamped in the same breath as Fingerprint, never
+	// independently: Compute always implements CurrentFingerprintVersion
+	// (see lineage.Run.Compute's doc and ADR 0012), so any Fingerprint this
+	// line just produced is, by construction, a CurrentFingerprintVersion
+	// fingerprint. A client-supplied fingerprint_version is discarded the
+	// same way a client-supplied fingerprint is -- ADR 0001's rule ("the
+	// server computes the fingerprint, never the client") covers the
+	// version tag too, or a client could claim an old, unnormalized
+	// fingerprint was produced under today's contract.
+	run.FingerprintVersion = lineage.CurrentFingerprintVersion
 	if run.RunID == "" {
 		// started_at is client-supplied, so two legitimate repeats of the same
 		// experiment sharing a coarse timestamp (e.g. a scheduler emitting

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kornsour/run-ledger/internal/lineage"
 	"github.com/kornsour/run-ledger/internal/metrics"
 	"github.com/kornsour/run-ledger/internal/store"
 )
@@ -67,6 +68,62 @@ func TestClientCannotDictateTheFingerprint(t *testing.T) {
 	_ = json.Unmarshal(w.Body.Bytes(), &got)
 	if got["fingerprint"] == "deadbeef" {
 		t.Fatal("server accepted a client-supplied fingerprint")
+	}
+}
+
+// TestRecordStampsCurrentFingerprintVersion pins the pairing api.record
+// makes: whatever Fingerprint a fresh record gets, it must be tagged with
+// the contract version that actually produced it (ADR 0012), not left at
+// the Go zero value or some other stale version.
+func TestRecordStampsCurrentFingerprintVersion(t *testing.T) {
+	w := post(t, srv(t), `{"project":"p","git_commit":"abc","config_hash":"cfg"}`)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("want 201, got %d: %s", w.Code, w.Body)
+	}
+	var got map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &got)
+	fv, ok := got["fingerprint_version"].(float64) // JSON numbers decode as float64
+	if !ok || int(fv) != lineage.CurrentFingerprintVersion {
+		t.Fatalf("want fingerprint_version %d, got %v", lineage.CurrentFingerprintVersion, got["fingerprint_version"])
+	}
+}
+
+// TestClientCannotDictateTheFingerprintVersion mirrors
+// TestClientCannotDictateTheFingerprint: a client-supplied fingerprint_version
+// must be discarded the same way a client-supplied fingerprint is, or a
+// caller could claim an old, unnormalized fingerprint was produced under
+// today's contract.
+func TestClientCannotDictateTheFingerprintVersion(t *testing.T) {
+	w := post(t, srv(t), `{"project":"p","git_commit":"abc","config_hash":"cfg","fingerprint_version":1}`)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("want 201, got %d: %s", w.Code, w.Body)
+	}
+	var got map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &got)
+	fv, ok := got["fingerprint_version"].(float64)
+	if !ok || int(fv) != lineage.CurrentFingerprintVersion {
+		t.Fatalf("server accepted a client-supplied fingerprint_version: got %v, want %d", got["fingerprint_version"], lineage.CurrentFingerprintVersion)
+	}
+}
+
+// TestRecordNormalizesNumericParamSpellings is the end-to-end version of
+// lineage.TestComputeCollapsesEquivalentNumericSpellings: it exercises the
+// same normalization through the actual HTTP handler, which is what closes
+// the gap issue #63 describes -- rlctl sending a literal "3e-4" and the
+// Python client sending str(3e-4) == "0.0003" must record the same
+// fingerprint, or the two clients keep disagreeing about identical runs.
+func TestRecordNormalizesNumericParamSpellings(t *testing.T) {
+	h := srv(t)
+	rlctlStyle := post(t, h, `{"project":"p","git_commit":"abc","config_hash":"cfg","params":{"lr":"3e-4"}}`)
+	pythonStyle := post(t, h, `{"project":"p","git_commit":"abc","config_hash":"cfg","params":{"lr":"0.0003"}}`)
+	if rlctlStyle.Code != http.StatusCreated || pythonStyle.Code != http.StatusCreated {
+		t.Fatalf("want both 201, got %d and %d", rlctlStyle.Code, pythonStyle.Code)
+	}
+	var a, b map[string]any
+	_ = json.Unmarshal(rlctlStyle.Body.Bytes(), &a)
+	_ = json.Unmarshal(pythonStyle.Body.Bytes(), &b)
+	if a["fingerprint"] == "" || a["fingerprint"] != b["fingerprint"] {
+		t.Fatalf(`lr="3e-4" and lr="0.0003" must record the same fingerprint, got %v and %v`, a["fingerprint"], b["fingerprint"])
 	}
 }
 

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -73,7 +73,7 @@ func TestClientCannotDictateTheFingerprint(t *testing.T) {
 
 // TestRecordStampsCurrentFingerprintVersion pins the pairing api.record
 // makes: whatever Fingerprint a fresh record gets, it must be tagged with
-// the contract version that actually produced it (ADR 0012), not left at
+// the contract version that actually produced it (ADR 0013), not left at
 // the Go zero value or some other stale version.
 func TestRecordStampsCurrentFingerprintVersion(t *testing.T) {
 	w := post(t, srv(t), `{"project":"p","git_commit":"abc","config_hash":"cfg"}`)

--- a/internal/lineage/run.go
+++ b/internal/lineage/run.go
@@ -42,7 +42,7 @@ type Run struct {
 	RunID       string `json:"run_id"`
 	Fingerprint string `json:"fingerprint"`
 	// FingerprintVersion records which version of Compute's hashing contract
-	// produced Fingerprint -- see ADR 0004 and ADR 0012. It is provenance
+	// produced Fingerprint -- see ADR 0004 and ADR 0013. It is provenance
 	// about the fingerprint, not an input to it: hashing the version itself
 	// would be circular, the same reason Fingerprint is not hashed either.
 	//
@@ -97,10 +97,10 @@ func Terminal(s Status) bool {
 }
 
 // Fingerprint hashing contract versions. See ADR 0004 (the fingerprint input
-// is a versioned contract) and ADR 0012 (param values are normalized before
+// is a versioned contract) and ADR 0013 (param values are normalized before
 // hashing).
 const (
-	// FingerprintVersionLegacy is the contract in effect before ADR 0012:
+	// FingerprintVersionLegacy is the contract in effect before ADR 0013:
 	// Params were hashed by the literal string spelling a client sent, so
 	// "3e-4", "0.0003", and "0.00030" fingerprinted as three different
 	// experiments. There is no way to recompute a legacy fingerprint under
@@ -161,7 +161,7 @@ func (r *Run) Validate() error {
 // also normalized (normalizeParamValue) before hashing, so a param that
 // merely looks like a different spelling of the same number -- "3e-4" versus
 // "0.0003" versus "0.00030" -- hashes the same regardless of which spelling
-// a particular client happened to send (ADR 0012).
+// a particular client happened to send (ADR 0013).
 func (r *Run) Compute() string {
 	h := sha256.New()
 	write := func(parts ...string) {

--- a/internal/lineage/run.go
+++ b/internal/lineage/run.go
@@ -7,7 +7,9 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -37,13 +39,29 @@ type Run struct {
 	// with none of these set. Widening them to pointers would ripple into
 	// Compute's hashing and every caller that decodes a lineage.Run from
 	// JSON, which is a bigger, separately-scoped change than this fix.
-	RunID            string    `json:"run_id"`
-	Fingerprint      string    `json:"fingerprint"`
-	Host             string    `json:"host"`
-	Device           string    `json:"device"`
-	FrameworkVersion string    `json:"framework_version"`
-	Status           Status    `json:"status"`
-	StartedAt        time.Time `json:"started_at"`
+	RunID       string `json:"run_id"`
+	Fingerprint string `json:"fingerprint"`
+	// FingerprintVersion records which version of Compute's hashing contract
+	// produced Fingerprint -- see ADR 0004 and ADR 0012. It is provenance
+	// about the fingerprint, not an input to it: hashing the version itself
+	// would be circular, the same reason Fingerprint is not hashed either.
+	//
+	// Never set this directly. The server stamps it alongside Fingerprint
+	// (api.record) whenever it computes a fresh one, and every Store
+	// implementation persists and returns whatever was stamped. A run
+	// decoded from a source that predates this field -- a JSON payload
+	// written before FingerprintVersion existed, or a store row from before
+	// its migration -- must not be read as FingerprintVersion's Go zero
+	// value (0), which names no real contract. DuckDB's migration backfills
+	// every pre-existing row to FingerprintVersionLegacy explicitly, and any
+	// other caller constructing a Run by hand for a legacy value should do
+	// the same rather than leave the field at its zero value.
+	FingerprintVersion int       `json:"fingerprint_version"`
+	Host               string    `json:"host"`
+	Device             string    `json:"device"`
+	FrameworkVersion   string    `json:"framework_version"`
+	Status             Status    `json:"status"`
+	StartedAt          time.Time `json:"started_at"`
 	// EndedAt is a pointer because a struct's zero value is never omitted by
 	// encoding/json's "omitempty" -- without the pointer, every run that
 	// hasn't ended would serialize ended_at as 0001-01-01T00:00:00Z instead
@@ -78,6 +96,32 @@ func Terminal(s Status) bool {
 	return s == StatusSucceeded || s == StatusFailed || s == StatusCancelled
 }
 
+// Fingerprint hashing contract versions. See ADR 0004 (the fingerprint input
+// is a versioned contract) and ADR 0012 (param values are normalized before
+// hashing).
+const (
+	// FingerprintVersionLegacy is the contract in effect before ADR 0012:
+	// Params were hashed by the literal string spelling a client sent, so
+	// "3e-4", "0.0003", and "0.00030" fingerprinted as three different
+	// experiments. There is no way to recompute a legacy fingerprint under
+	// today's Compute and expect it to still match what was stored --
+	// Compute only ever implements the current contract -- so this constant
+	// exists purely to label old records, never to select old behavior.
+	// Every run recorded before FingerprintVersion existed is this version,
+	// by definition of the migration that introduced the field (see
+	// internal/store/duckdb.go's schema migration), not by anything
+	// recomputed from its content.
+	FingerprintVersionLegacy = 1
+	// CurrentFingerprintVersion is the contract Compute implements: param
+	// values that parse as a finite decimal number are rewritten to a
+	// canonical spelling (normalizeParamValue) before hashing, so numeric
+	// params with different spellings but the same value fingerprint
+	// identically. Bump this, and add a new FingerprintVersion* constant
+	// documenting what changed, the next time Compute's input changes --
+	// per ADR 0004, that is never a change made without one.
+	CurrentFingerprintVersion = 2
+)
+
 // ErrDirtyTree is returned by Validate when a run reports a dirty working tree
 // without an explicit config hash. A dirty tree means the commit does not
 // describe the code that ran, so the config hash is the only remaining handle
@@ -104,11 +148,20 @@ func (r *Run) Validate() error {
 	return nil
 }
 
-// Compute returns the content-addressed fingerprint of a run's identity fields.
+// Compute returns the content-addressed fingerprint of a run's identity
+// fields. It always implements CurrentFingerprintVersion -- Compute has no
+// notion of "compute the old way," because a fingerprint already recorded
+// under FingerprintVersionLegacy is never recomputed (see FingerprintVersion
+// and ADR 0004): it stays exactly what was stored, and FingerprintVersion is
+// what tells a reader which contract produced it.
 //
 // Map iteration order in Go is deliberately randomized, so Params is sorted
 // before hashing: the same experiment described twice must produce the same
-// fingerprint, or nothing downstream can group runs.
+// fingerprint, or nothing downstream can group runs. Each param value is
+// also normalized (normalizeParamValue) before hashing, so a param that
+// merely looks like a different spelling of the same number -- "3e-4" versus
+// "0.0003" versus "0.00030" -- hashes the same regardless of which spelling
+// a particular client happened to send (ADR 0012).
 func (r *Run) Compute() string {
 	h := sha256.New()
 	write := func(parts ...string) {
@@ -126,7 +179,101 @@ func (r *Run) Compute() string {
 	}
 	sort.Strings(keys)
 	for _, k := range keys {
-		write(k, r.Params[k])
+		write(k, normalizeParamValue(r.Params[k]))
 	}
 	return hex.EncodeToString(h.Sum(nil))
+}
+
+// numericParamPattern matches the shape Compute treats as "a number, however
+// it's spelled": an optional sign, a JSON-number-shaped integer part (no
+// leading zeros, matching RFC 8259) or a bare leading decimal point, an
+// optional fractional part, and an optional exponent.
+//
+// It deliberately does not match everything strconv.ParseFloat accepts,
+// because ParseFloat's grammar is Go's floating-point-literal syntax, not
+// "numbers as ML tooling and JSON spell them," and two things it accepts
+// would silently misfire if this function fed them straight to ParseFloat:
+//
+//   - "1_000": ParseFloat accepts underscores as a Go numeric-literal digit
+//     separator. A param value is arbitrary user/CLI/JSON input, not Go
+//     source -- nothing else in this system treats "1_000" as a spelling of
+//     1000, so silently normalizing it here would be Compute inventing an
+//     equivalence no client asked for.
+//   - "007": ParseFloat parses leading zeros as an ordinary decimal (007 ==
+//     7). A zero-padded value is at least as likely to be an opaque
+//     identifier -- a shard id, a zero-padded run suffix -- as a number
+//     whose leading zeros are insignificant, and this package has no basis
+//     for guessing which. JSON's own number grammar excludes leading zeros
+//     for the same reason; this pattern follows it.
+//
+// "NaN", "Inf", "-Inf", and "Infinity" are excluded structurally, not by
+// special-casing the literal strings: they contain letters the pattern
+// doesn't allow outside the "e"/"E" exponent marker, so they never reach
+// strconv.ParseFloat and pass through Compute unchanged. That is deliberate
+// even though ParseFloat itself accepts all four (case-insensitively) with
+// no error -- unlike a finite number, there is no single canonical spelling
+// two different "Inf" literals necessarily agree on being about the same
+// underlying value, and NaN famously isn't equal to itself, which would make
+// folding every NaN spelling into one canonical string actively misleading
+// as an identity key rather than merely unnormalized.
+var numericParamPattern = regexp.MustCompile(`^-?((0|[1-9]\d*)(\.\d+)?|\.\d+)([eE][+-]?\d+)?$`)
+
+// normalizeParamValue rewrites v to a canonical spelling when it is
+// unambiguously a finite decimal number, so the same hyperparameter value
+// hashes identically no matter which of several equivalent spellings a
+// client sent. A value this function does not recognize as numeric --
+// including every case numericParamPattern's doc comment calls out --
+// passes through byte-for-byte unchanged: normalizing is only ever a no-op
+// or a like-for-like rewrite, never a way to lose information Compute has no
+// basis for discarding.
+func normalizeParamValue(v string) string {
+	if !numericParamPattern.MatchString(v) {
+		return v
+	}
+	f, err := strconv.ParseFloat(v, 64)
+	if err != nil {
+		// The pattern already guarantees valid float syntax, so the only
+		// way ParseFloat still errors is ErrRange: v is a syntactically
+		// well-formed number too large for float64 (e.g. "1e400", which
+		// ParseFloat resolves to +Inf plus this error). Formatting that
+		// would silently collapse every magnitude beyond float64's range
+		// onto one canonical "+Inf" spelling -- a far bigger identity
+		// change than reconciling spellings of the same in-range number --
+		// so an unrepresentable magnitude is left exactly as written.
+		return v
+	}
+	if f == 0 && !isZeroLiteral(v) {
+		// The mirror image of the overflow case, and easier to miss:
+		// ParseFloat silently underflows a nonzero magnitude too small for
+		// float64 (e.g. "1e-400") to exactly 0, with no error at all.
+		// Formatting that would conflate a tiny-but-nonzero literal with an
+		// actual zero, so it gets the same treatment as overflow -- left
+		// alone rather than misrepresented.
+		return v
+	}
+	if f == 0 {
+		// "-0", "-0.0", and "0" are the same hyperparameter value, but
+		// FormatFloat renders a parsed negative zero back out as "-0" --
+		// collapse the sign so they hash identically rather than keeping
+		// the two apart for a distinction nothing measures.
+		f = 0
+	}
+	return strconv.FormatFloat(f, 'g', -1, 64)
+}
+
+// isZeroLiteral reports whether s's significant digits (everything before
+// an exponent marker) are all zero -- i.e. s spells an exact zero rather
+// than a nonzero magnitude that merely underflows float64 to 0. Only
+// meaningful once numericParamPattern has already confirmed s is
+// number-shaped, which is the only way normalizeParamValue calls it.
+func isZeroLiteral(s string) bool {
+	if i := strings.IndexAny(s, "eE"); i >= 0 {
+		s = s[:i]
+	}
+	for _, r := range s {
+		if r >= '1' && r <= '9' {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/lineage/run_test.go
+++ b/internal/lineage/run_test.go
@@ -106,3 +106,166 @@ func TestValidateAcceptsAGoodRun(t *testing.T) {
 		t.Fatalf("valid run rejected: %v", err)
 	}
 }
+
+// TestComputeCollapsesEquivalentNumericSpellings pins the bug in issue #63:
+// rlctl sends whatever literal a caller typed on the command line, and the
+// Python client sends str() of an actual float, so the exact same
+// hyperparameter arrives as three different strings depending on which
+// client recorded it and how the number was typed. Before normalization,
+// each spelling below produced a different fingerprint, so the same
+// experiment recorded twice never grouped and spread/unattributable never
+// fired -- a false negative, and a silent one.
+func TestComputeCollapsesEquivalentNumericSpellings(t *testing.T) {
+	spellings := []string{"3e-4", "0.0003", "0.00030", "3.0e-4", "30e-5"}
+	want := ""
+	for _, s := range spellings {
+		r := base()
+		r.Params = map[string]string{"lr": s}
+		got := r.Compute()
+		if want == "" {
+			want = got
+			continue
+		}
+		if got != want {
+			t.Errorf("lr=%q fingerprinted as %s, want %s (same fingerprint as the other spellings)", s, got, want)
+		}
+	}
+}
+
+// TestComputeStillDistinguishesDifferentNumbers guards against a
+// normalization bug in the other direction: collapsing spellings of the
+// same number must not accidentally collapse genuinely different numbers
+// too.
+func TestComputeStillDistinguishesDifferentNumbers(t *testing.T) {
+	a, b := base(), base()
+	a.Params = map[string]string{"lr": "3e-4"}
+	b.Params = map[string]string{"lr": "3e-5"}
+	if a.Compute() == b.Compute() {
+		t.Fatal("3e-4 and 3e-5 are different learning rates and must not fingerprint identically")
+	}
+}
+
+// TestComputeLeavesNonNumericParamsUntouched is the negative case Compute
+// must get right for normalization to be safe: a param value that isn't a
+// number is identity-bearing exactly as written, and normalizeParamValue
+// must never rewrite it.
+func TestComputeLeavesNonNumericParamsUntouched(t *testing.T) {
+	values := map[string]string{
+		"git-sha-shaped":   "a1b2c3d",
+		"path":             "/mnt/data/v2",
+		"empty":            "",
+		"boolean spelling": "true",
+	}
+	for name, v := range values {
+		t.Run(name, func(t *testing.T) {
+			if got := normalizeParamValue(v); got != v {
+				t.Fatalf("normalizeParamValue(%q) = %q, want it unchanged", v, got)
+			}
+			// Compute must actually route through normalizeParamValue for
+			// these, not just leave them untouched by accident of never
+			// being called -- distinguish it from base() (no params).
+			a := base()
+			b := base()
+			b.Params = map[string]string{"p": v}
+			if a.Compute() == b.Compute() {
+				t.Fatalf("adding param %q=%q did not change the fingerprint", "p", v)
+			}
+		})
+	}
+}
+
+// TestNormalizeParamValueHandlesEdgeCasesDeliberately covers the cases the
+// issue specifically called out: overflow, the two non-finite spellings,
+// zero-padding, and Go's numeric-literal underscore separator. Each is
+// either normalized to a well-defined canonical form or passed through
+// completely unchanged -- never silently reinterpreted.
+func TestNormalizeParamValueHandlesEdgeCasesDeliberately(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		// The three spellings from the issue, plus a couple more, all
+		// collapse to one canonical form.
+		{"exponent form", "3e-4", "0.0003"},
+		{"decimal form", "0.0003", "0.0003"},
+		{"trailing zero", "0.00030", "0.0003"},
+		{"plain integer unchanged in value", "100", "100"},
+		{"trailing .0 dropped", "100.0", "100"},
+
+		// Overflow: syntactically a number, but strconv.ParseFloat cannot
+		// represent it -- left exactly as written rather than collapsed to
+		// "+Inf".
+		{"overflow", "1e400", "1e400"},
+		// Underflow: the mirror case ParseFloat gives no error for at all
+		// -- also left exactly as written rather than collapsed to "0".
+		{"underflow", "1e-400", "1e-400"},
+
+		// Not numbers as far as this function is concerned, even though
+		// ParseFloat itself would happily accept every one of them.
+		{"NaN passes through", "NaN", "NaN"},
+		{"Inf passes through", "Inf", "Inf"},
+		{"signed Inf passes through", "-Inf", "-Inf"},
+		{"Infinity passes through", "Infinity", "Infinity"},
+
+		// Go-source numeric-literal leniency that a param value must not
+		// inherit: an underscore digit separator, and a leading zero.
+		{"underscore separator untouched", "1_000", "1_000"},
+		{"zero-padded untouched", "007", "007"},
+
+		// Signed zero collapses to one spelling -- "-0" and "0" are the
+		// same hyperparameter value.
+		{"negative zero canonicalized", "-0", "0"},
+		{"negative zero with fraction canonicalized", "-0.0", "0"},
+
+		// Not numeric at all.
+		{"identifier untouched", "run-42", "run-42"},
+		{"empty string untouched", "", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := normalizeParamValue(c.in); got != c.want {
+				t.Fatalf("normalizeParamValue(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+// TestComputeNormalizationRoundTripsThroughIdenticalSpellings is a smaller,
+// direct check that Compute (not just normalizeParamValue in isolation)
+// applies normalization to every param, not just one hardcoded key.
+func TestComputeNormalizationRoundTripsThroughIdenticalSpellings(t *testing.T) {
+	a, b := base(), base()
+	a.Params = map[string]string{"lr": "3e-4", "warmup_frac": "007", "batch": "32.0"}
+	b.Params = map[string]string{"lr": "0.0003", "warmup_frac": "007", "batch": "32"}
+	if a.Compute() != b.Compute() {
+		t.Fatalf("expected normalized params to fingerprint identically: a=%s b=%s", a.Compute(), b.Compute())
+	}
+}
+
+// TestFingerprintVersionIsStampedTogetherWithFingerprint documents the
+// invariant callers must keep: Fingerprint and FingerprintVersion always
+// describe the same computation. Compute doesn't set FingerprintVersion
+// itself (it has no side effect on r, and returns only the hash), so this
+// pins that CurrentFingerprintVersion is the version a fresh Compute call
+// corresponds to -- the constant api.record and every Store test fixture
+// must pair with a freshly computed Fingerprint.
+func TestFingerprintVersionIsStampedTogetherWithFingerprint(t *testing.T) {
+	if CurrentFingerprintVersion == FingerprintVersionLegacy {
+		t.Fatal("CurrentFingerprintVersion must differ from FingerprintVersionLegacy, or a legacy record and a freshly computed one become indistinguishable")
+	}
+	// A legacy run whose stored Fingerprint was never recomputed keeps
+	// whatever value it already had -- Compute must not be consulted to
+	// "verify" or "upgrade" it. This is a documentation test: there is no
+	// API that recomputes a stored fingerprint, which is the point.
+	legacy := base()
+	legacy.Params = map[string]string{"lr": "3e-4"}
+	legacy.Fingerprint = "some-fingerprint-hashed-under-the-old-contract"
+	legacy.FingerprintVersion = FingerprintVersionLegacy
+	if legacy.Fingerprint == legacy.Compute() {
+		t.Fatal("test setup: the legacy fixture's stored fingerprint should not equal a fresh Compute() by coincidence")
+	}
+	if legacy.Fingerprint != "some-fingerprint-hashed-under-the-old-contract" {
+		t.Fatal("a version-1 record's stored fingerprint must not be reinterpreted or recomputed")
+	}
+}

--- a/internal/store/conformance.go
+++ b/internal/store/conformance.go
@@ -24,7 +24,12 @@ func RunConformance(t *testing.T, newStore func(t *testing.T) Store) {
 			Project: project, GitCommit: "c" + id, ConfigHash: "cfg",
 			RunID: id, Status: lineage.StatusSucceeded, StartedAt: at, Device: "cpu",
 		}
+		// Fingerprint and FingerprintVersion are always stamped together --
+		// Compute always implements CurrentFingerprintVersion, so a run
+		// whose Fingerprint came from a fresh Compute() call must record
+		// that version, the same pairing api.record does for a real request.
 		r.Fingerprint = r.Compute()
+		r.FingerprintVersion = lineage.CurrentFingerprintVersion
 		return r
 	}
 

--- a/internal/store/duckdb.go
+++ b/internal/store/duckdb.go
@@ -111,6 +111,28 @@ var migrations = []string{
 	// anything?" grouping.
 	`CREATE INDEX IF NOT EXISTS idx_runs_project_started ON runs (project, started_at_ns DESC)`,
 	`CREATE INDEX IF NOT EXISTS idx_runs_fingerprint ON runs (fingerprint)`,
+	// ADR 0012: Compute now normalizes numeric param spellings before
+	// hashing, which changes what Fingerprint means for any run recorded
+	// from here on. Every row that already exists at the moment this
+	// migration runs was fingerprinted under the old, unnormalized contract
+	// -- ADR 0004 is explicit that such a change must never silently
+	// reinterpret what's already stored, so this only adds a column, never
+	// touches the fingerprint column itself. DEFAULT 1 backfills every
+	// pre-existing row to lineage.FingerprintVersionLegacy in the same
+	// statement that adds the column, so there is no window where a
+	// pre-migration row reads back with an undefined version. Every row
+	// inserted after this migration gets an explicit value from the caller
+	// (api.record stamps lineage.CurrentFingerprintVersion), so the default
+	// only ever fires for rows that predate the column.
+	//
+	// Not declared NOT NULL: this DuckDB version rejects ADD COLUMN with an
+	// inline column constraint ("Adding columns with constraints not yet
+	// supported"). DEFAULT alone still backfills every existing row to a
+	// real value, and Record always supplies an explicit
+	// FingerprintVersion for every future insert, so a NULL in this column
+	// should never occur in practice -- the constraint would only catch a
+	// bug that got this far already writing bad data, not prevent one.
+	`ALTER TABLE runs ADD COLUMN fingerprint_version INTEGER DEFAULT 1`,
 }
 
 func (d *DuckDB) migrate(ctx context.Context) error {
@@ -190,12 +212,12 @@ func (d *DuckDB) Record(ctx context.Context, r lineage.Run) error {
 	_, err = tx.ExecContext(ctx, `
 		INSERT INTO runs (
 			run_id, project, git_commit, git_dirty, config_hash, dataset_version,
-			model_version, seed, fingerprint, host, device, framework_version,
-			status, started_at_ns, ended_at_ns, checkpoint_uri
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			model_version, seed, fingerprint, fingerprint_version, host, device,
+			framework_version, status, started_at_ns, ended_at_ns, checkpoint_uri
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		r.RunID, r.Project, r.GitCommit, r.GitDirty, r.ConfigHash, r.DatasetVersion,
-		r.ModelVersion, r.Seed, r.Fingerprint, r.Host, r.Device, r.FrameworkVersion,
-		string(r.Status), r.StartedAt.UnixNano(), endedAt, r.CheckpointURI,
+		r.ModelVersion, r.Seed, r.Fingerprint, r.FingerprintVersion, r.Host, r.Device,
+		r.FrameworkVersion, string(r.Status), r.StartedAt.UnixNano(), endedAt, r.CheckpointURI,
 	)
 	if err != nil {
 		return fmt.Errorf("inserting run: %w", err)
@@ -286,8 +308,8 @@ func (d *DuckDB) Get(ctx context.Context, runID string) (lineage.Run, error) {
 func (d *DuckDB) get(ctx context.Context, q queryer, runID string) (lineage.Run, error) {
 	r, err := scanRun(q.QueryRowContext(ctx, `
 		SELECT run_id, project, git_commit, git_dirty, config_hash, dataset_version,
-			model_version, seed, fingerprint, host, device, framework_version,
-			status, started_at_ns, ended_at_ns, checkpoint_uri
+			model_version, seed, fingerprint, fingerprint_version, host, device,
+			framework_version, status, started_at_ns, ended_at_ns, checkpoint_uri
 		FROM runs WHERE run_id = ?`, runID))
 	if err != nil {
 		return lineage.Run{}, err
@@ -310,8 +332,8 @@ func scanRun(row *sql.Row) (lineage.Run, error) {
 	var endedAtNS sql.NullInt64
 	err := row.Scan(
 		&r.RunID, &r.Project, &r.GitCommit, &r.GitDirty, &r.ConfigHash, &r.DatasetVersion,
-		&r.ModelVersion, &r.Seed, &r.Fingerprint, &r.Host, &r.Device, &r.FrameworkVersion,
-		&status, &startedAtNS, &endedAtNS, &r.CheckpointURI,
+		&r.ModelVersion, &r.Seed, &r.Fingerprint, &r.FingerprintVersion, &r.Host, &r.Device,
+		&r.FrameworkVersion, &status, &startedAtNS, &endedAtNS, &r.CheckpointURI,
 	)
 	if err == sql.ErrNoRows {
 		return lineage.Run{}, ErrNotFound
@@ -401,8 +423,8 @@ func (d *DuckDB) List(ctx context.Context, query Query) (Page, error) {
 
 	sqlStr := `
 		SELECT run_id, project, git_commit, git_dirty, config_hash, dataset_version,
-			model_version, seed, fingerprint, host, device, framework_version,
-			status, started_at_ns, ended_at_ns, checkpoint_uri
+			model_version, seed, fingerprint, fingerprint_version, host, device,
+			framework_version, status, started_at_ns, ended_at_ns, checkpoint_uri
 		FROM runs`
 	if len(where) > 0 {
 		sqlStr += " WHERE " + strings.Join(where, " AND ")
@@ -431,8 +453,8 @@ func (d *DuckDB) List(ctx context.Context, query Query) (Page, error) {
 		var endedAtNS sql.NullInt64
 		if err := rows.Scan(
 			&r.RunID, &r.Project, &r.GitCommit, &r.GitDirty, &r.ConfigHash, &r.DatasetVersion,
-			&r.ModelVersion, &r.Seed, &r.Fingerprint, &r.Host, &r.Device, &r.FrameworkVersion,
-			&status, &startedAtNS, &endedAtNS, &r.CheckpointURI,
+			&r.ModelVersion, &r.Seed, &r.Fingerprint, &r.FingerprintVersion, &r.Host, &r.Device,
+			&r.FrameworkVersion, &status, &startedAtNS, &endedAtNS, &r.CheckpointURI,
 		); err != nil {
 			rows.Close()
 			return Page{}, err

--- a/internal/store/duckdb.go
+++ b/internal/store/duckdb.go
@@ -111,7 +111,7 @@ var migrations = []string{
 	// anything?" grouping.
 	`CREATE INDEX IF NOT EXISTS idx_runs_project_started ON runs (project, started_at_ns DESC)`,
 	`CREATE INDEX IF NOT EXISTS idx_runs_fingerprint ON runs (fingerprint)`,
-	// ADR 0012: Compute now normalizes numeric param spellings before
+	// ADR 0013: Compute now normalizes numeric param spellings before
 	// hashing, which changes what Fingerprint means for any run recorded
 	// from here on. Every row that already exists at the moment this
 	// migration runs was fingerprinted under the old, unnormalized contract

--- a/internal/store/duckdb_test.go
+++ b/internal/store/duckdb_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"database/sql"
 	"path/filepath"
 	"testing"
 	"time"
@@ -40,6 +41,7 @@ func TestDuckDBPersistsAcrossReopen(t *testing.T) {
 		Params: map[string]string{"lr": "3e-4"}, Metrics: map[string]float64{"loss": 0.1},
 	}
 	r.Fingerprint = r.Compute()
+	r.FingerprintVersion = lineage.CurrentFingerprintVersion
 	if err := s1.Record(ctx, r); err != nil {
 		t.Fatalf("Record: %v", err)
 	}
@@ -62,6 +64,79 @@ func TestDuckDBPersistsAcrossReopen(t *testing.T) {
 	}
 	if !got.StartedAt.Equal(r.StartedAt) {
 		t.Fatalf("StartedAt did not survive a close/reopen cycle: got %v, want %v", got.StartedAt, r.StartedAt)
+	}
+	if got.FingerprintVersion != lineage.CurrentFingerprintVersion {
+		t.Fatalf("FingerprintVersion did not survive a close/reopen cycle: got %d, want %d", got.FingerprintVersion, lineage.CurrentFingerprintVersion)
+	}
+}
+
+// TestDuckDBLegacyRowsDefaultToFingerprintVersion1 exercises the migration
+// this change ships (ADR 0012): fingerprint_version is added by an ALTER
+// TABLE ... DEFAULT, not baked into the original CREATE TABLE, precisely so
+// that a row written before this migration existed reads back tagged
+// FingerprintVersionLegacy -- never Compute run fresh against it, and never
+// left at an undefined zero value.
+//
+// It simulates a pre-migration database the way the real one gets there: by
+// creating the runs table from migrations[0] alone (the original schema,
+// unedited -- see the comment on the migrations slice for why it is never
+// edited after release) and inserting a row directly, bypassing NewDuckDB
+// and its full migration chain entirely. Opening that database through
+// NewDuckDB afterward is what a real upgrade does.
+func TestDuckDBLegacyRowsDefaultToFingerprintVersion1(t *testing.T) {
+	ctx := context.Background()
+	dsn := filepath.Join(t.TempDir(), "runs.duckdb")
+
+	preMigration, err := sql.Open("duckdb", dsn)
+	if err != nil {
+		t.Fatalf("opening pre-migration duckdb: %v", err)
+	}
+	// migrations[0] is the original runs table, with no fingerprint_version
+	// column at all -- exactly the shape a database predating this change
+	// would have.
+	if _, err := preMigration.ExecContext(ctx, migrations[0]); err != nil {
+		t.Fatalf("creating pre-migration schema: %v", err)
+	}
+	const legacyFingerprint = "hashed-under-the-unnormalized-contract"
+	_, err = preMigration.ExecContext(ctx, `
+		INSERT INTO runs (
+			run_id, project, git_commit, git_dirty, config_hash, dataset_version,
+			model_version, seed, fingerprint, host, device, framework_version,
+			status, started_at_ns, ended_at_ns, checkpoint_uri
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		"legacy-run", "p", "c1", false, "cfg", "", "", 0,
+		legacyFingerprint, "", "", "", string(lineage.StatusSucceeded), time.Now().UnixNano(), nil, "",
+	)
+	if err != nil {
+		t.Fatalf("inserting pre-migration row: %v", err)
+	}
+	if err := preMigration.Close(); err != nil {
+		t.Fatalf("closing pre-migration handle: %v", err)
+	}
+
+	// A real upgrade opens the existing database through NewDuckDB, which
+	// runs every migration not yet applied -- here, only the new one, since
+	// the table this DSN already has satisfies "IF NOT EXISTS" for the rest.
+	s, err := NewDuckDB(dsn)
+	if err != nil {
+		t.Fatalf("NewDuckDB against a pre-migration database: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	got, err := s.Get(ctx, "legacy-run")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.FingerprintVersion != lineage.FingerprintVersionLegacy {
+		t.Fatalf("want a pre-migration row backfilled to FingerprintVersionLegacy (%d), got %d",
+			lineage.FingerprintVersionLegacy, got.FingerprintVersion)
+	}
+	// The point of versioning the contract instead of just fixing Compute:
+	// the stored fingerprint is never touched by the migration or by
+	// reading it back, whatever Compute would produce for this content today.
+	if got.Fingerprint != legacyFingerprint {
+		t.Fatalf("a pre-existing fingerprint must not be reinterpreted by the migration: got %q, want %q",
+			got.Fingerprint, legacyFingerprint)
 	}
 }
 

--- a/internal/store/duckdb_test.go
+++ b/internal/store/duckdb_test.go
@@ -71,7 +71,7 @@ func TestDuckDBPersistsAcrossReopen(t *testing.T) {
 }
 
 // TestDuckDBLegacyRowsDefaultToFingerprintVersion1 exercises the migration
-// this change ships (ADR 0012): fingerprint_version is added by an ALTER
+// this change ships (ADR 0013): fingerprint_version is added by an ALTER
 // TABLE ... DEFAULT, not baked into the original CREATE TABLE, precisely so
 // that a row written before this migration existed reads back tagged
 // FingerprintVersionLegacy -- never Compute run fresh against it, and never

--- a/python/runledger/_run.py
+++ b/python/runledger/_run.py
@@ -251,7 +251,7 @@ class Run:
             # typed; str(3e-4) here gives "0.0003", a different string for
             # the same value). The server now normalizes any numeric-looking
             # param value before hashing it into the fingerprint (see
-            # lineage.Run.Compute and ADR 0012), so this client only has to
+            # lineage.Run.Compute and ADR 0013), so this client only has to
             # produce *a* string that parses back to the right number, not
             # *the* string another client would have produced. Duplicating
             # Go's canonicalization here would just be a second

--- a/python/runledger/_run.py
+++ b/python/runledger/_run.py
@@ -243,6 +243,20 @@ class Run:
             # the same shape rlctl's --param key=value produces. Coercing
             # here lets callers pass a plain dict of numbers/bools/whatever
             # without hand-stringifying each value themselves.
+            #
+            # str(v) is not made to match Go's canonical float spelling, and
+            # deliberately isn't: two clients agreeing on one exact string
+            # for every number is the fragile version of this problem, the
+            # one that broke before (rlctl sends the literal "3e-4" a user
+            # typed; str(3e-4) here gives "0.0003", a different string for
+            # the same value). The server now normalizes any numeric-looking
+            # param value before hashing it into the fingerprint (see
+            # lineage.Run.Compute and ADR 0012), so this client only has to
+            # produce *a* string that parses back to the right number, not
+            # *the* string another client would have produced. Duplicating
+            # Go's canonicalization here would just be a second
+            # implementation of the same rule, with its own chance to drift
+            # from the first.
             payload["params"] = {k: str(v) for k, v in self.params.items()}
         if self._metrics:
             payload["metrics"] = dict(self._metrics)


### PR DESCRIPTION
Fixes #63

## Summary

`lineage.Run.Compute` hashed each param value as the exact string a client sent, so the same hyperparameter recorded three ways — `lr="3e-4"`, `lr="0.0003"`, `lr="0.00030"` — produced three different fingerprints. Worse, the two clients this repo ships disagree about spelling for the *same* input: `rlctl --param` sends the literal string a user typed, while the Python client's `Run.start(params={"lr": 3e-4})` sends `str(3e-4)` == `"0.0003"`. The same experiment, recorded from the CLI once and from training code once, never fingerprinted the same — a false negative that fails silently (`spread` never sees the repeat, `unattributable` never fires).

Full reasoning, including alternatives considered and rejected, is in [`docs/adr/0013-param-values-are-normalized-before-hashing.md`](docs/adr/0013-param-values-are-normalized-before-hashing.md).

## What changed

- **Normalization is server-side**, in `internal/lineage.Run.Compute`. Per ADR 0001 the server decides identity, not the client — relying on every client to format numbers identically would repeat the exact mistake ADR 0001 exists to prevent. Neither `rlctl` nor the Python client needed a behavior change.
- **"Numeric" is JSON-number-shaped** (optional sign, no leading zeros, optional fraction/exponent), parsed with `strconv.ParseFloat` and re-emitted with `FormatFloat(f, 'g', -1, 64)`. Deliberately excludes Go-specific leniency: `"1_000"` (underscore digit separator) and `"007"` (leading zero) pass through untouched. `"1e400"` (overflow) and its unreported twin `"1e-400"` (silent underflow to `0`, found while testing) are both left exactly as written rather than collapsed to `+Inf`/`0`. `"NaN"`/`"Inf"`/`"-Inf"`/`"Infinity"` never reach `ParseFloat` at all — they contain letters the pattern doesn't allow, so they're excluded structurally, not by special-casing the literal strings. Anything not recognized as numeric passes through byte-for-byte unchanged.
- **The fingerprint is now a versioned contract** (ADR 0004 requires this for any hash-input change, even a "fix"). `lineage.Run` gains `FingerprintVersion` (`fingerprint_version` on the wire), stamped alongside `Fingerprint` by `api.record`, never independently. `FingerprintVersionLegacy` (1) names the pre-normalization contract; `CurrentFingerprintVersion` (2) names this one. DuckDB gets one new migration appended to the existing chain (never editing the original `CREATE TABLE`): `ALTER TABLE runs ADD COLUMN fingerprint_version INTEGER DEFAULT 1`, backfilling every pre-existing row to `FingerprintVersionLegacy` in the same statement that adds the column.
- **Unlike ADR 0011**, this cannot be fixed by declaring one spelling canonical after the fact — existing param records already carry whichever spelling their client actually sent on purpose, and every fingerprint already computed from either spelling is a real, load-bearing value. See the ADR for why that distinguishes this case from ADR 0011's.
- `internal/compare.SameExperiment` needed **no change**: it already prefers the stored fingerprint over recomputing whenever both runs have one, which is exactly what keeps a version-1 fingerprint meaning what it meant when recorded.

## Also touched

- `docs/openapi.yaml`: `fingerprint_version` added to `RunInput`/`Run` schemas, keeping `spec_test.go` green.
- `python/runledger/_run.py`: one comment, no behavior change.
- `cmd/rlctl/main.go`: no change needed — it already forwards the literal string typed.
- `internal/store/conformance.go` / `duckdb_test.go`: test fixtures stamp `FingerprintVersion` alongside `Fingerprint`; new test simulates a pre-migration database and asserts a legacy row backfills correctly with its stored fingerprint untouched.

## Test plan

- [x] `go build ./... && go vet ./... && go test -race ./...`
- [x] `gofmt -l .` is clean
- [x] `python3 -m unittest discover -s python/tests`
- [x] `python3 -m unittest discover -s dashboard/tests`
- [x] `python3 -m unittest discover -s examples/churn`
- [x] New tests: three issue spellings collapsing to one fingerprint (unit + end-to-end via the API), a table of deliberate edge cases (overflow/underflow/NaN/Inf/underscore/leading-zero/signed-zero), non-numeric params untouched, client cannot dictate `fingerprint_version`, DuckDB legacy-row migration backfill

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
