### PR TITLE
python: record a running run at start, so a SIGKILL/OOM leaves a trace

### DIFF
--- a/docs/adr/0005-python-client-writes-once-at-the-end.md
+++ b/docs/adr/0005-python-client-writes-once-at-the-end.md
@@ -1,5 +1,7 @@
 # ADR 0005: The Python client writes the ledger exactly once, at the end of a run
 
+**Superseded by [ADR 0014](0014-python-client-writes-running-then-patches-terminal.md).**
+
 Status: Accepted
 Date: 2026-08-27
 

--- a/docs/adr/0014-python-client-writes-running-then-patches-terminal.md
+++ b/docs/adr/0014-python-client-writes-running-then-patches-terminal.md
@@ -1,0 +1,113 @@
+# ADR 0014: The Python client writes a `running` record at start, and patches it to a terminal status at the end
+
+Status: Accepted
+Date: 2026-08-29
+
+Supersedes [ADR 0005](0005-python-client-writes-once-at-the-end.md).
+
+## Context
+
+ADR 0005 chose to buffer a run's status and metrics locally and write the
+ledger exactly once, in `__exit__`, once the outcome was known. Its own
+"Revisited" section named the precondition for changing that: `spread`
+(`internal/api/api.go`) had to consider only terminal runs, or a `running`
+record's mid-training metric would be counted as a repeat measurement and
+could rank a fingerprint top of "reproduces worst" -- a false positive on
+the ledger's central claim.
+
+#52 ("Exclude non-terminal runs from spread") landed that precondition:
+`terminalRuns()` now filters both `spreadList` and `spreadOne`
+(`internal/api/api.go`) before either ever reaches `spread.Compute`. Issue
+#64 was filed believing this filter was still missing, and blocked on issue
+#65 to add it. #65's first comment corrected that: the filter already
+exists, landed by #52 before #64 was even filed, and #64 was never
+actually blocked on it.
+
+The reason ADR 0005 gave for writing once no longer holds. Meanwhile, that
+design has carried a real cost the whole time it stood: `Run.start()`
+wrote the ledger only from `__exit__`, and nothing runs `__exit__` for a
+`SIGKILL`, an OOM kill, or a scheduler escalating past its grace period --
+the single most common way a real training job actually dies. Those
+produced *zero* trace: not a `failed` record, not a spooled line, nothing.
+`SIGKILL` cannot be caught by anything running in the process that
+receives it; the only way to survive it is to already have a record on the
+server before it arrives. `/v1/fingerprints` no longer rewards writing a
+`running` record early with a spread false positive, so writing early is
+now the only cost-free way to survive an uncatchable kill, and the balance
+that held ADR 0005 in place has flipped.
+
+## Decision
+
+`Run.start()` now writes the ledger twice:
+
+1. At `_enter()`, immediately after git context is captured and validated
+   (before any training happens), it `POST`s a `running` record. Success
+   populates `run.run_id` and `run.fingerprint` right away, rather than
+   only at the end of the run.
+2. At `_finish()`, it `PATCH`es that run to its terminal status
+   (`succeeded`/`failed`) with `ended_at` and the metrics logged before
+   then. This is exactly the `rlctl start` / `rlctl finish` lifecycle
+   (`cmd/rlctl/main.go`), and exactly the `created -> running ->
+   {succeeded, failed, cancelled}` transition the server already enforces
+   (`legalTransitions` in `internal/store/store.go`).
+
+This closes the gap ADR 0005 named as its own remaining consequence: a
+kill that bypasses `__exit__` entirely now still leaves the `running`
+record behind, even though nothing ever updates it to a terminal status.
+That is strictly better than the zero-trace status quo, and it is exactly
+what a person debugging a pile of dead runs needs to reconstruct: which
+configuration was running, on what commit, and when it stopped answering.
+
+`SIGTERM` -- the signal a scheduler almost always sends before escalating
+to `SIGKILL` -- is now also handled directly. A handler installed at
+`_enter()` (main thread only; Python refuses to install a handler anywhere
+else) records the active run(s) as `failed`, then chains to whatever
+handler was previously installed, or restores the default disposition and
+re-sends the signal to this process if there wasn't one worth calling --
+so the signal still kills the process the way its sender intended, rather
+than being silently absorbed. An `atexit` hook backstops whatever that
+misses (a run started off the main thread; a chained handler further up
+that calls `sys.exit()` instead of dying from the signal itself).
+
+**Recording must still never fail the training run**, so the start-time
+write follows the write side's existing degrade-to-warning rule
+(`python/runledger/_run.py`'s "never let recording fail the training run"
+design note), with one difference: it does not spool on failure. A
+`running` record with nothing to ever follow it up is worse than no record
+-- and spooling it would conflict with a spool contract (ADR 0008) that
+already treats a spooled line as one *complete* run. Concretely:
+
+- If the start-time `POST` fails, `_finish()` finds no `run_id` and falls
+  back to a single full `POST` at the end -- exactly ADR 0005's original
+  one-shot behaviour -- which spools on failure exactly as it always did.
+- If the start-time `POST` succeeds but the closing `PATCH` fails, the
+  full record is spooled in the patch's place. Replay (`replay.py`, ADR
+  0008) only knows how to resend a complete `POST /runs` body, not a
+  partial patch, so replaying that spool line creates a second, terminal
+  row rather than resurrecting the original `run_id` -- leaving an
+  orphaned `running` row behind that never reaches a terminal status. That
+  row is invisible to `spread` either way (`terminalRuns`, #52); losing
+  the run's final metrics would be the worse outcome of the two.
+
+## Consequences
+
+- A run killed by `SIGKILL`, the OOM killer, or a scheduler's hard timeout
+  now leaves a `running` record behind: accurate identity and provenance,
+  the `started_at` it began at, no terminal status and no final metrics --
+  but it exists, and it's visible with `rlctl list --status running` (or
+  `runledger.runs(status="running")`) to a person reconstructing what died.
+- A run killed by `SIGTERM` -- which is most of them; `SIGKILL` is usually
+  a scheduler's second resort after a grace period -- is now recorded
+  `failed` with whatever metrics had been logged, the same as an
+  in-process exception, provided the process is in its main thread (Python
+  does not allow installing signal handlers anywhere else).
+- The ledger now has a live "this is currently running" record while
+  training runs, which ADR 0005 listed as a capability this client lacked.
+  A dashboard can show in-flight runs from this client for the first time.
+- Two HTTP calls per run instead of one, and up to two `RuntimeWarning`s
+  instead of one in the fully-degraded (ledger unreachable for the whole
+  run) case. Both still spool at most once, not twice.
+- A `PATCH` failure after a successful start write leaves a permanently
+  non-terminal `running` row behind once the spooled replacement is
+  eventually replayed. Nothing here cleans that row up automatically --
+  that is a known, accepted cost, not an oversight.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -23,6 +23,7 @@ section is a summary of these; this folder is the account.
 | [0009](0009-url-path-versioning-for-the-http-api.md) | URL path versioning (`/v1`) for the HTTP API, excluding health/readiness/metrics | Accepted |
 | [0010](0010-comparisons-is-a-resource-not-a-verb.md) | `/comparisons` is a resource, not a verb | Accepted |
 | [0011](0011-empty-string-means-not-recorded.md) | An empty string means "not recorded" | Accepted |
+| [0014](0014-python-client-writes-running-then-patches-terminal.md) | The Python client writes a `running` record at start, and patches it to a terminal status at the end | Accepted |
 
 ## Adding a record
 

