### PR TITLE
lineage: correct the Run comment that ADR 0011 superseded

### DIFF
--- a/internal/lineage/run.go
+++ b/internal/lineage/run.go
@@ -33,12 +33,20 @@ type Run struct {
 
 	// --- provenance: recorded, not hashed ---
 	//
-	// Host, Device, FrameworkVersion, ConfigHash, DatasetVersion, and
-	// ModelVersion share a known gap: an empty string is indistinguishable
-	// from "not recorded," which can misrepresent a run that genuinely ran
-	// with none of these set. Widening them to pointers would ripple into
-	// Compute's hashing and every caller that decodes a lineage.Run from
-	// JSON, which is a bigger, separately-scoped change than this fix.
+	// For Host, Device, FrameworkVersion, ConfigHash, DatasetVersion, and
+	// ModelVersion, an empty string means "not recorded" -- not a value of
+	// its own. None of them has a meaningful empty value (an empty config
+	// hash *is* no config hash; a host always has a name), so the two
+	// spellings a client might send were deliberately collapsed into one
+	// meaning rather than distinguished. See ADR 0011.
+	//
+	// This block previously described that as a known gap and proposed
+	// widening these to pointers. ADR 0011 considered and rejected exactly
+	// that: it would have changed the fingerprint contract for the three
+	// identity fields, and made the fingerprint sensitive to whether a
+	// client serializes an unset key or omits it -- how a client spells
+	// things, rather than what the experimenter chose. Consumers may rely
+	// on "" == absent for these fields; compare.Runs already does.
 	RunID       string `json:"run_id"`
 	Fingerprint string `json:"fingerprint"`
 	// FingerprintVersion records which version of Compute's hashing contract


### PR DESCRIPTION
The provenance block in `lineage.Run` still describes empty-versus-not-recorded
as **"a known gap"** that "can misrepresent a run", and proposes widening the
six fields to pointers as the eventual fix.

[ADR 0011](docs/adr/0011-empty-string-means-not-recorded.md) settled that
question and reached the opposite conclusion. None of those fields has a
meaningful empty value, so `""` and "not recorded" are *one meaning with two
spellings*, deliberately collapsed — and pointers were considered and
explicitly rejected, because they would have changed the fingerprint contract
for the three identity fields and made the fingerprint sensitive to how a
client serializes rather than to what the experimenter chose.

## This comment is not inert

An agent writing golden-file tests for `rlctl show` (#82) read it, concluded
the JSON output carried an unresolved ambiguity, and documented a limitation
that does not exist — `"host": ""` is correct and unambiguous under ADR 0011.
It has exactly one state, not two.

A future reader could as easily have "fixed" the non-problem by widening the
fields to pointers, which is the change ADR 0011 argues against at length.

## Same failure mode as issue #65

Prose asserting something the decisions have since reversed, trusted over the
code. That is how I filed #65 on a false premise: ADR 0005 named a blocker
that PR #52 had already removed.

#79 says under "What this will not fix" that no test in it detects this class
— prose cannot be diffed against behaviour the way a JSON schema can. So the
correction is by hand, and the mitigation stays procedural: write the
superseding record, and fix the comments the supersession invalidates.

The replacement states the rule, names the rejected alternative and why it was
rejected, and says consumers may rely on `"" == absent` for these fields —
which `compare.Runs` already does via its `optional()` helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