--- a/python/README.md
+++ b/python/README.md
@@ -61,13 +61,17 @@ The first six are **identity** — they are hashed into the run's fingerprint.
 The last three configure the client and are not recorded in the ledger. The
 names match the wire schema and `rlctl`'s flags exactly.
 
-`run.log_metric(name, value)` records a measured metric as training
-progresses. Nothing is sent to the ledger yet — see below.
+`run.log_metric(name, value)` records a measured metric locally as training
+progresses; it is not sent to the ledger until the run ends.
 
-On a normal exit, the run is recorded `succeeded`. On an exception, it is
-recorded `failed`, with whatever metrics were logged before the exception,
-and the exception is re-raised unchanged — `Run.start()` never swallows your
-training script's own errors.
+`Run.start()` records the run twice: `running` the moment the `with` block
+is entered, and its outcome when the block ends. On a normal exit, that's
+`succeeded`. On an exception, it's `failed`, with whatever metrics were
+logged before the exception, and the exception is re-raised unchanged —
+`Run.start()` never swallows your training script's own errors. A `SIGTERM`
+partway through is recorded `failed` the same way, and a `SIGKILL` or an OOM
+kill — which nothing can catch — still leaves the `running` record behind.
+See ["Surviving a kill"](#surviving-a-kill) below.
 
 ### The honest example
 
@@ -209,38 +213,73 @@ did my experiments do?" with "they didn't". `RunNotFoundError` (a subclass of
 id or fingerprint — `compare()` names which side, `a` or `b`, when it is the
 one that doesn't exist.
 
-## Why one HTTP call, not two
+## Surviving a kill
 
-It might look natural for `Run.start()` to record the run as `running`
-immediately, then update it to `succeeded`/`failed` at the end. The API
-supports that — `PATCH /v1/runs/{id}` exists, and `rlctl start` / `rlctl finish`
-use it. This client deliberately does not.
+`SIGKILL`, the OOM killer, and a scheduler's hard timeout all end a process
+without running any Python cleanup code — no `except`, no `finally`, no
+`__exit__`. A training job killed that way used to leave *zero* trace in the
+ledger: not a `failed` record, not a spooled line, nothing, because
+`Run.start()` wrote the ledger only once, from `__exit__`, when the outcome
+was already known.
 
-The obstacle is on the read side, not the write side. `/v1/fingerprints` groups
-every run sharing a fingerprint without filtering on status, so a `running`
-record would count as a *repeat measurement* of that experiment and its
-mid-training metric would join the group's min/max/mean/stddev. A loss
-sampled at step 50 of 10,000 sitting beside a finished run's final loss
-would widen the spread and could rank that fingerprint worst-reproducing —
-reporting "something affecting the result went unrecorded" when the real
-explanation is "one of these has not finished." That is a false positive on
-the ledger's central claim, so this client does not create the condition.
+It no longer does. `Run.start()` now `POST`s a `running` record the moment
+the `with` block is entered — before any training happens — and `PATCH`es it
+to `succeeded`/`failed` when the block ends. `run.run_id` and
+`run.fingerprint` are populated right away, from that first call, not only
+at the end.
 
-So it buffers the run's status and metrics locally for its whole lifetime,
-and writes the ledger exactly once, in `Run.start()`'s `__exit__`, once the
-outcome is known. `run.run_id` and `run.fingerprint` are only populated
-after that one call completes. See
-[ADR 0005](../docs/adr/0005-python-client-writes-once-at-the-end.md).
+That means:
+
+- **`SIGKILL` / OOM / a hard scheduler timeout**: uncatchable by
+  construction, so nothing here can record the outcome. But the `running`
+  record from the start of the run is already on the server, so the run
+  isn't invisible — `rlctl list --status running` (or
+  `runledger.runs(status="running")`) shows it, with accurate identity and
+  provenance and no terminal status, for someone reconstructing what died.
+- **`SIGTERM`**: what almost every real scheduler sends *before* escalating
+  to `SIGKILL`. This client catches it (main thread only — Python does not
+  allow installing a signal handler anywhere else) and records the run
+  `failed` with whatever metrics were logged so far, then lets the process
+  die from the signal exactly as it would have otherwise — the handler
+  never turns a kill into a clean exit, and it chains to any handler your
+  own code already installed rather than replacing it.
+- **An exception inside the `with` body**: unchanged — recorded `failed`,
+  re-raised unchanged.
+
+Why this is safe now, when it wasn't before: `/v1/fingerprints` used to
+group every run sharing a fingerprint without filtering on status, so a
+`running` record's mid-training metric would be counted as a repeat
+measurement and could rank that fingerprint worst-reproducing — a false
+positive on the ledger's central claim. That is why this client used to
+write once, at the end (ADR 0005). The server now excludes non-terminal
+runs from `spread` before that comparison ever happens, so a `running`
+record sitting on the server no longer distorts anything it's read back
+into. See [ADR 0014](../docs/adr/0014-python-client-writes-running-then-patches-terminal.md)
+for the full reasoning, including what the closing `PATCH` does when the
+opening `POST` never landed.
 
 ## When the ledger is unreachable
 
-Recording must never fail the training run. If the final write can't reach
-the server — connection refused, timed out, DNS failure, a bad response — the
-client emits a `RuntimeWarning` and appends the run record as one JSON line
-to a local spool file (`~/.runledger/spool.jsonl` by default, or
-`spool_path=` on `Run.start()`) instead of raising. `run.spooled` is `True`
-when that happened, and `run.resolved_spool_path()` is the file it actually
-wrote — `spool_path` keeps whatever you passed, `~` and all.
+Recording must never fail the training run. If either write can't reach the
+server — connection refused, timed out, DNS failure, a bad response — the
+client emits a `RuntimeWarning` rather than raising. What happens next
+depends on which write failed:
+
+- The **start-time write** failing does not spool anything: a `running`
+  record with nothing to ever follow it up would sit in the spool forever,
+  and there's no terminal status or final metrics to give it yet anyway.
+  The run still gets recorded normally if the ledger comes back before it
+  ends — see the next point.
+- The **end-of-run write** failing spools the complete run record as one
+  JSON line to a local spool file (`~/.runledger/spool.jsonl` by default, or
+  `spool_path=` on `Run.start()`). This is the only path that sets
+  `run.spooled = True`; `run.resolved_spool_path()` is the file it actually
+  wrote — `spool_path` keeps whatever you passed, `~` and all. If the
+  start-time write had already succeeded, replaying this spool line later
+  creates a *second*, terminal row rather than resurrecting the original
+  run — the original is left behind, permanently `running`. That row is
+  never counted in `spread` (the server excludes non-terminal runs), so the
+  cost is a little clutter in `rlctl list`, not a wrong verdict.
 
 ### Replaying a spool
 

--- a/python/runledger/_run.py
+++ b/python/runledger/_run.py
@@ -1,55 +1,119 @@
 """Run.start(): the in-process client for recording a run's lineage.
 
-Design note -- why this makes exactly one HTTP call, at the end
------------------------------------------------------------------
-``PATCH /v1/runs/{id}`` exists, so the mechanical obstacle to a "record
-running, then update to succeeded/failed" pair is gone -- ``rlctl start``
-and ``rlctl finish`` do exactly that. This client still does not, on
-purpose, and the reason is analytical rather than mechanical: nothing on
-the read side yet distinguishes a finished run from an in-flight one.
-``/v1/fingerprints`` lists every run sharing a fingerprint without filtering on
-status, so a ``running`` record carrying a mid-training metric would be
-counted as a *repeat measurement* of that experiment. Its half-finished loss
-would widen the group's spread and could rank the fingerprint top of "which
-experiments reproduce worst" -- announcing that something affecting the
-result went unrecorded, when in truth one of the runs simply had not
-finished. That is a false positive on the single claim this ledger exists
-to make.
+Design note -- why this writes the ledger twice, not once
+-----------------------------------------------------------
+`Run.start()` `POST`s a `running` record the moment a run starts, and
+`PATCH`es it to a terminal status (`succeeded`/`failed`) when the `with`
+block ends -- the same two-step lifecycle `rlctl start` / `rlctl finish`
+already use (`cmd/rlctl/main.go`), and exactly the `created -> running ->
+{succeeded, failed, cancelled}` transition the server enforces
+(`internal/store/store.go`'s `legalTransitions`).
 
-Instead, ``Run`` buffers the run's status and metrics locally for its whole
-lifetime and writes the ledger exactly once, in ``__exit__``, once the
-outcome is known. That produces one accurate record per run, and degrading
-to a spool file (see below) applies to that one call.
+That used to be one write, always, from `__exit__`, once the outcome was
+known (ADR 0005). The reason was analytical, not mechanical: `/v1/fingerprints`
+did not filter by status, so a `running` record's mid-training metric would
+be counted as a repeat measurement, widen a fingerprint's spread, and could
+rank it top of "reproduces worst" -- a false positive on the one claim this
+ledger exists to make. That filter now exists (`terminalRuns` in
+`internal/api/api.go`, added by #52), so a non-terminal run no longer
+reaches `spread.Compute` at all. The reason to write once is gone.
 
-See ADR 0005 for the decision, including the read-side change that would
-make revisiting it safe.
+Writing once had a real cost the whole time, though: `__exit__` never runs
+for a `SIGKILL`, an OOM kill, or a scheduler escalating past its grace
+period -- the single most common way a real training job dies -- so those
+produced *zero* trace, not even a `failed` record. `SIGKILL` cannot be
+caught by anything running in the process that receives it; the only way to
+survive it is to already have a record on the server before it arrives.
+That is what the start-time write buys, at the cost described below. See
+ADR 0014 (supersedes ADR 0005) for the full reasoning.
 
 Design note -- never let recording fail the training run
 ----------------------------------------------------------
 A ledger that is down, slow, or unreachable must not turn into an exception
 in the middle of (or at the end of) an expensive job. Any failure to reach
-the server -- a connection error, a timeout, a non-2xx response -- is caught,
-turned into a ``RuntimeWarning``, and the record is appended as one JSON line
-to a local spool file instead. Nothing else about the run is affected.
+the server -- a connection error, a timeout, a non-2xx response -- is caught
+and turned into a ``RuntimeWarning``. This now applies to *two* calls
+instead of one, and they degrade differently:
+
+- If the start-time ``POST`` fails, nothing is spooled. A ``running``
+  record with nothing to ever follow it up would sit in the spool forever
+  (replay only understands complete records, and a run that failed to
+  start recording has no terminal status or final metrics to give it yet).
+  Instead ``_finish()`` notices there is no ``run_id`` and falls back to a
+  single full ``POST`` at the end -- exactly ADR 0005's original one-shot
+  behaviour -- which spools on failure the same way it always did.
+- If the start-time ``POST`` succeeds but the closing ``PATCH`` fails, the
+  full record is spooled in its place. Replay (``replay.py``, ADR 0008)
+  only knows how to resend a complete ``POST /runs`` body, not a partial
+  patch, so on replay this creates a second, terminal row rather than
+  resurrecting the original ``run_id`` -- leaving an orphaned ``running``
+  row behind that never reaches a terminal status. That row is invisible
+  to ``spread`` either way (``terminalRuns``, #52), and losing the run's
+  final metrics would be worse than one stray non-terminal row.
 
 This is distinct from ``UnreconstructibleRunError``: a run with no git
 commit, or a dirty tree with no config hash, is refused immediately, in
 ``Run.start()``, before any training happens -- the same way ``rlctl record``
 refuses it. That is a mistake in how the run was launched, not a ledger
 outage, and failing fast is the useful behavior there.
+
+Design note -- recovering from a kill that never reaches ``__exit__``
+------------------------------------------------------------------------
+``SIGKILL`` cannot be caught -- that is what the start-time ``running``
+record above is for. ``SIGTERM`` can be, and is what almost every real
+scheduler sends first: Slurm's ``scancel``, Kubernetes evicting a pod,
+LSF's ``bkill`` all deliver ``SIGTERM`` and only escalate to ``SIGKILL``
+after a grace period if the process is still alive. Catching it here
+recovers the common case. An ``atexit`` hook backstops whatever the signal
+handler doesn't cover -- a run started off the main thread (Python refuses
+to let anything but the main thread install a signal handler), or a
+handler further up the chain that calls ``sys.exit()`` instead of letting
+the process actually die from the signal.
+
+Two things the signal handler must not do:
+
+1. **Swallow the signal.** A process a scheduler sent ``SIGTERM`` to must
+   still die from ``SIGTERM`` -- not linger, and not exit cleanly with
+   status 0. A shell script checking ``$?``, or a scheduler checking
+   ``WIFSIGNALED``, may depend on that. So after recording, the handler
+   either calls whatever handler was installed before ours, or -- if there
+   wasn't one worth calling (``SIG_DFL``/``SIG_IGN``) -- restores the
+   default disposition and re-sends the signal to this process. That is
+   the standard idiom for "run cleanup code, then die exactly as if the
+   handler had never been installed."
+2. **Clobber a handler that was already there.** A training script that
+   also traps ``SIGTERM`` for its own checkpointing would silently stop
+   doing that the moment ``Run.start()`` ran, if this just called
+   ``signal.signal()`` without saving what was already installed. Instead
+   the previous disposition is saved and invoked -- last in, first served,
+   the same as any other signal-chaining code.
+
+Alternative considered and rejected: registering only via ``atexit``, with
+no signal handler at all. ``atexit`` callbacks do not run when a process
+dies from an uncaught signal -- only on ``sys.exit()``, falling off the end
+of the program, or an uncaught exception unwinding normally -- which is
+exactly the ``SIGTERM`` case. Recording would then depend on user code (or
+some other library) happening to convert the signal into a clean exit
+instead of letting it kill the process, which is not how any scheduler in
+the wild actually behaves. A handler plus ``atexit`` recovers most real
+kills; ``atexit`` alone would recover almost none of them.
 """
 
 from __future__ import annotations
 
+import atexit
 import contextlib
 import dataclasses
 import json
 import os
+import signal
 import socket
+import threading
+import urllib.parse
 import urllib.request
 import warnings
 from datetime import datetime, timezone
-from typing import Any, Dict, Iterator, Optional
+from typing import Any, Dict, Iterator, List, Optional
 
 from . import _git, _provenance
 from .read import API_VERSION
@@ -95,6 +159,101 @@ def _utcnow() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
 
 
+# ---------------------------------------------------------------------------
+# Signal + atexit bookkeeping.
+#
+# One handler is shared across every active Run rather than one per run:
+# only one disposition can be installed for a given signal at a time, so
+# per-run handlers would just overwrite each other. Runs are tracked by
+# identity (`is`, not `==`) rather than relying on dataclass equality/
+# hashing -- two runs constructed with identical arguments could otherwise
+# compare equal and cause the wrong one to be dropped from the active list.
+# ---------------------------------------------------------------------------
+
+_HANDLED_SIGNALS = (signal.SIGTERM,)
+
+_hooks_lock = threading.Lock()
+_active_runs: List["Run"] = []
+# The disposition each handled signal had before runledger installed its
+# own -- SIG_DFL, SIG_IGN, or a caller's own handler. Populated the first
+# time a Run enters on the main thread, and cleared again once the last
+# active run finishes, so a long-lived process that starts and finishes
+# many runs over time doesn't accumulate anything.
+_previous_handlers: Dict[int, Any] = {}
+
+
+def _signal_handler(signum: int, frame: Any) -> None:
+    """Installed for every signal in ``_HANDLED_SIGNALS`` while at least one
+    Run is active. Records every currently-active run as ``failed``, then
+    chains to (or restores and re-raises) whatever was installed before --
+    see the module docstring's signal-handling design note for why both
+    steps matter.
+    """
+    previous = _previous_handlers.get(signum)
+    for run in list(_active_runs):
+        try:
+            run._finish("failed")
+        except Exception:
+            # Everything _finish calls already degrades failures to a
+            # warning; this is only a last line of defense so that one
+            # run's recording trouble can't stop another active run from
+            # being recorded, or stop the signal from reaching `previous`.
+            pass
+    if callable(previous):
+        previous(signum, frame)
+        return
+    # No handler worth calling (SIG_DFL, SIG_IGN, or nothing installed):
+    # restore the default disposition and re-send the signal to ourselves.
+    # This -- not sys.exit() -- is what makes the process die *from the
+    # signal*, the same way it would have if runledger had never installed
+    # anything here.
+    signal.signal(signum, signal.SIG_DFL)
+    os.kill(os.getpid(), signum)
+
+
+def _register_hooks(run: "Run") -> None:
+    """Adds ``run`` to the active set and, on the main thread, installs the
+    shared signal handler the first time it's needed. Always registers the
+    ``atexit`` backstop, regardless of thread -- ``atexit.register`` itself
+    has no main-thread restriction.
+    """
+    with _hooks_lock:
+        _active_runs.append(run)
+        if threading.current_thread() is threading.main_thread():
+            for sig in _HANDLED_SIGNALS:
+                if sig not in _previous_handlers:
+                    _previous_handlers[sig] = signal.signal(sig, _signal_handler)
+        # Off the main thread, signal.signal() would raise ValueError --
+        # Python only allows installing handlers there. Such a run simply
+        # has no SIGTERM coverage; the atexit hook below still applies.
+    atexit.register(run._on_atexit)
+
+
+def _unregister_hooks(run: "Run") -> None:
+    """Reverses ``_register_hooks``: drops ``run`` from the active set,
+    cancels its atexit callback, and -- once no run is left active --
+    restores whatever signal dispositions were there before.
+    """
+    atexit.unregister(run._on_atexit)
+    with _hooks_lock:
+        _active_runs[:] = [r for r in _active_runs if r is not run]
+        if _active_runs:
+            return
+        restored = []
+        for sig, previous in _previous_handlers.items():
+            try:
+                signal.signal(sig, previous)
+                restored.append(sig)
+            except ValueError:
+                # Not the main thread. Leave the handler installed -- it is
+                # harmless with no active runs to record, and a future run
+                # entering from the main thread will find this entry still
+                # correct and try again when it finishes.
+                pass
+        for sig in restored:
+            del _previous_handlers[sig]
+
+
 @dataclasses.dataclass
 class Run:
     """One experiment run's lineage, recorded once its outcome is known.
@@ -126,6 +285,10 @@ class Run:
     _started_at: str = dataclasses.field(default="", init=False, repr=False)
     _git_commit: str = dataclasses.field(default="", init=False, repr=False)
     _git_dirty: bool = dataclasses.field(default=False, init=False, repr=False)
+    # Guards _finish() so it runs at most once, however it's triggered --
+    # normal __exit__, an exception, the signal handler, or the atexit
+    # backstop can all reach it, and only the first should count.
+    _finished: bool = dataclasses.field(default=False, init=False, repr=False)
 
     @classmethod
     @contextlib.contextmanager
@@ -142,13 +305,15 @@ class Run:
         timeout: float = DEFAULT_TIMEOUT,
         spool_path: str = DEFAULT_SPOOL_PATH,
     ) -> Iterator["Run"]:
-        """Context manager: captures lineage now, records the outcome later.
+        """Context manager: records the run running now, and its outcome later.
 
         Raises :class:`UnreconstructibleRunError` immediately -- before the
         ``with`` body runs -- if the run would not be reconstructible. Any
         exception raised inside the ``with`` body is recorded as a
         ``failed`` run (with whatever metrics were logged before the
-        exception) and then re-raised unchanged.
+        exception) and then re-raised unchanged. A ``SIGTERM`` delivered
+        while the ``with`` body is running is recorded the same way, from
+        the main thread only -- see the module docstring.
 
         Every option is spelled out here rather than collected into
         ``**kwargs``: this is the package's entire public entry point, and a
@@ -213,16 +378,27 @@ class Run:
         self._git_commit = commit
         self._git_dirty = dirty
         self._started_at = _utcnow()
+        # Hooks go up before the start-time write below, not after: this is
+        # the earliest point a kill would otherwise leave zero trace, and
+        # everything from here until _finish() runs must be recorded if the
+        # process dies. Registering only after a validation failure (the
+        # raises above) would leave a run that never entered the `with`
+        # body registered forever, since start()'s try/finally hasn't begun
+        # yet at that point -- so this must come after both checks succeed.
+        _register_hooks(self)
+        self._record_start()
 
     def log_metric(self, name: str, value: float) -> None:
         """Records a measured metric. Overwrites a prior value for `name`."""
         self._metrics[name] = float(value)
 
-    def _finish(self, status: str) -> None:
-        self.status = status
-        self._send(self._payload())
+    # -- writing -----------------------------------------------------------
 
-    def _payload(self) -> Dict[str, Any]:
+    def _identity_and_provenance(self) -> Dict[str, Any]:
+        """Fields shared by the start-time POST and the fallback full POST
+        at finish -- everything except status and the timestamps that
+        depend on which one is being built.
+        """
         payload: Dict[str, Any] = {
             "project": self.project,
             "git_commit": self._git_commit,
@@ -231,9 +407,6 @@ class Run:
             "dataset_version": self.dataset_version,
             "model_version": self.model_version,
             "seed": self.seed,
-            "status": self.status,
-            "started_at": self._started_at,
-            "ended_at": _utcnow(),
             "host": socket.gethostname(),
             "device": _provenance.device_name(),
             "framework_version": _provenance.framework_version(),
@@ -244,16 +417,135 @@ class Run:
             # here lets callers pass a plain dict of numbers/bools/whatever
             # without hand-stringifying each value themselves.
             payload["params"] = {k: str(v) for k, v in self.params.items()}
+        return payload
+
+    def _start_payload(self) -> Dict[str, Any]:
+        """The record POSTed the moment the run starts. No ``ended_at`` and
+        no ``metrics``: neither exists yet, and sending them would claim
+        measurements that have not happened.
+        """
+        payload = self._identity_and_provenance()
+        payload["status"] = "running"
+        payload["started_at"] = self._started_at
+        return payload
+
+    def _payload(self) -> Dict[str, Any]:
+        """The complete, final record -- used as the fallback full POST at
+        finish (when the start write never landed) and as what gets spooled
+        on any finish-time failure, whichever path produced it.
+        """
+        payload = self._identity_and_provenance()
+        payload["status"] = self.status
+        payload["started_at"] = self._started_at
+        payload["ended_at"] = _utcnow()
         if self._metrics:
             payload["metrics"] = dict(self._metrics)
         return payload
 
-    def _send(self, payload: Dict[str, Any]) -> None:
+    def _finish_patch(self) -> Dict[str, Any]:
+        """The PATCH body that closes out a run whose start-time POST
+        already landed -- just what changed, not the identity fields
+        (those can't change, and PATCH treats a mismatched one as a
+        conflict rather than silently ignoring it).
+        """
+        patch: Dict[str, Any] = {"status": self.status, "ended_at": _utcnow()}
+        if self._metrics:
+            patch["metrics"] = dict(self._metrics)
+        return patch
+
+    def _record_start(self) -> None:
+        """Best-effort POST of a `running` record so a SIGKILL/OOM kill
+        still leaves a trace server-side (see the module docstring). Never
+        spools on failure -- see `_finish` for why.
+        """
+        self._send(
+            "POST",
+            "/runs",
+            self._start_payload(),
+            warn="record the start of this run",
+        )
+
+    def _finish(self, status: str) -> None:
+        if self._finished:
+            # Reached twice: e.g. a SIGTERM the handler couldn't chain to a
+            # process-killing disposition for, so the with-block resumed
+            # and reached its own normal else-branch afterward. Whichever
+            # got here first wins; the outcome already recorded (the kill)
+            # is more accurate than the one that would overwrite it.
+            return
+        self._finished = True
+        self.status = status
+        try:
+            if self.run_id is not None:
+                self._update_finish()
+            else:
+                self._record_whole_run()
+        finally:
+            _unregister_hooks(self)
+
+    def _update_finish(self) -> None:
+        """The start-time POST landed: PATCH the run it created to a
+        terminal status. On failure, spool the *complete* record instead
+        of the patch -- see the module docstring for why that's a full
+        record and what it means for the run to end up with two rows.
+        """
+        self._send(
+            "PATCH",
+            f"/runs/{urllib.parse.quote(self.run_id, safe='')}",
+            self._finish_patch(),
+            warn=f"update run {self.run_id}",
+            spool_payload=self._payload(),
+        )
+
+    def _record_whole_run(self) -> None:
+        """The start-time POST never landed (ledger was unreachable, or
+        this run started on a thread not covered by any of the above): fall
+        back to one full record, exactly ADR 0005's original behaviour.
+        """
+        self._send(
+            "POST",
+            "/runs",
+            self._payload(),
+            warn="record this run",
+            spool_payload=self._payload(),
+        )
+
+    def _on_atexit(self) -> None:
+        """Backstop for interpreter shutdown this run's own context manager
+        never saw -- e.g. a chained signal handler that calls ``sys.exit()``
+        instead of letting the process die from the signal, or a run
+        started off the main thread with no SIGTERM coverage at all.
+        Idempotent with every other path into ``_finish``, so this is safe
+        to call unconditionally.
+        """
+        self._finish("failed")
+
+    def _send(
+        self,
+        method: str,
+        path: str,
+        payload: Dict[str, Any],
+        *,
+        warn: str,
+        spool_payload: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        """One HTTP call against the ledger. Returns whether it succeeded;
+        never raises.
+
+        A down, slow, or unreachable ledger degrades to a ``RuntimeWarning``
+        -- whatever the cause (network error, timeout, bad response,
+        non-2xx status) -- recording must never fail the training run. When
+        ``spool_payload`` is given, that payload (not necessarily the one
+        just sent -- see ``_update_finish``) is appended to the local spool
+        file on failure; when it's omitted, nothing is spooled, because the
+        caller has determined there is nothing worth spooling yet
+        (``_record_start``).
+        """
         body = json.dumps(payload).encode("utf-8")
         req = urllib.request.Request(
-            self.server.rstrip("/") + API_VERSION + "/runs",
+            self.server.rstrip("/") + API_VERSION + path,
             data=body,
-            method="POST",
+            method=method,
             headers={"Content-Type": "application/json"},
         )
         token = os.environ.get("RUNLEDGER_TOKEN")
@@ -263,20 +555,24 @@ class Run:
             with urllib.request.urlopen(req, timeout=self.timeout) as resp:
                 raw = resp.read()
             out = json.loads(raw.decode("utf-8")) if raw else {}
-            self.run_id = out.get("run_id")
-            self.fingerprint = out.get("fingerprint")
+            if out.get("run_id"):
+                self.run_id = out["run_id"]
+            if out.get("fingerprint"):
+                self.fingerprint = out["fingerprint"]
+            return True
         except Exception as exc:
-            # Recording must never fail the training run: a down, slow, or
-            # unreachable ledger degrades to a warning and a local spool
-            # file, whatever the cause (network error, timeout, bad
-            # response, non-2xx status).
-            warnings.warn(
-                f"runledger: could not record run at {self.server} "
-                f"({exc}); spooling to {self.resolved_spool_path()} instead",
-                RuntimeWarning,
-                stacklevel=3,
-            )
-            self._spool(payload)
+            message = f"runledger: could not {warn} at {self.server} ({exc})"
+            if spool_payload is not None:
+                message += f"; spooling to {self.resolved_spool_path()} instead"
+            # stacklevel=4: _send's own frame, its caller (_record_start /
+            # _update_finish / _record_whole_run), *that* caller (_enter /
+            # _finish), and finally the frame that invoked one of those --
+            # as close as this gets to pointing at the caller's own code
+            # through contextlib.contextmanager's generator indirection.
+            warnings.warn(message, RuntimeWarning, stacklevel=4)
+            if spool_payload is not None:
+                self._spool(spool_payload)
+            return False
 
     def resolved_spool_path(self) -> str:
         """``spool_path`` with ``~`` expanded -- the file actually written.

--- a/python/tests/test_run.py
+++ b/python/tests/test_run.py
@@ -2,8 +2,8 @@
 
 Runs against a tiny in-process HTTP server standing in for the real
 `runledger` server, so these don't need Go, a build, or a live process --
-just enough of POST /runs's contract (echo run_id/fingerprint on success) to
-exercise the client honestly.
+just enough of POST /runs and PATCH /runs/{id}'s contract (echo
+run_id/fingerprint on success) to exercise the client honestly.
 """
 
 from __future__ import annotations
@@ -13,6 +13,7 @@ import inspect
 import json
 import os
 import shutil
+import signal
 import sys
 import tempfile
 import threading
@@ -28,25 +29,48 @@ from runledger import _run as run_module  # noqa: E402
 
 
 class _Handler(BaseHTTPRequestHandler):
+    """Accepts both halves of the two-phase write: POST /runs (start) and
+    PATCH /runs/{id} (finish). Always succeeds, echoing a fixed run_id/
+    fingerprint the same way for either verb.
+    """
+
     def log_message(self, *args):  # silence the default request logging
         pass
 
-    def do_POST(self):
+    def _read_json(self):
         length = int(self.headers.get("Content-Length", 0))
-        body = self.rfile.read(length)
-        payload = json.loads(body.decode("utf-8"))
+        if not length:
+            return {}
+        return json.loads(self.rfile.read(length).decode("utf-8"))
+
+    def _record(self, method):
         self.server.received.append(
-            {"payload": payload, "authorization": self.headers.get("Authorization")}
+            {
+                "method": method,
+                "path": self.path,
+                "payload": self._read_json(),
+                "authorization": self.headers.get("Authorization"),
+            }
         )
-        self.send_response(201)
+
+    def _respond(self, code, out):
+        self.send_response(code)
         self.send_header("Content-Type", "application/json")
         self.end_headers()
-        out = {"run_id": "fake-run-id", "fingerprint": "fake-fingerprint"}
         self.wfile.write(json.dumps(out).encode("utf-8"))
+
+    def do_POST(self):
+        self._record("POST")
+        self._respond(201, {"run_id": "fake-run-id", "fingerprint": "fake-fingerprint"})
+
+    def do_PATCH(self):
+        self._record("PATCH")
+        run_id = self.path.rsplit("/", 1)[-1]
+        self._respond(200, {"run_id": run_id, "fingerprint": "fake-fingerprint"})
 
 
 class _FakeLedger:
-    """A minimal stand-in for POST /runs, listening on localhost."""
+    """A minimal stand-in for POST /runs and PATCH /runs/{id}, on localhost."""
 
     def __enter__(self):
         self.server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
@@ -168,6 +192,10 @@ class SpoolPathTests(unittest.TestCase):
             shutil.rmtree(work, ignore_errors=True)
 
     def test_warning_names_the_resolved_path(self):
+        # Unreachable for the whole run: both the start POST and the
+        # finish-fallback POST fail, and only the second one spools -- see
+        # RunDegradesGracefullyTests below for that split in detail. Either
+        # warning naming the resolved path satisfies this test.
         home = tempfile.mkdtemp()
         try:
             with mock.patch.dict(os.environ, {"HOME": home}):
@@ -223,36 +251,57 @@ class RunStartValidationTests(unittest.TestCase):
                 project="demo", config_hash="cfg1", server=ledger.addr
             ):
                 pass
-        self.assertEqual(len(ledger.received), 1)
-        self.assertEqual(ledger.received[0]["payload"]["config_hash"], "cfg1")
-        self.assertTrue(ledger.received[0]["payload"]["git_dirty"])
+        self.assertEqual(len(ledger.received), 2, "a start POST and a finish PATCH")
+        start_call = ledger.received[0]
+        self.assertEqual(start_call["method"], "POST")
+        self.assertEqual(start_call["payload"]["config_hash"], "cfg1")
+        self.assertTrue(start_call["payload"]["git_dirty"])
 
 
 class RunRecordingTests(unittest.TestCase):
-    def test_success_records_once_with_final_metrics(self):
+    """Run.start() now writes the ledger twice: POST /runs with status
+    `running` the moment the with-block is entered, and PATCH /runs/{id}
+    with the terminal status and final metrics when it ends.
+    """
+
+    def test_start_posts_running_then_finish_patches_terminal_status(self):
         with _clean_git(), _FakeLedger() as ledger:
             with runledger.Run.start(
                 project="demo", seed=1, params={"lr": 0.001}, server=ledger.addr
             ) as run:
+                # run_id/fingerprint are populated from the start-time POST,
+                # not only once the run finishes.
+                self.assertEqual(run.run_id, "fake-run-id")
+                self.assertEqual(run.fingerprint, "fake-fingerprint")
                 run.log_metric("loss", 0.9)
                 run.log_metric("loss", 0.5)  # overwrites
                 run.log_metric("acc", 0.8)
 
             self.assertEqual(run.status, "succeeded")
-            self.assertEqual(run.run_id, "fake-run-id")
-            self.assertEqual(run.fingerprint, "fake-fingerprint")
             self.assertFalse(run.spooled)
 
-        self.assertEqual(len(ledger.received), 1, "exactly one HTTP call per run")
-        payload = ledger.received[0]["payload"]
-        self.assertEqual(payload["project"], "demo")
-        self.assertEqual(payload["seed"], 1)
-        self.assertEqual(payload["params"], {"lr": "0.001"})
-        self.assertEqual(payload["status"], "succeeded")
-        self.assertEqual(payload["metrics"], {"loss": 0.5, "acc": 0.8})
-        self.assertIn("git_commit", payload)
-        self.assertIn("started_at", payload)
-        self.assertIn("ended_at", payload)
+        self.assertEqual(len(ledger.received), 2, "one POST at start, one PATCH at finish")
+        start_call, finish_call = ledger.received
+
+        self.assertEqual(start_call["method"], "POST")
+        self.assertEqual(start_call["path"], "/v1/runs")
+        self.assertEqual(start_call["payload"]["project"], "demo")
+        self.assertEqual(start_call["payload"]["seed"], 1)
+        self.assertEqual(start_call["payload"]["params"], {"lr": "0.001"})
+        self.assertEqual(start_call["payload"]["status"], "running")
+        self.assertIn("git_commit", start_call["payload"])
+        self.assertIn("started_at", start_call["payload"])
+        self.assertNotIn("metrics", start_call["payload"])
+        self.assertNotIn("ended_at", start_call["payload"])
+
+        self.assertEqual(finish_call["method"], "PATCH")
+        self.assertEqual(finish_call["path"], "/v1/runs/fake-run-id")
+        self.assertEqual(finish_call["payload"]["status"], "succeeded")
+        self.assertEqual(finish_call["payload"]["metrics"], {"loss": 0.5, "acc": 0.8})
+        self.assertIn("ended_at", finish_call["payload"])
+        self.assertNotIn(
+            "project", finish_call["payload"], "PATCH only carries what changed"
+        )
 
     def test_failure_records_failed_with_partial_metrics_and_reraises(self):
         with _clean_git(), _FakeLedger() as ledger:
@@ -263,17 +312,20 @@ class RunRecordingTests(unittest.TestCase):
 
             self.assertEqual(run.status, "failed")
 
-        self.assertEqual(len(ledger.received), 1)
-        payload = ledger.received[0]["payload"]
-        self.assertEqual(payload["status"], "failed")
-        self.assertEqual(payload["metrics"], {"loss": 0.9})
+        self.assertEqual(len(ledger.received), 2)
+        finish_call = ledger.received[1]
+        self.assertEqual(finish_call["method"], "PATCH")
+        self.assertEqual(finish_call["payload"]["status"], "failed")
+        self.assertEqual(finish_call["payload"]["metrics"], {"loss": 0.9})
 
     def test_bearer_token_sent_when_set(self):
         with _clean_git(), _FakeLedger() as ledger:
             with mock.patch.dict(os.environ, {"RUNLEDGER_TOKEN": "s3cr3t"}):
                 with runledger.Run.start(project="demo", server=ledger.addr):
                     pass
-        self.assertEqual(ledger.received[0]["authorization"], "Bearer s3cr3t")
+        self.assertTrue(ledger.received)
+        for call in ledger.received:
+            self.assertEqual(call["authorization"], "Bearer s3cr3t")
 
     def test_no_token_means_no_authorization_header(self):
         with _clean_git(), _FakeLedger() as ledger:
@@ -282,11 +334,13 @@ class RunRecordingTests(unittest.TestCase):
             with mock.patch.dict(os.environ, env, clear=True):
                 with runledger.Run.start(project="demo", server=ledger.addr):
                     pass
-        self.assertIsNone(ledger.received[0]["authorization"])
+        self.assertTrue(ledger.received)
+        for call in ledger.received:
+            self.assertIsNone(call["authorization"])
 
 
 class RunDegradesGracefullyTests(unittest.TestCase):
-    """Never let recording fail the training run."""
+    """Never let recording fail the training run -- for either write."""
 
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp()
@@ -297,7 +351,10 @@ class RunDegradesGracefullyTests(unittest.TestCase):
 
     def test_unreachable_server_warns_and_spools_instead_of_raising(self):
         # Nothing is listening on this port: connection should be refused
-        # promptly rather than hang.
+        # promptly rather than hang. Unreachable for the whole run, so both
+        # the start POST and the finish-fallback POST fail -- and only the
+        # second spools (see test_start_write_failure_does_not_spool below
+        # for that distinction in isolation).
         unreachable = "http://127.0.0.1:1"
         with _clean_git():
             with warnings.catch_warnings(record=True) as caught:
@@ -312,7 +369,7 @@ class RunDegradesGracefullyTests(unittest.TestCase):
                 # no exception escaped the with-block
 
         self.assertTrue(run.spooled)
-        self.assertIsNone(run.run_id)
+        self.assertIsNone(run.run_id, "the start write never landed either")
         self.assertTrue(
             any(issubclass(w.category, RuntimeWarning) for w in caught),
             "expected a RuntimeWarning about the unreachable ledger",
@@ -321,7 +378,9 @@ class RunDegradesGracefullyTests(unittest.TestCase):
         self.assertTrue(os.path.exists(self.spool_path))
         with open(self.spool_path, encoding="utf-8") as fh:
             lines = [json.loads(line) for line in fh if line.strip()]
-        self.assertEqual(len(lines), 1)
+        self.assertEqual(
+            len(lines), 1, "the failed start write must not also spool a line"
+        )
         self.assertEqual(lines[0]["project"], "demo")
         self.assertEqual(lines[0]["status"], "succeeded")
         self.assertEqual(lines[0]["metrics"], {"loss": 0.42})
@@ -355,6 +414,247 @@ class RunDegradesGracefullyTests(unittest.TestCase):
             server.shutdown()
             server.server_close()
             thread.join(timeout=5)
+
+    def test_start_write_failure_does_not_raise_and_finish_recovers_if_ledger_returns(self):
+        """The end-of-run write when the start-time write failed.
+
+        Distinct from total unreachability above: here the ledger rejects
+        only the `running` POST and accepts everything else, modelling a
+        ledger that came back (or was merely flaky) by the time the run
+        ended. `_finish()` must notice there is no run_id and fall back to
+        one full POST -- not a PATCH against an id it never learned -- and
+        that fallback succeeding means nothing gets spooled.
+        """
+
+        class _RejectRunningHandler(BaseHTTPRequestHandler):
+            def log_message(self, *args):
+                pass
+
+            def do_POST(self):
+                length = int(self.headers.get("Content-Length", 0))
+                payload = json.loads(self.rfile.read(length).decode("utf-8")) if length else {}
+                self.server.received.append(payload)
+                if payload.get("status") == "running":
+                    self.send_response(503)
+                    self.send_header("Content-Type", "application/json")
+                    self.end_headers()
+                    self.wfile.write(b'{"error":"simulated start failure"}')
+                    return
+                self.send_response(201)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                out = {"run_id": "fallback-run-id", "fingerprint": "fake-fingerprint"}
+                self.wfile.write(json.dumps(out).encode("utf-8"))
+
+            def do_PATCH(self):
+                # Must never be reached: with no run_id from a successful
+                # start write, _finish() has to fall back to a full POST.
+                self.send_response(500)
+                self.end_headers()
+
+        server = ThreadingHTTPServer(("127.0.0.1", 0), _RejectRunningHandler)
+        server.received = []
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            addr = f"http://127.0.0.1:{server.server_port}"
+            with _clean_git():
+                with warnings.catch_warnings(record=True) as caught:
+                    warnings.simplefilter("always")
+                    with runledger.Run.start(
+                        project="demo", server=addr, timeout=2.0
+                    ) as run:
+                        self.assertIsNone(run.run_id, "the start write failed")
+                        run.log_metric("loss", 0.1)
+                    # no exception escaped the with-block
+
+            self.assertEqual(run.status, "succeeded")
+            self.assertEqual(run.run_id, "fallback-run-id")
+            self.assertFalse(
+                run.spooled, "the fallback POST succeeded; nothing to spool"
+            )
+            self.assertEqual(len(server.received), 2)
+            self.assertEqual(server.received[0]["status"], "running")
+            self.assertEqual(server.received[1]["status"], "succeeded")
+            self.assertEqual(server.received[1]["metrics"], {"loss": 0.1})
+            self.assertTrue(
+                any(issubclass(w.category, RuntimeWarning) for w in caught),
+                "the failed start write should still warn",
+            )
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=5)
+
+    def test_patch_failure_after_successful_start_spools_the_full_record(self):
+        """The opposite split: the start POST succeeds (a run_id exists on
+        the server), but the closing PATCH cannot be delivered. Replay only
+        understands full POST /runs bodies (ADR 0008), so the fallback
+        spools the complete record rather than the patch -- on replay this
+        creates a second, terminal row instead of resurrecting the
+        original run_id, leaving that one permanently `running` (ADR 0014).
+        """
+
+        class _PatchAlwaysFailsHandler(BaseHTTPRequestHandler):
+            def log_message(self, *args):
+                pass
+
+            def do_POST(self):
+                length = int(self.headers.get("Content-Length", 0))
+                self.rfile.read(length)
+                self.send_response(201)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                out = {"run_id": "orphan-run-id", "fingerprint": "fake-fingerprint"}
+                self.wfile.write(json.dumps(out).encode("utf-8"))
+
+            def do_PATCH(self):
+                length = int(self.headers.get("Content-Length", 0))
+                self.rfile.read(length)
+                self.send_response(500)
+                self.end_headers()
+
+        server = ThreadingHTTPServer(("127.0.0.1", 0), _PatchAlwaysFailsHandler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            addr = f"http://127.0.0.1:{server.server_port}"
+            with _clean_git():
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore")
+                    with runledger.Run.start(
+                        project="demo",
+                        server=addr,
+                        timeout=2.0,
+                        spool_path=self.spool_path,
+                    ) as run:
+                        self.assertEqual(run.run_id, "orphan-run-id")
+                        run.log_metric("loss", 0.2)
+
+            self.assertTrue(run.spooled)
+            with open(self.spool_path, encoding="utf-8") as fh:
+                lines = [json.loads(line) for line in fh if line.strip()]
+            self.assertEqual(len(lines), 1)
+            self.assertEqual(lines[0]["status"], "succeeded")
+            self.assertEqual(lines[0]["metrics"], {"loss": 0.2})
+            self.assertIn(
+                "project", lines[0], "a full record was spooled, not a bare patch"
+            )
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=5)
+
+
+class SignalHandlingTests(unittest.TestCase):
+    """SIGTERM is the signal a real scheduler sends before escalating to
+    SIGKILL (Slurm's scancel, a Kubernetes eviction, LSF's bkill all work
+    this way). This client catches it -- main thread only, since Python
+    forbids installing a handler anywhere else -- records the active run,
+    and then either chains to whatever handler was already there or lets
+    the process die from the signal itself.
+    """
+
+    def setUp(self):
+        self._original_sigterm = signal.getsignal(signal.SIGTERM)
+
+    def tearDown(self):
+        # Belt and suspenders: _finish()/_unregister_hooks should already
+        # have restored this once every active run finishes, but a failed
+        # assertion mid-test must not leak a handler into later tests.
+        signal.signal(signal.SIGTERM, self._original_sigterm)
+
+    def test_sigterm_records_the_run_as_failed(self):
+        chained = []
+
+        def previous_handler(signum, frame):
+            # A benign stand-in for whatever was installed before
+            # Run.start() ran -- it does not kill the process, so this
+            # test process survives to make its assertions.
+            chained.append(signum)
+
+        signal.signal(signal.SIGTERM, previous_handler)
+
+        with _clean_git(), _FakeLedger() as ledger:
+            with runledger.Run.start(project="demo", server=ledger.addr) as run:
+                run.log_metric("loss", 0.7)
+                signal.raise_signal(signal.SIGTERM)
+                # previous_handler doesn't terminate the process, so
+                # execution resumes here -- but the run is already
+                # finished, recorded by the signal handler above.
+                self.assertEqual(run.status, "failed")
+
+            # Falling off the end of the with-block normally would record
+            # `succeeded` -- it must not overwrite what the signal already
+            # recorded.
+            self.assertEqual(run.status, "failed")
+
+        self.assertEqual(
+            chained, [signal.SIGTERM], "the previously-installed handler must still run"
+        )
+        self.assertEqual(len(ledger.received), 2)
+        finish_call = ledger.received[1]
+        self.assertEqual(finish_call["method"], "PATCH")
+        self.assertEqual(finish_call["payload"]["status"], "failed")
+        self.assertEqual(finish_call["payload"]["metrics"], {"loss": 0.7})
+
+    def test_signal_handler_chains_to_a_preexisting_handler_instead_of_dropping_it(self):
+        calls = []
+
+        def previous_handler(signum, frame):
+            calls.append(signum)
+
+        signal.signal(signal.SIGTERM, previous_handler)
+
+        # The ledger address doesn't matter for this test -- it's about
+        # whether the pre-existing handler still runs, not what got
+        # recorded -- so an unreachable address (fast to fail) keeps it
+        # quick, with the resulting warning silenced.
+        with _clean_git():
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                with runledger.Run.start(
+                    project="demo", server="http://127.0.0.1:1", timeout=1.0
+                ):
+                    signal.raise_signal(signal.SIGTERM)
+
+        self.assertEqual(
+            calls,
+            [signal.SIGTERM],
+            "chaining must invoke the pre-existing handler exactly once, not drop it",
+        )
+        self.assertIs(
+            signal.getsignal(signal.SIGTERM),
+            previous_handler,
+            "the pre-existing handler must be restored once the run finishes",
+        )
+
+    def test_run_started_off_the_main_thread_does_not_install_a_handler(self):
+        # signal.signal() raises ValueError anywhere but the main thread;
+        # Run.start() must not let that escape into the caller's training
+        # code, and must not leave the process's SIGTERM disposition
+        # touched by a run it can't actually protect with one.
+        original = signal.getsignal(signal.SIGTERM)
+        errors = []
+
+        def worker():
+            try:
+                with _clean_git(), _FakeLedger() as ledger:
+                    with runledger.Run.start(project="demo", server=ledger.addr):
+                        pass
+            except Exception as exc:  # pragma: no cover - failure path
+                errors.append(exc)
+
+        thread = threading.Thread(target=worker)
+        thread.start()
+        thread.join(timeout=10)
+
+        self.assertFalse(errors, f"Run.start() must not raise off the main thread: {errors}")
+        self.assertIs(
+            signal.getsignal(signal.SIGTERM),
+            original,
+            "no handler should leak from a non-main-thread run",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #64

## Correction to the issue as filed

Issue #64 says it depends on #65 because ADR 0005 names the missing status
filter on `/v1/fingerprints` as the blocker for writing a `running` record.
That is stale: #65's own first comment confirms `terminalRuns()` already
filters both `spreadList` and `spreadOne` in `internal/api/api.go`, landed
by #52 before #64 was filed. Verified independently (grepped `api.go`,
confirmed both call sites) before starting. **#64 was never blocked.**

## What changed

`runledger.Run.start()` used to write the ledger exactly once, from
`__exit__` (ADR 0005) -- which meant a `SIGKILL`, an OOM kill, or a
scheduler escalating past its grace period (the most common way a real
training job dies) left *zero* trace: not a `failed` record, not a spooled
line.

It now writes twice:

1. `POST /v1/runs` with `status="running"` at `_enter()`, before any
   training happens -- `run.run_id`/`run.fingerprint` populate immediately.
2. `PATCH /v1/runs/{id}` to `succeeded`/`failed` at `_finish()`, with
   `ended_at` and whatever metrics were logged.

This is exactly the `rlctl start`/`rlctl finish` lifecycle
(`cmd/rlctl/main.go`) and the `created -> running -> {succeeded, failed,
cancelled}` transition the server already enforces.

**Signals handled:** `SIGTERM` only, main thread only (Python forbids
installing a handler anywhere else). The handler records every active run
as `failed`, then either calls whatever handler was already installed
(chaining, never clobbering) or restores the default disposition and
re-sends the signal to this process -- so the signal still kills the
process the way its sender intended, rather than being silently absorbed.
An `atexit` hook backstops what that misses (a run started off the main
thread; a chained handler that calls `sys.exit()` instead of dying from the
signal). `SIGINT` needed no new handling -- Python's default disposition
already turns it into `KeyboardInterrupt`, which the existing `except
BaseException` in `start()` already records as `failed`. `SIGKILL` is
uncatchable by construction; surviving it is exactly what the start-time
`running` record is for.

**What the end-of-run write does when the start write failed:** `_finish()`
sees no `run_id` and falls back to a single full `POST` -- ADR 0005's
original one-shot behaviour -- which spools on failure the same way it
always did. If instead the start write *succeeded* but the closing `PATCH`
fails, the full record is spooled in the patch's place (replay only
understands complete `POST /runs` bodies, ADR 0008), which on replay
creates a second, terminal row rather than resurrecting the original
`run_id` -- leaving an orphaned, permanently-`running` row behind. That row
is invisible to `spread` either way (`terminalRuns`, #52); losing the run's
final metrics would be the worse outcome. Recording still never fails the
training run either way -- everything degrades to a `RuntimeWarning`.

**ADR 0005 is superseded by ADR 0014** (new), which documents this
reasoning in full, including why writing early used to be unsafe and isn't
anymore. Per `docs/adr/README.md`'s convention, ADR 0005 got exactly one
edit: a "Superseded by ADR 0014" line at the top: it was not rewritten to
pretend the original reasoning never held.

## Files touched

- `python/runledger/_run.py` -- the implementation
- `python/tests/test_run.py` -- rewritten/extended for the two-phase write
- `python/README.md` -- "Why one HTTP call, not two" replaced with
  "Surviving a kill"; the unreachable-ledger section split by which write
  failed
- `docs/adr/0014-*.md` (new), `docs/adr/0005-*.md` (one line),
  `docs/adr/README.md` (one table row)

No Go files, `docs/openapi.yaml`, the top-level `README.md`, or
`python/runledger/_provenance.py` were touched, per the file-ownership
split with the agent working on `internal/lineage/`, `internal/store/`,
`internal/api/`, and `cmd/rlctl/` in parallel.

I noticed the top-level `README.md` has two passages that now describe the
old write-once design and cite ADR 0005 as current -- out of scope here
(explicitly excluded from my file list), so I flagged it as a separate
follow-up task rather than editing it.

## Testing

- `go build ./... && go vet ./... && go test -race ./...` -- pass (no Go
  changes)
- `test -z "$(gofmt -l .)"` -- clean
- `python3 -m unittest discover -s python/tests` -- 70 tests pass, including
  new coverage: SIGTERM records the run and chains to a pre-existing
  handler, a non-main-thread run installs no handler, an exception still
  records `failed` with partial metrics, the ledger being unreachable at
  start doesn't raise, the end-of-run fallback when the start write failed,
  and a PATCH failure after a successful start spools the full record.
- `python3 -m unittest discover -s dashboard/tests` -- pass
- `python3 -m unittest discover -s examples/churn` -- pass
- `make notebook` not run locally (no `jupyter` in this environment); the
  notebook's public API usage is unaffected by this change, and the
  structural notebook tests in `python/tests/test_notebook.py` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)