### PR TITLE
Record what the client attempted to capture, not just what it captured

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,19 @@ have to be true to revisit each one — lives in [`docs/adr/`](docs/adr/).
   that it is a claim, not a verified fact, until named per-caller tokens
   exist.
   ([ADR 0015](docs/adr/0015-run-attribution-is-provenance-self-asserted.md))
+- **A capture declaration (`capture.client`, `capture.attempted`) records what
+  the client tried to capture, not just what it captured, and is never
+  hashed.** `device: ""` can mean "this run has no device" or "this client
+  never looks" -- a single value field can't say which, so `attempted`
+  answers the question the value field can't: was `device` even named in it?
+  `Capture` is the one pointer field on `Run`, on purpose -- unlike ADR
+  0011's fields, "no declaration at all" and "declared, and declared
+  nothing" are different, useful claims, and
+  `examples/churn/completeness.py`'s peer-comparison fallback depends on
+  telling them apart. Not patchable: a client already knows what it
+  attempted in full at record time, so there is no "fill this in later"
+  case the way there is for `host`/`device`/`job_id`.
+  ([ADR 0016](docs/adr/0016-record-what-the-client-attempted-to-capture.md))
 
 ## Status
 

--- a/cmd/rlctl/main.go
+++ b/cmd/rlctl/main.go
@@ -25,6 +25,16 @@ import (
 // bump is one edit here, not one per call site below.
 const apiVersion = "/v1"
 
+// clientVersion is rlctl's own version, reported in every recorded run's
+// capture.client (ADR 0016) as "rlctl/<clientVersion>" -- the same
+// "name/version" shape the Python client's __version__ already produces.
+// There is no build-time version stamping elsewhere in this repo to read
+// instead, so this is the one place it is spelled out; bump it alongside
+// python/runledger's __version__ when the two should stay in step, but
+// nothing enforces that they must -- rlctl and the Python client are
+// versioned and released independently.
+const clientVersion = "0.1.0"
+
 const usage = `rlctl — record and compare experiment runs
 
   rlctl record --project P [--seed N] [--dataset V] [--model V] [--param k=v ...] [--metric k=v ...]
@@ -32,13 +42,15 @@ const usage = `rlctl — record and compare experiment runs
                            Capture git context from the working tree and record a run.
                            --submitter-claim is self-asserted, not verified (see ADR 0015).
                            --job-id defaults from $SLURM_JOB_ID/$CI_JOB_ID/$GITHUB_RUN_ID if set.
+                           Every run records a capture declaration (ADR 0016): which
+                           fields rlctl itself attempts to auto-detect (today, only host).
   rlctl start  <run-id>    Mark a recorded run running.
   rlctl finish [--status succeeded|failed|cancelled] [--metric k=v ...] [--checkpoint URI] <run-id>
                            Move a running run to a terminal status. --status defaults to succeeded.
   rlctl fail   [--metric k=v ...] <run-id>
                            Shorthand for finish --status failed.
   rlctl list   [--project P] [--commit SHA] [--status S] [--submitter-claim WHO] [--job-id ID]
-               [--limit N] [--cursor C]
+               [--capture-client C] [--limit N] [--cursor C]
                            Server caps --limit; pass the printed "next cursor"
                            back as --cursor to fetch the following page.
   rlctl show   <run-id>
@@ -140,6 +152,20 @@ func cmdRecord(args []string) error {
 		Seed: *seed, Device: *device, Status: lineage.Status(*status),
 		SubmitterClaim: *submitterClaim, JobID: *jobID,
 		StartedAt: time.Now().UTC(),
+		// rlctl attempts exactly one field on its own: host, via
+		// os.Hostname() just below, unconditionally. Every other capturable
+		// field (config_hash, dataset_version, model_version, device,
+		// framework_version, checkpoint_uri) is a plain pass-through of
+		// whatever flag value a caller typed -- rlctl never inspects the
+		// environment to fill one in, so declaring them "attempted" would
+		// overstate what this client actually does. "host" belongs in
+		// Attempted regardless of whether os.Hostname() below succeeds:
+		// attempted records that the client's code tried, not that it
+		// found something -- see ADR 0016.
+		Capture: &lineage.CaptureDeclaration{
+			Client:    "rlctl/" + clientVersion,
+			Attempted: []string{"host"},
+		},
 	}
 	if host, err := os.Hostname(); err == nil {
 		run.Host = host
@@ -261,6 +287,7 @@ func cmdList(args []string) error {
 	status := fs.String("status", "", "filter by status")
 	submitterClaim := fs.String("submitter-claim", "", "filter by submitter_claim (self-asserted; see ADR 0015)")
 	jobID := fs.String("job-id", "", "filter by job_id")
+	captureClient := fs.String("capture-client", "", "filter by capture.client, e.g. runledger-py/0.1.0 (see ADR 0016)")
 	limit := fs.Int("limit", 20, "maximum rows (server-capped; see --help)")
 	cursor := fs.String("cursor", "", "opaque page cursor from a previous list's \"next cursor\" line")
 	_ = fs.Parse(args)
@@ -271,6 +298,7 @@ func cmdList(args []string) error {
 	set(q, "status", *status)
 	set(q, "submitter_claim", *submitterClaim)
 	set(q, "job_id", *jobID)
+	set(q, "capture_client", *captureClient)
 	set(q, "cursor", *cursor)
 	q.Set("limit", fmt.Sprint(*limit))
 

--- a/docs/adr/0016-record-what-the-client-attempted-to-capture.md
+++ b/docs/adr/0016-record-what-the-client-attempted-to-capture.md
@@ -1,0 +1,266 @@
+# ADR 0016: Record what the client attempted to capture, not just what it captured
+
+Status: Accepted
+
+Date: 2026-08-29
+
+> **`lineage.Run` gains `Capture *CaptureDeclaration`, kept alongside the run
+> and never hashed.** `CaptureDeclaration` carries `Client` (which client
+> library and version wrote this) and `Attempted` (which of the seven ADR
+> 0011 fields that client's recording code actively tried to determine).
+> `device: ""` with `"device"` in `Attempted` means the client looked and
+> found nothing -- a fact about the environment. `device: ""` with `"device"`
+> absent from `Attempted` means the client never looks -- a fact about the
+> pipeline. Neither is expressible by widening `Device` itself, which is why
+> this is a new field next to it rather than a change to it.
+
+## Context
+
+Issue #68 proposed exactly this shape and then argued, at equal length, that
+it should not be built yet. The issue is worth quoting rather than
+paraphrasing, because the caution it recorded is the reason this ADR exists
+to state plainly rather than let quietly lapse:
+
+> The trigger to build this is the first time something wants to **act** on
+> the answer automatically, because a heuristic cannot carry that weight:
+> a gate ... fleet scale ... attribution across client versions ... Overlaps
+> with #67.
+
+None of those three triggers has fired. There is no gate today that refuses
+runs from clients missing a field, `examples/churn/completeness.py`'s
+peer-comparison heuristic is still the only consumer of "was this
+captured", and this repository has exactly two clients (`rlctl`, the Python
+package), not a fleet on divergent versions. By the issue's own stated
+test -- *is there something that wants to act on the answer* -- the honest
+answer is still no.
+
+This ADR exists anyway because the repository owner asked for it directly,
+having read that reasoning. That is a legitimate way for a "not yet"
+decision to become a "now": the issue's caution was about avoiding a
+speculative field nobody asked for, not about the field being a bad idea in
+itself, and "the person who owns this repository wants it" is precisely the
+kind of concrete want the issue said to wait for. What follows is not a
+retraction of the issue's reasoning -- the reasoning was right about what
+makes this worth building, and stays right about what a good version has to
+honor. It is a record that the trigger this time was a direct ask, not one
+of the three the issue named, and that the caution was read, not skipped.
+
+The underlying gap is the one ADR 0011's own "what would have to be true to
+revisit this" section already named: "did the client try?" is a fact about
+the recording process, not the experiment, and a nullable value field is
+the wrong place for it -- `device: ""` can say *this run has no device*,
+but it cannot say *this client does not know how to look for one*. Those
+are different claims, and ADR 0011 declined pointers for exactly the reason
+one field cannot hold both.
+
+## Decision
+
+### Shape
+
+```json
+{"device": "",
+ "capture": {"client": "runledger-py/0.1.0",
+             "attempted": ["host", "device", "framework_version"]}}
+```
+
+`lineage.CaptureDeclaration` (`internal/lineage/run.go`):
+
+```go
+type CaptureDeclaration struct {
+	Client    string   `json:"client"`
+	Attempted []string `json:"attempted,omitempty"`
+}
+```
+
+`Attempted` may only name a field from `lineage.CaptureFields` -- the same
+seven ADR 0011 gives a single "not recorded" meaning to (`config_hash`,
+`dataset_version`, `model_version`, `host`, `device`, `framework_version`,
+`checkpoint_uri`). `Run.Validate` rejects anything else, the same way it
+rejects an unrecognized `Status`.
+
+### Provenance, and never hashed -- `Capture` is the one pointer field on `Run`
+
+`Capture` is added below the identity/provenance boundary; `Compute` never
+reads it. `internal/lineage/run_property_test.go`'s
+`TestProperty_MutatingAProvenanceFieldLeavesFingerprintUnchanged` and
+`TestProperty_EveryRunFieldIsClassified` enforce this by construction, and
+`Capture` is tagged `lineage:"provenance"` in `run.go` to be picked up by
+them (see below).
+
+Every other field ADR 0011 or ADR 0015 added stayed a plain `string`, and
+that ADR rejected pointers specifically because a nullable *identity*
+field would make the fingerprint depend on how a client serializes an
+unset value. `Capture` is provenance, never hashed, so that objection does
+not apply here -- but a different, real distinction does, and it is why
+`Capture` is a pointer rather than a plain struct with `omitempty` (which
+`encoding/json` does not honor for non-pointer structs regardless): `nil`
+means no client ever sent a declaration for this run; non-nil means a
+client asserted (possibly empty) knowledge of its own capture behaviour.
+`examples/churn/completeness.py`'s peer-comparison fallback (below) depends
+on telling those two apart -- collapsing them the way ADR 0011 collapses
+`""` and absent would silently break that fallback for the runs it exists
+to cover, which is most of them today.
+
+### The identity/provenance split now comes from `run.go` itself
+
+Issue #79's property-test work (`run_property_test.go`) had already asked
+for the identity/provenance boundary to be derived from `lineage.Run`
+rather than hand-duplicated in the test file, and considered a struct tag
+for it -- rejecting the idea only because that task was scoped not to touch
+`run.go`. This change is not so scoped, so every field on `Run` now carries
+a `lineage:"identity"` or `lineage:"provenance"` struct tag, and
+`identityFieldNames`/`provenanceFieldNames` in the test file are derived
+from those tags via `reflect` instead of being written out twice.
+
+This does not make the mutation tests redundant. A struct tag is an
+assertion, not a proof: nothing stops a future field from being tagged
+`provenance` while `Compute` quietly hashes it anyway. That is exactly what
+`TestProperty_MutatingAProvenanceFieldLeavesFingerprintUnchanged` still
+catches, by calling the real `Compute` and checking the real fingerprint --
+the tag only removes the hand-duplication of *names*, not the need to
+verify *behaviour*. `TestProperty_EveryRunFieldIsClassified` remains the
+loud-failure backstop for the other mistake: a field with no tag at all,
+which would otherwise fall through untested.
+
+### Persisted by both store backends
+
+`internal/store/conformance.go` gained subtests covering: a declaration
+round-trips through `Record`/`Get` and through `List`; a run with no
+declaration reads back with `Capture == nil`, not an empty one; filtering by
+`capture_client`; and that `Update` never disturbs a run's declaration.
+Both `Memory` and `DuckDB` pass the same suite.
+
+`DuckDB` stores `Attempted` in a side table (`run_capture_attempted`,
+`(run_id, field)`), the same shape `run_params`/`run_metrics` already use
+for a variable-length, per-run collection, and two scalar columns on
+`runs`: `capture_declared BOOLEAN` and `capture_client VARCHAR`.
+`capture_declared` is what carries "no declaration at all" as a state
+distinct from "declared, with an empty client name" -- `capture_client`
+alone can't: both would read back as `''`. Both columns default (`DEFAULT
+FALSE` / `DEFAULT ''`, not `NOT NULL` -- this DuckDB build rejects an
+inline constraint on `ADD COLUMN`), so every pre-migration row backfills to
+exactly "no declaration", which is the true state of a row written before
+this feature existed. `TestDuckDBLegacyRowsHaveNoCaptureDeclaration` pins
+this the same way the fingerprint-version and attribution migrations
+already pin their own backfill.
+
+`Attempted` is conceptually a set, but a `Store`'s idempotent re-record
+check (and DuckDB's own side table, which has no row order of its own)
+both compare it as a concrete slice. `lineage.Run.NormalizeCapture` sorts
+it into a canonical order; every `Store.Record` calls it before comparing
+or persisting, so a byte-identical retry that happened to build the list in
+a different order is not refused as a spurious conflict.
+
+### Not patchable
+
+`PATCH /v1/runs/{id}` does not accept `capture`, unlike `host`, `device`,
+`framework_version`, `submitter_claim`, and `job_id`. Those fields are
+patchable because a run is often recorded before every fact about it is
+knowable -- a device only knowable once a job schedules onto specific
+hardware, a job id assigned by the scheduler after submission. A capture
+declaration has no such case: it describes what the recording client's own
+code tried, which the client already knows in full at the moment it makes
+the very first request for a run (both `rlctl` and the Python client build
+it before sending anything, start-time write included). Allowing a later
+patch to set it would also raise a question the other patchable fields
+never have to answer -- whose declaration is it, if a different call
+supplies it after the run already exists -- for no case that needs
+answering. `internal/store.Patch`'s doc comment states this explicitly, not
+just by the field's absence.
+
+### Filterable, not (yet) wired into spread
+
+`GET /v1/runs?capture_client=` filters exact-match, the same shape
+`device`/`submitter_claim`/`job_id` already have -- this is the "attribution
+across client versions" trigger the issue named directly: "did capture
+regress in client 2.3" is a query over runs by `capture_client`, not a
+statistic. `rlctl list --capture-client` exposes it the same way
+`--submitter-claim`/`--job-id` already do.
+
+`internal/spread.provenanceFields` (the columns `GET /v1/fingerprints`
+calls out as a likely explanation for a group's spread) does not gain
+`capture.client`. `device`/`framework_version`/`submitter_claim`/`job_id`
+are there because a disagreement on any of them is itself a plausible cause
+of two runs measuring differently, or a strong pointer to one. Which client
+recorded a run is not that kind of fact -- a capture declaration describes
+the *recording*, not anything that could make training behave differently
+-- so it does not belong on the same list, and is left off on purpose
+rather than added reflexively because a new provenance field exists.
+Auditing capture coverage is a different job than explaining a spread, and
+`declared_blind_spots` (below) is where that job lives.
+
+### `compare.Runs` reports two provenance fields
+
+`capture.client` (optional string, "" means not recorded, same rule as
+every other scalar provenance field) and `capture.attempted` (the set,
+rendered sorted and comma-joined so two declarations naming the same
+fields in different orders never manufacture a diff that isn't there). Both
+are `KindProvenance`: a capture declaration never makes two runs different
+experiments. A diff has no use for "no declaration" versus "declared, and
+declared nothing" -- both render as absent, the same normalization ADR
+0011 already applies to every other scalar field. That distinction is
+real, but it belongs to `completeness.py`'s fallback logic, not to a
+two-run diff.
+
+### Both clients populate it
+
+`rlctl` declares `Attempted: ["host"]` -- the only field it auto-detects
+(`os.Hostname()`, called unconditionally in `cmdRecord`); `--device`,
+`--dataset`, `--model`, `--config-hash` are plain pass-throughs of whatever
+a caller typed, not something `rlctl`'s own code looks for, so they do not
+belong in `Attempted`. The Python client declares
+`Attempted: ["host", "device", "framework_version"]` -- all three
+unconditionally attempted every time `_identity_and_provenance()` builds a
+payload -- which is the issue's own worked example, not a coincidence:
+`_provenance.device_name()` now correctly returns `""` when it cannot
+determine a device (#66), and `attempted` is precisely what disambiguates
+that `""` from "this client doesn't try". `internal/conformance`'s
+cross-client fingerprint suite stays green unmodified, because `Capture`
+is provenance -- it was never going to affect what the suite checks.
+
+### `examples/churn/completeness.py` defers to a declaration when one exists
+
+The peer-comparison heuristic (`odd_ones_out`, `blind_spots`) existed only
+because "did the client try" was unavailable, and stated so in its own
+module docstring. It still is unavailable for most runs recorded so far,
+so it is not removed -- it is demoted to the fallback for exactly the runs
+it always covered: ones with no capture declaration.
+
+A run that carries a declaration is never a candidate for `odd_ones_out`
+now, regardless of what it is missing: flagging it would report an
+inferred, lower-confidence guess ("probably a bad launch") over a fact the
+run already states outright ("this client never looks for X", or "it
+looked and genuinely found nothing"). A new function, `declared_blind_spots`,
+reports the ground-truth counterpart of the pipeline-level signal: a field
+every capture-declaring run in the project agrees it never attempts, which
+needs no peer-share threshold because it is not an inference. `report()`
+surfaces it as "known blind spots", worded to read differently from the
+inferred "blind spots (never recorded)" line beside it -- one is a
+statistical prior, the other is what the clients themselves said.
+
+## Consequences
+
+- A capture declaration is exactly as self-asserted as `Host`/`Device`
+  already are: a caller can claim `Attempted: ["device"]` and never
+  actually look. Nothing about this field is attested. That is an accepted
+  gap, not an oversight, the same posture ADR 0015 takes for
+  `submitter_claim`.
+- Every run recorded from here on by `rlctl` or the Python client carries a
+  declaration; every run recorded before this change, or through raw HTTP
+  without one, does not, and reads back with `Capture == nil` rather than
+  an empty object. `completeness.py`'s fallback exists because of that
+  imbalance and will keep mattering for as long as it lasts.
+- `docs/openapi.yaml` documents `capture` as omitted-by-default on `Run`
+  and `RunInput`, present only when a client sends one, and absent from
+  `RunPatch` entirely -- `TestSchemasMatchGoTypes` pins the Go/spec field
+  sets agreeing, and `TestRoutesMatchSpec` pins the routes.
+
+## What would have to be true to revisit this
+
+Nothing about the shape needs revisiting on its own terms. What could
+change is scope: if a gate or an automated check ever wants to *act* on
+`capture.attempted` (the first of the issue's three original triggers,
+still not built), or if `capture.client` earns a place in
+`spread.provenanceFields` because auditing coverage and explaining spread
+turn out to be the same workflow after all, those are natural, additive
+follow-ups -- not reversals of anything decided here.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -27,6 +27,7 @@ section is a summary of these; this folder is the account.
 | [0013](0013-param-values-are-normalized-before-hashing.md) | Param values are normalized before hashing, and the fingerprint is now versioned | Accepted |
 | [0014](0014-python-client-writes-running-then-patches-terminal.md) | The Python client writes a `running` record at start, and patches it to a terminal status at the end | Accepted |
 | [0015](0015-run-attribution-is-provenance-self-asserted.md) | Run attribution is provenance, and is self-asserted until named tokens exist | Accepted |
+| [0016](0016-record-what-the-client-attempted-to-capture.md) | Record what the client attempted to capture, not just what it captured | Accepted |
 
 ## Adding a record
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -6,8 +6,10 @@ info:
     git_commit, git_dirty, config_hash, dataset_version, model_version, seed,
     params) determine a run's fingerprint; provenance fields (host, device,
     framework_version, submitter_claim, job_id, status, timestamps,
-    checkpoint_uri, metrics) record what happened without affecting it. See
-    the repository README for the full model.
+    checkpoint_uri, metrics, capture) record what happened without affecting
+    it. capture is a declaration of what the client attempted to capture, not
+    what it captured -- see ADR 0016 and the Run schema's capture
+    description. See the repository README for the full model.
   version: "1.0.0"
   license:
     name: MIT
@@ -51,6 +53,9 @@ paths:
                 lr: "3e-4"
               device: cpu
               framework_version: torch-2.3.0
+              capture:
+                client: runledger-py/0.1.0
+                attempted: [host, device, framework_version]
               status: created
       responses:
         "201":
@@ -137,6 +142,15 @@ paths:
         - name: job_id
           in: query
           description: Filter to runs whose job_id matches exactly.
+          schema:
+            type: string
+        - name: capture_client
+          in: query
+          description: >
+            Filter to runs whose capture.client matches exactly (e.g.
+            runledger-py/0.1.0) -- isolates every run one client version
+            recorded, for questions like "did capture coverage regress in
+            client X.Y". A run with no capture declaration never matches.
           schema:
             type: string
         - name: since
@@ -242,7 +256,11 @@ paths:
         {succeeded, failed, cancelled}; a terminal status cannot be left.
         Identity fields may be included only to confirm they are unchanged
         -- sending one that differs from the stored value is rejected as a
-        conflict rather than silently ignored.
+        conflict rather than silently ignored. capture is deliberately not
+        patchable: it describes what the recording client's own code tried,
+        which it already knows in full at record time, so there is no
+        legitimate "fill this in later" case the way there is for the fields
+        above (see ADR 0016).
       security:
         - bearerAuth: []
         - {}
@@ -637,6 +655,18 @@ components:
             The CI job id, Slurm job id, or other scheduler-assigned
             identifier of the job that launched this run. One generic
             field for whatever a launcher calls its own unit of work.
+        capture:
+          allOf:
+            - $ref: "#/components/schemas/CaptureDeclaration"
+          description: >
+            What the client attempted to capture when it wrote this run, not
+            what it captured -- see ADR 0016. Omitted entirely means no
+            declaration was sent at all, which is a different claim from a
+            declaration that names nothing (see CaptureDeclaration). Not
+            accepted by PATCH: a capture declaration describes what the
+            recording client's own code tried, which it already knows in
+            full at record time, so there is no legitimate "fill this in
+            later" case the way there is for host/device/job_id.
         status:
           $ref: "#/components/schemas/Status"
         started_at:
@@ -751,6 +781,18 @@ components:
             identifier of the job that launched this run. One generic
             field for whatever a launcher calls its own unit of work. Empty
             means not recorded.
+        capture:
+          allOf:
+            - $ref: "#/components/schemas/CaptureDeclaration"
+          description: >
+            What the client attempted to capture when it wrote this run, not
+            what it captured -- a fact about the recording process, never
+            hashed into fingerprint. Absent means no client ever sent a
+            declaration for this run (every run recorded before this field
+            existed, or a client that doesn't populate it) -- a different
+            claim from a declaration present but naming nothing, which is
+            why this is omitted rather than defaulted to an empty object.
+            See ADR 0016.
         status:
           $ref: "#/components/schemas/Status"
         started_at:
@@ -767,6 +809,42 @@ components:
           additionalProperties:
             type: number
             format: double
+
+    # ADR 0016: "did the client try to capture X" is a fact about the
+    # recording process, not a value the experiment can take, so a nullable
+    # value field can't hold it -- CaptureDeclaration is a small object kept
+    # alongside the run for exactly that fact, and is never hashed.
+    CaptureDeclaration:
+      type: object
+      additionalProperties: false
+      properties:
+        client:
+          type: string
+          description: >
+            The client library and version that produced this declaration
+            (e.g. runledger-py/0.1.0), so "did capture regress in client
+            X.Y" is answerable directly from stored runs. Self-asserted the
+            same way host and device already are.
+        attempted:
+          type: array
+          items:
+            type: string
+            enum:
+              - config_hash
+              - dataset_version
+              - model_version
+              - host
+              - device
+              - framework_version
+              - checkpoint_uri
+          description: >
+            Which of the seven fields ADR 0011 gives "" a single meaning for
+            this client's recording code actively tried to determine,
+            regardless of whether the attempt succeeded. A field's absence
+            here means the client never looks for it at all -- distinct from
+            looking and finding nothing, which is that field present here
+            with an empty value on the run itself. Unrecognized names are
+            rejected the same way an unrecognized status is.
 
     RunPatch:
       type: object

--- a/examples/churn/completeness.py
+++ b/examples/churn/completeness.py
@@ -2,8 +2,8 @@
 
 The ledger's one claim is "same fingerprint + different metrics = something
 real is going unrecorded." It deliberately does not say what. But there is a
-cheap signal it can offer about *where to look first*, and it needs no
-schema change and no new field: compare a run against its peers.
+cheap signal it can offer about *where to look first*: compare a run against
+its peers.
 
 The reasoning
 -------------
@@ -16,9 +16,27 @@ What stays unanswerable from a single record is *why*: whether this run
 genuinely had no dataset version, or the client that submitted it failed
 to send one. That is a fact about the recording process rather than about
 the experiment, and no amount of widening the field's type would recover
-it.
+it -- which is why this module used to stop here and infer the answer
+statistically instead.
 
-Across a *project*, though, it is recoverable statistically. If 11 of 12
+ADR 0016 closes that gap directly: a run's `capture` field, when present,
+names exactly which fields its client attempted to determine. For a run
+that carries one, this module no longer has to guess -- an empty field the
+client says it attempted is a real fact about the environment (it looked
+and found nothing), and a field absent from `attempted` is a real fact
+about the pipeline (this client never looks), neither of which is evidence
+of a bad launch. Such a run is excluded from `odd_ones_out` entirely: the
+peer heuristic exists to approximate a signal that a capture declaration
+now states outright, and inference has nothing to add once the fact is
+already known. `declared_blind_spots` reports the ground-truth counterpart
+of the pipeline-level signal below.
+
+Most runs recorded before ADR 0016 -- and any client that still doesn't
+send a declaration -- carry no `capture` field at all. For exactly those
+runs, the statistical approximation below is still what this module has,
+and it works the same way it always did:
+
+Across a *project*, missing-ness is recoverable statistically. If 11 of 12
 runs in a project record `framework_version` and one does not, the odds that
 the twelfth run genuinely had no framework are poor. The peer group supplies
 the prior that the individual record lacks.
@@ -65,6 +83,30 @@ ODD_ONE_OUT_SHARE = 0.6
 MIN_PEERS = 3
 
 
+def _declares_capture(run: Dict[str, Any]) -> bool:
+    """Whether run carries a capture declaration at all (ADR 0016).
+
+    The server omits the `capture` key entirely for a run whose client
+    never sent one -- absent means "no declaration", not "declared with
+    nothing in it" -- so a plain truthiness check already distinguishes
+    the two the same way the wire representation does.
+    """
+    return bool(run.get("capture"))
+
+
+def _attempted(run: Dict[str, Any]) -> "set[str]":
+    """The set of fields run's capture declaration says its client tried.
+
+    Only meaningful when `_declares_capture(run)` is true. For a run with
+    no declaration this also returns an empty set -- the same shape a
+    declared-but-attempts-nothing client would produce -- so callers must
+    check `_declares_capture` first if the distinction matters to them
+    (`odd_ones_out` and `declared_blind_spots` both do).
+    """
+    capture = run.get("capture") or {}
+    return set(capture.get("attempted") or [])
+
+
 def coverage(runs: Sequence[Dict[str, Any]]) -> Dict[str, float]:
     """Share of runs recording a non-empty value, per capturable field."""
     if not runs:
@@ -77,10 +119,24 @@ def coverage(runs: Sequence[Dict[str, Any]]) -> Dict[str, float]:
 
 
 def odd_ones_out(runs: Sequence[Dict[str, Any]]) -> List[Dict[str, Any]]:
-    """Runs missing a field their peers overwhelmingly record."""
+    """Runs missing a field their peers overwhelmingly record.
+
+    A run that carries a capture declaration (ADR 0016) is never a
+    candidate here, whatever it's missing: the whole point of the peer
+    heuristic is approximating an answer this module can't otherwise get,
+    and a declared run already states the answer outright. Flagging it
+    anyway would report an inferred, lower-confidence guess ("probably a
+    bad launch") over a known fact ("this client never looks for X", or
+    "it looked and genuinely found nothing") -- strictly a worse claim,
+    not merely a redundant one. Peer coverage (`cov`, above) still counts
+    every run, declared or not, when judging *other* runs: a declared
+    run's recorded values are real data about the project either way.
+    """
     cov = coverage(runs)
     findings = []
     for run in runs:
+        if _declares_capture(run):
+            continue
         missing = []
         for field, kind in CAPTURABLE:
             share = cov.get(field, 0.0)
@@ -105,6 +161,33 @@ def blind_spots(runs: Sequence[Dict[str, Any]]) -> List[Dict[str, str]]:
     cov = coverage(runs)
     return [
         {"field": f, "kind": k} for f, k in CAPTURABLE if cov.get(f, 0.0) == 0.0
+    ]
+
+
+def declared_blind_spots(runs: Sequence[Dict[str, Any]]) -> List[Dict[str, str]]:
+    """Fields that every capture-declaring run in the project says its
+    client never attempts (ADR 0016) -- the ground-truth counterpart to
+    `blind_spots`.
+
+    `blind_spots` can only ever *infer* "nobody records this" from
+    presence, which cannot tell "no run happened to need it" apart from
+    "the client never looks" -- that ambiguity is the entire reason ADR
+    0016 exists. A run with a capture declaration removes it directly:
+    `field not in attempted` is a fact about that run's client, not a
+    guess. This checks it across every declared run in the project rather
+    than trusting a single one, the same "don't act on one data point"
+    caution `ODD_ONE_OUT_SHARE`/`MIN_PEERS` apply to the inferred signal.
+
+    Returns `[]` when no run in the project declares capture -- there is
+    nothing to conclude without at least one.
+    """
+    declared = [r for r in runs if _declares_capture(r)]
+    if not declared:
+        return []
+    return [
+        {"field": f, "kind": k}
+        for f, k in CAPTURABLE
+        if all(f not in _attempted(r) for r in declared)
     ]
 
 
@@ -196,4 +279,14 @@ def report(runs: Sequence[Dict[str, Any]]) -> str:
         lines.append("  -> no unexplained spread in this project, so nothing to chase.")
     else:
         lines.append("no blind spots: every capturable field is recorded somewhere")
+
+    known = declared_blind_spots(runs)
+    if known:
+        names = ", ".join(s["field"] for s in known)
+        lines.append("")
+        lines.append(f"known blind spots (client says it never attempts): {names}")
+        lines.append(
+            "  -> not a guess: every run that declared what it attempts (ADR 0016)\n"
+            "     agrees it doesn't try these. Update the client, not the launch."
+        )
     return "\n".join(lines)

--- a/examples/churn/test_completeness.py
+++ b/examples/churn/test_completeness.py
@@ -81,6 +81,92 @@ class BlindSpots(unittest.TestCase):
         self.assertIn("BLIND SPOTS, AND THEY MATTER HERE", completeness.report(noisy))
 
 
+class CaptureAware(unittest.TestCase):
+    """ADR 0016: a run that declares what it attempted no longer needs the
+    peer heuristic to guess about it -- these pin that a declared run is
+    never flagged by odd_ones_out, whatever it's missing, and that
+    declared_blind_spots reports the ground-truth version of the
+    pipeline-level signal.
+    """
+
+    def test_declared_run_missing_an_attempted_field_is_not_odd_one_out(self):
+        # The client looked for dataset_version and genuinely found
+        # nothing -- a real fact about the environment, not a bad launch,
+        # even though every peer records it.
+        peers = [run(f"r{i}") for i in range(5)]
+        declared = run(
+            "declared",
+            dataset_version="",
+            capture={"client": "c/1", "attempted": ["dataset_version"]},
+        )
+        self.assertEqual(completeness.odd_ones_out(peers + [declared]), [])
+
+    def test_declared_run_missing_an_unattempted_field_is_not_odd_one_out(self):
+        # The client never even looks for dataset_version -- a known
+        # blind spot for this run's pipeline, not an outlier launch.
+        peers = [run(f"r{i}") for i in range(5)]
+        declared = run(
+            "declared",
+            dataset_version="",
+            capture={"client": "c/1", "attempted": ["host", "device"]},
+        )
+        self.assertEqual(completeness.odd_ones_out(peers + [declared]), [])
+
+    def test_undeclared_runs_are_still_flagged_normally(self):
+        # The peer heuristic must keep working unchanged for the runs it
+        # exists for -- most existing runs have no capture declaration.
+        runs = [run(f"r{i}") for i in range(5)] + [run("odd", dataset_version="")]
+        [finding] = completeness.odd_ones_out(runs)
+        self.assertEqual(finding["run_id"], "odd")
+
+    def test_declared_blind_spots_needs_every_declared_run_to_agree(self):
+        # attempted lists only the fields each run's client actually tried;
+        # every field this fixture doesn't explicitly attempt is set to ""
+        # too, so a run's attempted list and its values agree the way a
+        # real client's would (declaring a field "attempted" is unrelated
+        # to whether a *different*, pass-through-supplied field happens to
+        # carry a value -- see rlctl, whose --device flag can be set even
+        # though rlctl itself never "attempts" device detection).
+        all_but_framework = ["config_hash", "dataset_version", "model_version", "host", "device"]
+        declared_never = run(
+            "a", framework_version="", capture={"client": "c/1", "attempted": all_but_framework}
+        )
+        declared_also_never = run(
+            "b", framework_version="", capture={"client": "c/2", "attempted": all_but_framework}
+        )
+        self.assertEqual(
+            [s["field"] for s in completeness.declared_blind_spots([declared_never, declared_also_never])],
+            ["framework_version"],
+        )
+
+    def test_declared_blind_spots_is_not_fooled_by_one_declared_run_that_tries(self):
+        all_fields = ["config_hash", "dataset_version", "model_version", "host", "device", "framework_version"]
+        never_tries = run(
+            "a",
+            framework_version="",
+            capture={"client": "c/1", "attempted": [f for f in all_fields if f != "framework_version"]},
+        )
+        does_try = run(
+            "b",
+            framework_version="torch 2.5",
+            capture={"client": "c/2", "attempted": all_fields},
+        )
+        self.assertEqual(completeness.declared_blind_spots([never_tries, does_try]), [])
+
+    def test_declared_blind_spots_empty_with_no_declarations_at_all(self):
+        runs = [run(f"r{i}", framework_version="") for i in range(4)]
+        self.assertEqual(completeness.declared_blind_spots(runs), [])
+
+    def test_report_surfaces_known_blind_spots_distinctly(self):
+        runs = [
+            run(f"r{i}", framework_version="", capture={"client": "c/1", "attempted": ["host"]})
+            for i in range(3)
+        ]
+        text = completeness.report(runs)
+        self.assertIn("known blind spots", text)
+        self.assertIn("framework_version", text.split("known blind spots")[1])
+
+
 class UnattributableGroups(unittest.TestCase):
     def test_identical_metrics_are_not_spread(self):
         runs = [run(f"r{i}", metrics={"auc": 0.8}) for i in range(4)]

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -557,6 +557,10 @@ var listQueryParams = map[string]bool{
 	// runs" workflow #67 exists for, consistent with the existing
 	// provenance filter (device) rather than a new mechanism.
 	"submitter_claim": true, "job_id": true,
+	// capture_client: "did capture regress in client X.Y" (ADR 0016) needs
+	// to isolate every run one client version recorded, the same exact-match
+	// shape device/submitter_claim/job_id already have.
+	"capture_client": true,
 }
 
 func (s *Server) list(w http.ResponseWriter, r *http.Request) {
@@ -604,6 +608,7 @@ func (s *Server) list(w http.ResponseWriter, r *http.Request) {
 		Device:         q.Get("device"),
 		SubmitterClaim: q.Get("submitter_claim"),
 		JobID:          q.Get("job_id"),
+		CaptureClient:  q.Get("capture_client"),
 		Limit:          limit,
 		After:          after,
 		Since:          since,

--- a/internal/compare/compare.go
+++ b/internal/compare/compare.go
@@ -4,6 +4,7 @@ package compare
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/kornsour/run-ledger/internal/lineage"
 )
@@ -145,11 +146,52 @@ func Runs(a, b lineage.Run) Result {
 	add("job_id", KindProvenance, optional(a.JobID), optional(b.JobID))
 	add("status", KindProvenance, optional(string(a.Status)), optional(string(b.Status)))
 	add("checkpoint_uri", KindProvenance, optional(a.CheckpointURI), optional(b.CheckpointURI))
+	add("capture.client", KindProvenance, optional(captureClient(a.Capture)), optional(captureClient(b.Capture)))
+	// Attempted is a set, not an ordered list -- captureAttempted renders it
+	// as a sorted, comma-joined string so two declarations naming the same
+	// fields in different orders (a real possibility: nothing about
+	// CaptureDeclaration.Attempted's wire order is meaningful) compare equal
+	// rather than manufacturing a diff out of nothing. A nil Capture (no
+	// declaration at all) and one with an empty Attempted both render as ""
+	// here and are optional()-normalized to nil the same way every other
+	// scalar provenance field is -- compare.go's job is "what differs",
+	// and "no declaration" vs "declared nothing" is a distinction
+	// completeness.py's peer-comparison fallback needs (see ADR 0016), not
+	// one a two-run diff has any use for.
+	add("capture.attempted", KindProvenance, optional(captureAttempted(a.Capture)), optional(captureAttempted(b.Capture)))
 
 	for _, k := range unionKeysF(a.Metrics, b.Metrics) {
 		add("metrics."+k, KindMetric, fmtMetric(a.Metrics, k), fmtMetric(b.Metrics, k))
 	}
 	return res
+}
+
+// captureClient returns c's client string, or "" if the run carries no
+// capture declaration at all. Fed through optional() at the call site, the
+// same "" means not recorded" treatment every other scalar provenance
+// field already gets -- a diff has no use for "no declaration" versus
+// "declared with an empty client name", only for "declared" versus "not".
+func captureClient(c *lineage.CaptureDeclaration) string {
+	if c == nil {
+		return ""
+	}
+	return c.Client
+}
+
+// captureAttempted renders c.Attempted as a canonical, comma-joined string:
+// sorted, because Attempted is conceptually a set (which fields the client
+// tried, not in what order it lists them), so two declarations naming the
+// same fields in different orders must compare equal rather than showing a
+// diff that isn't there. Returns "" for a nil Capture or an empty
+// Attempted -- fed through optional() at the call site, so both render as
+// "not recorded" the same as every other scalar provenance field.
+func captureAttempted(c *lineage.CaptureDeclaration) string {
+	if c == nil || len(c.Attempted) == 0 {
+		return ""
+	}
+	attempted := append([]string(nil), c.Attempted...)
+	sort.Strings(attempted)
+	return strings.Join(attempted, ",")
 }
 
 // fmtMetric returns nil for a metric the run did not report, which is

--- a/internal/compare/compare_test.go
+++ b/internal/compare/compare_test.go
@@ -202,6 +202,71 @@ func TestEmptyAttributionFieldsReportAsAbsent(t *testing.T) {
 	}
 }
 
+// TestCaptureDiffersFromNoDeclaration exercises the "did the client try"
+// half of ADR 0016: a run whose client declared it looked for device (and
+// found nothing) must compare as different from a run with no capture
+// declaration at all, even though both runs have Device == "".
+func TestCaptureDiffersFromNoDeclaration(t *testing.T) {
+	a, b := run("a"), run("b")
+	b.Capture = &lineage.CaptureDeclaration{Client: "runledger-py/0.1.0", Attempted: []string{"device", "host"}}
+
+	fields := Runs(a, b).Fields
+	var sawClient, sawAttempted bool
+	for _, f := range fields {
+		switch f.Name {
+		case "capture.client":
+			sawClient = true
+			if f.A != nil || f.B == nil || *f.B != "runledger-py/0.1.0" {
+				t.Errorf("capture.client: got a=%v b=%v, want a=nil b=%q", f.A, f.B, "runledger-py/0.1.0")
+			}
+		case "capture.attempted":
+			sawAttempted = true
+			if f.A != nil || f.B == nil || *f.B != "device,host" {
+				t.Errorf("capture.attempted: got a=%v b=%v, want a=nil b=%q (sorted)", f.A, f.B, "device,host")
+			}
+		}
+	}
+	if !sawClient || !sawAttempted {
+		t.Fatalf("want both capture.client and capture.attempted reported as differences, got %+v", fields)
+	}
+	if Runs(a, b).SameExperiment != true {
+		t.Fatal("a capture declaration must never affect same_experiment -- it is provenance, not identity")
+	}
+}
+
+// TestCaptureAttemptedOrderDoesNotProduceASpuriousDiff pins that Attempted
+// is compared as a set, not a sequence: two declarations naming the same
+// fields in different orders describe the same recording behaviour and
+// must not show up as a difference.
+func TestCaptureAttemptedOrderDoesNotProduceASpuriousDiff(t *testing.T) {
+	a, b := run("a"), run("b")
+	a.Capture = &lineage.CaptureDeclaration{Client: "c/1", Attempted: []string{"host", "device", "framework_version"}}
+	b.Capture = &lineage.CaptureDeclaration{Client: "c/1", Attempted: []string{"framework_version", "device", "host"}}
+
+	for _, f := range Runs(a, b).Fields {
+		if f.Name == "capture.attempted" || f.Name == "capture.client" {
+			t.Fatalf("want no diff for reordered-but-identical capture declarations, got %+v", f)
+		}
+	}
+}
+
+// TestCaptureDeclaredEmptyIsIndistinguishableFromNoDeclarationInADiff pins a
+// deliberate choice: a diff has no use for "no declaration" versus
+// "declared, and declared nothing" -- both mean the same thing to a reader
+// comparing two runs. That distinction exists only for
+// examples/churn/completeness.py's fallback logic (ADR 0016), which reads
+// the raw API response, not compare.Runs's diff.
+func TestCaptureDeclaredEmptyIsIndistinguishableFromNoDeclarationInADiff(t *testing.T) {
+	a, b := run("a"), run("b")
+	b.Capture = &lineage.CaptureDeclaration{} // declared, with an empty client and no attempted fields
+
+	for _, f := range Runs(a, b).Fields {
+		if f.Name == "capture.attempted" || f.Name == "capture.client" {
+			t.Fatalf("want no diff between no declaration and an empty declaration, got %+v", f)
+		}
+	}
+}
+
 // compare must not answer "same experiment" independently of the stored
 // fingerprint the rest of the ledger groups by. Recomputing here gave a
 // second answer to the same question, which stays invisible only while

--- a/internal/lineage/run.go
+++ b/internal/lineage/run.go
@@ -20,16 +20,29 @@ import (
 // are hashed into the RunID; the fields below record *what happened* and are
 // not. Two runs with the same Fingerprint were the same experiment, whatever
 // their outcome — which is what makes "did this change anything?" answerable.
+//
+// Every field also carries a `lineage:"identity"` or `lineage:"provenance"`
+// struct tag agreeing with which side of that boundary it's on.
+// run_property_test.go's TestProperty_EveryRunFieldIsClassified reads these
+// tags (rather than a hand-maintained list duplicated in the test file) to
+// build the field sets its mutation properties exercise, and fails loudly if
+// a field is missing one or carries an unrecognized value. A tag can still
+// say something false -- nothing stops a future field from being tagged
+// "provenance" while Compute quietly hashes it anyway -- which is exactly
+// why the tag only supplies the field *names* under test; the properties
+// still call the real Compute and fail if a "provenance"-tagged field
+// actually moves the fingerprint. The tag removes the duplication, not the
+// need for that behavioral check.
 type Run struct {
 	// --- identity: hashed into Fingerprint ---
-	Project        string            `json:"project"`
-	GitCommit      string            `json:"git_commit"`
-	GitDirty       bool              `json:"git_dirty"`
-	ConfigHash     string            `json:"config_hash"`
-	DatasetVersion string            `json:"dataset_version"`
-	ModelVersion   string            `json:"model_version"`
-	Seed           int64             `json:"seed"`
-	Params         map[string]string `json:"params,omitempty"`
+	Project        string            `json:"project" lineage:"identity"`
+	GitCommit      string            `json:"git_commit" lineage:"identity"`
+	GitDirty       bool              `json:"git_dirty" lineage:"identity"`
+	ConfigHash     string            `json:"config_hash" lineage:"identity"`
+	DatasetVersion string            `json:"dataset_version" lineage:"identity"`
+	ModelVersion   string            `json:"model_version" lineage:"identity"`
+	Seed           int64             `json:"seed" lineage:"identity"`
+	Params         map[string]string `json:"params,omitempty" lineage:"identity"`
 
 	// --- provenance: recorded, not hashed ---
 	//
@@ -47,8 +60,16 @@ type Run struct {
 	// client serializes an unset key or omits it -- how a client spells
 	// things, rather than what the experimenter chose. Consumers may rely
 	// on "" == absent for these fields; compare.Runs already does.
-	RunID       string `json:"run_id"`
-	Fingerprint string `json:"fingerprint"`
+	//
+	// What ADR 0011 leaves unanswered is *why* a field is empty. A client
+	// that looked for a device and found none, and a client that never
+	// looks at all, both produce Device == "" -- indistinguishable from a
+	// single record, and no amount of widening Device's own type recovers
+	// the difference, because "did the client try" is a fact about the
+	// recording process, not a value the experiment can take. See Capture,
+	// below, and ADR 0016.
+	RunID       string `json:"run_id" lineage:"provenance"`
+	Fingerprint string `json:"fingerprint" lineage:"provenance"`
 	// FingerprintVersion records which version of Compute's hashing contract
 	// produced Fingerprint -- see ADR 0004 and ADR 0013. It is provenance
 	// about the fingerprint, not an input to it: hashing the version itself
@@ -64,10 +85,10 @@ type Run struct {
 	// every pre-existing row to FingerprintVersionLegacy explicitly, and any
 	// other caller constructing a Run by hand for a legacy value should do
 	// the same rather than leave the field at its zero value.
-	FingerprintVersion int    `json:"fingerprint_version"`
-	Host               string `json:"host"`
-	Device             string `json:"device"`
-	FrameworkVersion   string `json:"framework_version"`
+	FingerprintVersion int    `json:"fingerprint_version" lineage:"provenance"`
+	Host               string `json:"host" lineage:"provenance"`
+	Device             string `json:"device" lineage:"provenance"`
+	FrameworkVersion   string `json:"framework_version" lineage:"provenance"`
 	// SubmitterClaim names the human or service account the caller says
 	// recorded this run. The field is named "claim", not "submitter" or
 	// "user", on purpose: RUNLEDGER_TOKEN is one shared secret today (see
@@ -85,7 +106,7 @@ type Run struct {
 	// differently depending on who happened to launch it, which destroys the
 	// one property fingerprinting exists to give (same fingerprint means
 	// same experiment, full stop).
-	SubmitterClaim string `json:"submitter_claim"`
+	SubmitterClaim string `json:"submitter_claim" lineage:"provenance"`
 	// JobID is the identifier of the job or scheduler invocation that
 	// launched this run -- a CI job id, a Slurm job id, or whatever a
 	// launcher calls its own unit of work. Deliberately one generic field
@@ -96,16 +117,99 @@ type Run struct {
 	// are -- unlike SubmitterClaim it does not name a person, so it does not
 	// need the same "claim" framing in its name; forging it gains a caller
 	// nothing the way misattributing a run to someone else would.
-	JobID     string    `json:"job_id"`
-	Status    Status    `json:"status"`
-	StartedAt time.Time `json:"started_at"`
+	JobID     string    `json:"job_id" lineage:"provenance"`
+	Status    Status    `json:"status" lineage:"provenance"`
+	StartedAt time.Time `json:"started_at" lineage:"provenance"`
 	// EndedAt is a pointer because a struct's zero value is never omitted by
 	// encoding/json's "omitempty" -- without the pointer, every run that
 	// hasn't ended would serialize ended_at as 0001-01-01T00:00:00Z instead
 	// of leaving the field out.
-	EndedAt       *time.Time         `json:"ended_at,omitempty"`
-	CheckpointURI string             `json:"checkpoint_uri,omitempty"`
-	Metrics       map[string]float64 `json:"metrics,omitempty"`
+	EndedAt       *time.Time         `json:"ended_at,omitempty" lineage:"provenance"`
+	CheckpointURI string             `json:"checkpoint_uri,omitempty" lineage:"provenance"`
+	Metrics       map[string]float64 `json:"metrics,omitempty" lineage:"provenance"`
+	// Capture records what the client attempted to capture when it wrote
+	// this run, not what it captured -- see ADR 0016. nil means no client
+	// sent a declaration at all (every run recorded before this field
+	// existed, or a caller that simply doesn't populate it); non-nil means a
+	// client asserted (possibly empty) knowledge of its own capture
+	// behaviour.
+	//
+	// That nil-vs-non-nil distinction is deliberate, and is the reason this
+	// is the one field on Run that is a pointer: ADR 0011 rejected pointers
+	// for the seven scalar fields precisely because nothing there needed a
+	// third state beyond "recorded" and "not recorded" -- but
+	// examples/churn/completeness.py's peer-comparison heuristic needs to
+	// tell "no declaration at all, fall back to inferring from peers" apart
+	// from "declared, and declared nothing", and collapsing those two the
+	// way ADR 0011 collapses "" and absent would silently break that
+	// fallback for the runs it exists to cover (most of them, today). This
+	// does not reopen ADR 0011's objection: that objection was about the
+	// fingerprint contract -- a nullable identity field would make the
+	// fingerprint depend on how a client serializes an unset value rather
+	// than on what the experimenter chose. Capture is never hashed (see
+	// Compute below), so there is no fingerprint contract here to destabilize.
+	Capture *CaptureDeclaration `json:"capture,omitempty" lineage:"provenance"`
+}
+
+// CaptureDeclaration records which fields a client's recording code path
+// actively tried to determine for a run, regardless of whether the attempt
+// succeeded -- see ADR 0016. It answers a question no value field can hold
+// on its own: not "what did this run have", but "did this client know how
+// to look".
+type CaptureDeclaration struct {
+	// Client identifies the client library and version that produced this
+	// declaration (e.g. "runledger-py/0.1.0"), so "did capture regress in
+	// client X.Y" is answerable directly from stored runs rather than by
+	// cross-referencing anything else. Self-asserted the same way Host and
+	// Device already are -- forging it gains a caller nothing, the same
+	// reason JobID needs no special "claim" framing.
+	Client string `json:"client"`
+	// Attempted names which of CaptureFields this client's recording code
+	// tried to determine for this run. A field's absence from Attempted is
+	// itself the fact this type exists to carry: it means the client never
+	// looks for that field at all, as distinct from looking and finding
+	// nothing (an empty value on Run with the field named here). Validate
+	// rejects any name not in CaptureFields, the same way it rejects an
+	// unrecognized Status -- an unknown name here is a typo, not a new kind
+	// of fact.
+	Attempted []string `json:"attempted,omitempty"`
+}
+
+// CaptureFields are the fields ADR 0011 gives a single meaning to "" for --
+// the ones "did the client try?" is answerable about. CaptureDeclaration's
+// Attempted may name only fields from this list.
+var CaptureFields = []string{
+	"config_hash", "dataset_version", "model_version",
+	"host", "device", "framework_version", "checkpoint_uri",
+}
+
+var captureFieldSet = func() map[string]bool {
+	m := make(map[string]bool, len(CaptureFields))
+	for _, f := range CaptureFields {
+		m[f] = true
+	}
+	return m
+}()
+
+// NormalizeCapture sorts r.Capture.Attempted into a canonical (lexical)
+// order, if r carries a capture declaration. Attempted is conceptually a
+// set -- which fields the client tried, not in what order -- but a Store's
+// idempotent re-record check compares it as a concrete slice, and DuckDB
+// reads it back from a side table with no row order of its own. Without a
+// canonical order, a legitimate retry of a byte-identical request could
+// read back non-identically ordered and be refused as a conflict for a
+// reason that has nothing to do with what the client actually sent.
+//
+// Every Store.Record implementation calls this before comparing or
+// persisting (see internal/store). It is deliberately not folded into
+// Validate: Validate only reports whether a run can be trusted as lineage
+// and never mutates it, and giving it a side effect here would break that
+// for every existing caller that assumes Validate is a pure check.
+func (r *Run) NormalizeCapture() {
+	if r.Capture == nil || len(r.Capture.Attempted) < 2 {
+		return
+	}
+	sort.Strings(r.Capture.Attempted)
 }
 
 // Status is the lifecycle state of a run.
@@ -181,6 +285,13 @@ func (r *Run) Validate() error {
 	}
 	if r.EndedAt != nil && r.EndedAt.Before(r.StartedAt) {
 		return errors.New("ended_at precedes started_at")
+	}
+	if r.Capture != nil {
+		for _, f := range r.Capture.Attempted {
+			if !captureFieldSet[f] {
+				return fmt.Errorf("capture.attempted names unknown field %q", f)
+			}
+		}
 	}
 	return nil
 }

--- a/internal/lineage/run_property_test.go
+++ b/internal/lineage/run_property_test.go
@@ -47,58 +47,68 @@ func newPropertyRand(t *testing.T) *rand.Rand {
 //
 // Three ways to express the boundary were considered:
 //
-//  1. A struct tag on each field (e.g. `lineage:"identity"`). This would be
-//     the most machine-checkable option, but it requires editing run.go,
-//     which this task is explicitly scoped not to touch -- and even if it
-//     weren't, a tag is just as capable of drifting from what Compute
-//     actually hashes as anything else here: nothing stops someone from
-//     adding a field, tagging it "provenance", and also (by mistake) adding
-//     it to Compute's write() call. A tag only moves the hand-maintained
-//     source of truth from a test file to the struct; it doesn't remove the
-//     need for one.
+//  1. A struct tag on each field (e.g. `lineage:"identity"`). The most
+//     machine-checkable option -- but a tag is just as capable of drifting
+//     from what Compute actually hashes as anything else here: nothing
+//     stops someone from adding a field, tagging it "provenance", and also
+//     (by mistake) adding it to Compute's write() call. A tag only moves
+//     the hand-maintained source of truth from a test file to the struct;
+//     it doesn't remove the need for a behavioral check.
 //  2. Parsing the "--- identity ---" / "--- provenance ---" boundary
 //     comment out of run.go via go/ast. This sounds the most "automatic",
 //     but a comment is not a language-level contract: nothing stops it from
 //     drifting out of sync with the fields around it after a refactor, a
 //     parser has to make an editorial judgment call about which comment
-//     line is "the" boundary, and the payoff over option 3 is small since
+//     line is "the" boundary, and the payoff over option 1 is small since
 //     both still require a human to keep two things in agreement.
-//  3. Two explicit field-name whitelists in this test file, one mirroring
-//     exactly what Compute's write() call and Params loop hash
-//     (identityFieldNames) and one covering everything else
-//     (provenanceFieldNames) -- with a separate test
-//     (TestProperty_EveryRunFieldIsClassified) asserting every field on
-//     Run appears in exactly one of the two, and failing loudly if a field
-//     appears in neither.
+//  3. Two explicit field-name whitelists duplicated in this test file, with
+//     a separate test (TestProperty_EveryRunFieldIsClassified) asserting
+//     every field on Run appears in exactly one of them.
 //
-// Option 3 is what's implemented below, because it's the only one of the
-// three whose failure mode actually matches the goal. Consider the case
-// this exists to catch: someone adds a new field to Run, hashes it inside
-// Compute, but forgets to touch this test file. identityFieldNames doesn't
-// contain the new field's name, so TestProperty_EveryRunFieldIsClassified
-// fails immediately and loudly ("unclassified field") -- it can't be
-// silently treated as provenance, because the classification test runs
-// before either mutation test does. Now suppose instead they add it to
-// provenanceFieldNames by mistake, believing it's not hashed, when in fact
-// it is: TestProperty_MutatingAProvenanceFieldLeavesFingerprintUnchanged
-// mutates it, calls the *real* Compute, and fails because the fingerprint
-// actually changed. Either mistake is caught by exercising real behavior,
-// not by the whitelist agreeing with itself -- a struct tag or a parsed
-// comment would only have prevented the first mistake, not the second,
-// since both of those approaches would have happily believed whatever the
-// human wrote down.
+// This file used to implement option 3, because an earlier version of this
+// task was scoped not to touch run.go and so couldn't use option 1 at all.
+// That constraint no longer holds, and option 3's duplication was never the
+// point -- it was the fallback once the run.go edit wasn't available. Now
+// that it is, option 1 is strictly better: identityFieldNames and
+// provenanceFieldNames below are derived by reading each field's
+// `lineage:"identity"|"provenance"` struct tag via reflection, so run.go
+// stays the one place a human writes "this field is identity" down. The
+// tag can still say something false -- nothing about a tag stops a field
+// from being marked "provenance" while Compute quietly hashes it anyway --
+// which is why TestProperty_EveryRunFieldIsClassified remains the
+// loud-failure backstop below, and why the two mutation tests still call
+// the *real* Compute rather than trusting the tag: a field mistagged
+// "provenance" that Compute actually hashes is caught by
+// TestProperty_MutatingAProvenanceFieldLeavesFingerprintUnchanged mutating
+// it, calling Compute, and failing because the fingerprint moved. A struct
+// tag only prevents the *other* mistake (a field with no tag at all,
+// silently falling through); it cannot prevent a tag that lies, and this
+// file's mutation tests are what catches that one.
 
-var identityFieldNames = map[string]bool{
-	"Project": true, "GitCommit": true, "GitDirty": true, "ConfigHash": true,
-	"DatasetVersion": true, "ModelVersion": true, "Seed": true, "Params": true,
+// classifyRunFields reads every field's `lineage` struct tag off
+// lineage.Run and partitions field names into the two sets below. A field
+// with a missing or unrecognized tag value lands in neither set --
+// TestProperty_EveryRunFieldIsClassified is what turns that into a loud
+// failure instead of a silently-untested field.
+func classifyRunFields() (identity, provenance map[string]bool) {
+	identity, provenance = map[string]bool{}, map[string]bool{}
+	typ := reflect.TypeOf(Run{})
+	for i := 0; i < typ.NumField(); i++ {
+		f := typ.Field(i)
+		switch f.Tag.Get("lineage") {
+		case "identity":
+			identity[f.Name] = true
+		case "provenance":
+			provenance[f.Name] = true
+			// default (including ""): left unclassified on purpose --
+			// TestProperty_EveryRunFieldIsClassified is the only place that
+			// gets to decide what happens to an unclassified field.
+		}
+	}
+	return identity, provenance
 }
 
-var provenanceFieldNames = map[string]bool{
-	"RunID": true, "Fingerprint": true, "FingerprintVersion": true,
-	"Host": true, "Device": true, "FrameworkVersion": true,
-	"SubmitterClaim": true, "JobID": true, "Status": true,
-	"StartedAt": true, "EndedAt": true, "CheckpointURI": true, "Metrics": true,
-}
+var identityFieldNames, provenanceFieldNames = classifyRunFields()
 
 // TestProperty_EveryRunFieldIsClassified is the loud-failure backstop
 // described above: it must run (and be seen) before either mutation test
@@ -113,12 +123,12 @@ func TestProperty_EveryRunFieldIsClassified(t *testing.T) {
 		inProvenance := provenanceFieldNames[name]
 		switch {
 		case inIdentity && inProvenance:
-			t.Fatalf("field %q is listed in both identityFieldNames and provenanceFieldNames in run_property_test.go", name)
+			t.Fatalf("field %q is tagged as both identity and provenance -- impossible given classifyRunFields' switch, so this indicates a bug in classifyRunFields itself", name)
 		case !inIdentity && !inProvenance:
-			t.Fatalf("field %q on lineage.Run is not classified in run_property_test.go -- "+
-				"decide, from run.go's identity/provenance boundary comment and Compute's write() call, "+
-				"whether it is hashed into Fingerprint, and add it to identityFieldNames or "+
-				"provenanceFieldNames; an unclassified field must never be silently treated as provenance", name)
+			t.Fatalf("field %q on lineage.Run has no (or an unrecognized) `lineage:\"...\"` struct tag in run.go -- "+
+				"decide, from Compute's write() call, whether it is hashed into Fingerprint, and tag it "+
+				"`lineage:\"identity\"` or `lineage:\"provenance\"` there; an unclassified field must never be "+
+				"silently treated as provenance", name)
 		}
 	}
 }
@@ -220,16 +230,37 @@ func mutateField(t *testing.T, name string, v reflect.Value, rng *rand.Rand) ref
 		cur := v.Interface().(time.Time)
 		return reflect.ValueOf(cur.Add(time.Duration(1+rng.IntN(10000)) * time.Second))
 	case reflect.Ptr:
-		if v.Type() != reflect.TypeOf((*time.Time)(nil)) {
+		switch v.Type() {
+		case reflect.TypeOf((*time.Time)(nil)):
+			if v.IsNil() {
+				nt := time.Now().Add(time.Duration(rng.IntN(10000)) * time.Second)
+				return reflect.ValueOf(&nt)
+			}
+			cur := v.Interface().(*time.Time)
+			nt := cur.Add(time.Duration(1+rng.IntN(10000)) * time.Second)
+			return reflect.ValueOf(&nt)
+		case reflect.TypeOf((*CaptureDeclaration)(nil)):
+			// A nil Capture (no declaration at all) always differs from a
+			// non-nil one, so the nil case just needs *some* value; the
+			// non-nil case mutates Client, which is enough to guarantee
+			// inequality without needing to reason about Attempted's
+			// contents (CaptureFields' order doesn't matter to this test --
+			// only that the fingerprint doesn't move).
+			if v.IsNil() {
+				return reflect.ValueOf(&CaptureDeclaration{
+					Client:    "client-" + randString(rng, 6),
+					Attempted: []string{CaptureFields[rng.IntN(len(CaptureFields))]},
+				})
+			}
+			cur := v.Interface().(*CaptureDeclaration)
+			mutated := &CaptureDeclaration{
+				Client:    cur.Client + "-mut-" + randString(rng, 6),
+				Attempted: append([]string(nil), cur.Attempted...),
+			}
+			return reflect.ValueOf(mutated)
+		default:
 			t.Fatalf("mutateField: field %q is an unsupported pointer type %v -- extend run_property_test.go's mutator before this field can be classified", name, v.Type())
 		}
-		if v.IsNil() {
-			nt := time.Now().Add(time.Duration(rng.IntN(10000)) * time.Second)
-			return reflect.ValueOf(&nt)
-		}
-		cur := v.Interface().(*time.Time)
-		nt := cur.Add(time.Duration(1+rng.IntN(10000)) * time.Second)
-		return reflect.ValueOf(&nt)
 	default:
 		t.Fatalf("mutateField: field %q has kind %v, which run_property_test.go's mutator does not yet handle -- "+
 			"a field this test cannot mutate is a field it cannot prove is correctly classified as identity or "+
@@ -348,6 +379,12 @@ func cloneRun(r Run) Run {
 	if r.EndedAt != nil {
 		et := *r.EndedAt
 		c.EndedAt = &et
+	}
+	if r.Capture != nil {
+		c.Capture = &CaptureDeclaration{
+			Client:    r.Capture.Client,
+			Attempted: append([]string(nil), r.Capture.Attempted...),
+		}
 	}
 	return c
 }

--- a/internal/lineage/run_test.go
+++ b/internal/lineage/run_test.go
@@ -54,6 +54,71 @@ func TestFingerprintIgnoresAttribution(t *testing.T) {
 	}
 }
 
+// TestFingerprintIgnoresCapture pins the property ADR 0016 exists to
+// guarantee, alongside the generated coverage in
+// TestProperty_MutatingAProvenanceFieldLeavesFingerprintUnchanged: a capture
+// declaration describes the recording process, not the experiment, so a run
+// with one and an otherwise-identical run with none (or a different one)
+// must fingerprint identically.
+func TestFingerprintIgnoresCapture(t *testing.T) {
+	a, b := base(), base()
+	b.Capture = &CaptureDeclaration{
+		Client:    "runledger-py/0.1.0",
+		Attempted: []string{"host", "device", "framework_version"},
+	}
+	if a.Compute() != b.Compute() {
+		t.Fatal("adding a capture declaration changed the fingerprint; capture describes how the run was recorded, not what experiment it was")
+	}
+}
+
+func TestValidateRejectsUnknownCaptureField(t *testing.T) {
+	r := base()
+	r.Capture = &CaptureDeclaration{Client: "test/1", Attempted: []string{"device", "gpu_temperature"}}
+	if err := r.Validate(); err == nil {
+		t.Fatal("a capture declaration naming a field outside CaptureFields was accepted")
+	}
+}
+
+func TestValidateAcceptsEveryCaptureField(t *testing.T) {
+	r := base()
+	r.Capture = &CaptureDeclaration{Client: "test/1", Attempted: append([]string(nil), CaptureFields...)}
+	if err := r.Validate(); err != nil {
+		t.Fatalf("every name in CaptureFields should be a valid capture.attempted entry, got %v", err)
+	}
+}
+
+// TestNormalizeCaptureSortsAttempted pins the reason NormalizeCapture
+// exists: Attempted is a set, but a Store compares it as a concrete slice
+// (an idempotent re-record check, and DuckDB's own side-table round trip
+// with no inherent row order), so two semantically identical declarations
+// sent in different orders must normalize to one canonical order rather
+// than being told apart as if they disagreed.
+func TestNormalizeCaptureSortsAttempted(t *testing.T) {
+	r := base()
+	r.Capture = &CaptureDeclaration{Attempted: []string{"host", "device", "checkpoint_uri"}}
+	r.NormalizeCapture()
+	want := []string{"checkpoint_uri", "device", "host"}
+	if len(r.Capture.Attempted) != len(want) {
+		t.Fatalf("got %v, want %v", r.Capture.Attempted, want)
+	}
+	for i := range want {
+		if r.Capture.Attempted[i] != want[i] {
+			t.Fatalf("got %v, want %v", r.Capture.Attempted, want)
+		}
+	}
+}
+
+// TestNormalizeCaptureIsANoOpWithNoDeclaration guards the nil case:
+// NormalizeCapture must not panic, or manufacture a declaration, for a run
+// that never had one.
+func TestNormalizeCaptureIsANoOpWithNoDeclaration(t *testing.T) {
+	r := base()
+	r.NormalizeCapture()
+	if r.Capture != nil {
+		t.Fatalf("NormalizeCapture must not create a declaration where there was none, got %+v", r.Capture)
+	}
+}
+
 func TestFingerprintDistinguishesIdentityFields(t *testing.T) {
 	for name, mutate := range map[string]func(*Run){
 		"project":         func(r *Run) { r.Project = "other" },

--- a/internal/store/conformance.go
+++ b/internal/store/conformance.go
@@ -151,6 +151,130 @@ func RunConformance(t *testing.T, newStore func(t *testing.T) Store) {
 		}
 	})
 
+	t.Run("a capture declaration round-trips through Record/Get, and a run with none stays nil", func(t *testing.T) {
+		s := newStore(t)
+		declared := mk("a", "p", time.Now())
+		declared.Capture = &lineage.CaptureDeclaration{
+			Client:    "runledger-py/0.1.0",
+			Attempted: []string{"host", "device", "framework_version"},
+		}
+		declared.Fingerprint = declared.Compute()
+		if err := s.Record(ctx, declared); err != nil {
+			t.Fatal(err)
+		}
+		undeclared := mk("b", "p", time.Now())
+		if err := s.Record(ctx, undeclared); err != nil {
+			t.Fatal(err)
+		}
+
+		got, err := s.Get(ctx, "a")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Capture == nil || got.Capture.Client != "runledger-py/0.1.0" {
+			t.Fatalf("capture declaration did not round-trip: %+v", got.Capture)
+		}
+		wantAttempted := []string{"device", "framework_version", "host"} // canonical order
+		if len(got.Capture.Attempted) != len(wantAttempted) {
+			t.Fatalf("want attempted %v, got %v", wantAttempted, got.Capture.Attempted)
+		}
+		for i := range wantAttempted {
+			if got.Capture.Attempted[i] != wantAttempted[i] {
+				t.Fatalf("want attempted %v, got %v", wantAttempted, got.Capture.Attempted)
+			}
+		}
+
+		gotUndeclared, err := s.Get(ctx, "b")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if gotUndeclared.Capture != nil {
+			t.Fatalf("a run whose client sent no capture declaration must read back with Capture == nil, got %+v", gotUndeclared.Capture)
+		}
+
+		// The same distinction must survive List, not just Get -- List
+		// hydrates capture.attempted through a separate batched query
+		// (DuckDB), which is exactly the kind of thing that can silently
+		// diverge from Get's own path if only one of the two is exercised.
+		page, err := s.List(ctx, Query{Project: "p"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		byID := map[string]lineage.Run{}
+		for _, r := range page.Runs {
+			byID[r.RunID] = r
+		}
+		if byID["a"].Capture == nil || len(byID["a"].Capture.Attempted) != 3 {
+			t.Fatalf("List did not hydrate capture.attempted for %q: %+v", "a", byID["a"].Capture)
+		}
+		if byID["b"].Capture != nil {
+			t.Fatalf("List must not manufacture a capture declaration for %q, got %+v", "b", byID["b"].Capture)
+		}
+	})
+
+	t.Run("capture_client filters the listing", func(t *testing.T) {
+		s := newStore(t)
+		now := time.Now()
+		a := mk("a", "p", now)
+		a.Capture = &lineage.CaptureDeclaration{Client: "runledger-py/0.1.0", Attempted: []string{"host"}}
+		a.Fingerprint = a.Compute()
+		b := mk("b", "p", now.Add(-time.Minute))
+		b.Capture = &lineage.CaptureDeclaration{Client: "rlctl/0.1.0", Attempted: []string{"host"}}
+		b.Fingerprint = b.Compute()
+		if err := s.Record(ctx, a); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.Record(ctx, b); err != nil {
+			t.Fatal(err)
+		}
+		page, err := s.List(ctx, Query{Project: "p", CaptureClient: "runledger-py/0.1.0"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(page.Runs) != 1 || page.Runs[0].RunID != "a" {
+			t.Fatalf("capture_client filter did not narrow: %+v", page.Runs)
+		}
+	})
+
+	t.Run("re-recording a run with an equivalent, differently-ordered capture declaration is idempotent", func(t *testing.T) {
+		// Attempted is a set; a client library retrying a request has no
+		// reason to reorder it, but nothing about the type guarantees that,
+		// and a backend's own storage (a side table, in DuckDB's case) has
+		// no order of its own to begin with. This is the property
+		// NormalizeCapture exists to guarantee.
+		s := newStore(t)
+		r := mk("a", "p", time.Now())
+		r.Capture = &lineage.CaptureDeclaration{Attempted: []string{"host", "device", "framework_version"}}
+		r.Fingerprint = r.Compute()
+		if err := s.Record(ctx, r); err != nil {
+			t.Fatal(err)
+		}
+		reordered := r
+		reordered.Capture = &lineage.CaptureDeclaration{Attempted: []string{"framework_version", "device", "host"}}
+		if err := s.Record(ctx, reordered); err != nil {
+			t.Fatalf("re-recording with a reordered-but-equivalent capture declaration should be idempotent, got %v", err)
+		}
+	})
+
+	t.Run("update does not disturb a run's capture declaration", func(t *testing.T) {
+		s := newStore(t)
+		r := mk("a", "p", time.Now())
+		r.Status = lineage.StatusRunning
+		r.Capture = &lineage.CaptureDeclaration{Client: "runledger-py/0.1.0", Attempted: []string{"host"}}
+		r.Fingerprint = r.Compute()
+		if err := s.Record(ctx, r); err != nil {
+			t.Fatal(err)
+		}
+		succeeded := lineage.StatusSucceeded
+		got, err := s.Update(ctx, "a", Patch{Status: &succeeded})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Capture == nil || got.Capture.Client != "runledger-py/0.1.0" {
+			t.Fatalf("an unrelated patch must not disturb the run's capture declaration, got %+v", got.Capture)
+		}
+	})
+
 	t.Run("concurrent identical Record calls are idempotent", func(t *testing.T) {
 		s := newStore(t)
 		r := mk("a", "p", time.Now())

--- a/internal/store/duckdb.go
+++ b/internal/store/duckdb.go
@@ -144,6 +144,32 @@ var migrations = []string{
 	// applied atomically -- see migrate's per-entry transaction below.
 	`ALTER TABLE runs ADD COLUMN submitter_claim VARCHAR DEFAULT ''`,
 	`ALTER TABLE runs ADD COLUMN job_id VARCHAR DEFAULT ''`,
+	// ADR 0016: a capture declaration records what a client attempted to
+	// capture, not what it captured -- a fact about the recording process,
+	// never hashed, kept alongside the run the same way submitter_claim and
+	// job_id are. Two columns, not one: capture_declared is what lets a
+	// pre-migration row (or any run whose client never sends the field)
+	// read back with lineage.Run.Capture == nil rather than a declaration
+	// that merely happens to be empty -- those are different claims (see
+	// lineage.Run.Capture's doc comment), and completeness.py's
+	// peer-comparison fallback depends on telling them apart. DEFAULT
+	// FALSE / DEFAULT '' backfills every pre-existing row to exactly that
+	// "no declaration" state; NOT NULL is omitted for the same reason it is
+	// on every other ALTER TABLE ADD COLUMN in this slice -- this DuckDB
+	// build rejects an inline constraint on a new column.
+	`ALTER TABLE runs ADD COLUMN capture_declared BOOLEAN DEFAULT FALSE`,
+	`ALTER TABLE runs ADD COLUMN capture_client VARCHAR DEFAULT ''`,
+	// Attempted is a variable-length list of field names, not a scalar, so
+	// it gets a side table the same way Params and Metrics do -- a row per
+	// (run_id, field) rather than a JSON blob in a column, so a future
+	// "which runs attempted device" query is a real predicate. No value
+	// column: membership is the only fact this table records, the same
+	// shape a set takes when SQL has no native set type.
+	`CREATE TABLE IF NOT EXISTS run_capture_attempted (
+		run_id VARCHAR NOT NULL REFERENCES runs(run_id),
+		field  VARCHAR NOT NULL,
+		PRIMARY KEY (run_id, field)
+	)`,
 }
 
 func (d *DuckDB) migrate(ctx context.Context) error {
@@ -195,6 +221,13 @@ func (d *DuckDB) Record(ctx context.Context, r lineage.Run) error {
 	if err := r.Validate(); err != nil {
 		return err
 	}
+	// See lineage.Run.NormalizeCapture's doc comment: this backend in
+	// particular reads Capture.Attempted back from a side table with no
+	// row order of its own (see get(), below), so the incoming value must
+	// agree with that canonical order before the idempotency comparison a
+	// few lines down, or a byte-identical retry could be refused as a
+	// conflict purely because of ordering.
+	r.NormalizeCapture()
 
 	d.mu.Lock()
 	defer d.mu.Unlock()
@@ -220,17 +253,18 @@ func (d *DuckDB) Record(ctx context.Context, r lineage.Run) error {
 	if r.EndedAt != nil {
 		endedAt = r.EndedAt.UnixNano()
 	}
+	captureDeclared, captureClient := captureColumns(r.Capture)
 	_, err = tx.ExecContext(ctx, `
 		INSERT INTO runs (
 			run_id, project, git_commit, git_dirty, config_hash, dataset_version,
 			model_version, seed, fingerprint, fingerprint_version, host, device,
-			framework_version, submitter_claim, job_id, status, started_at_ns,
-			ended_at_ns, checkpoint_uri
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			framework_version, submitter_claim, job_id, capture_declared,
+			capture_client, status, started_at_ns, ended_at_ns, checkpoint_uri
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		r.RunID, r.Project, r.GitCommit, r.GitDirty, r.ConfigHash, r.DatasetVersion,
 		r.ModelVersion, r.Seed, r.Fingerprint, r.FingerprintVersion, r.Host, r.Device,
-		r.FrameworkVersion, r.SubmitterClaim, r.JobID, string(r.Status), r.StartedAt.UnixNano(),
-		endedAt, r.CheckpointURI,
+		r.FrameworkVersion, r.SubmitterClaim, r.JobID, captureDeclared, captureClient,
+		string(r.Status), r.StartedAt.UnixNano(), endedAt, r.CheckpointURI,
 	)
 	if err != nil {
 		return fmt.Errorf("inserting run: %w", err)
@@ -248,8 +282,29 @@ func (d *DuckDB) Record(ctx context.Context, r lineage.Run) error {
 			return fmt.Errorf("inserting metric %q: %w", k, err)
 		}
 	}
+	if r.Capture != nil {
+		for _, field := range r.Capture.Attempted {
+			if _, err := tx.ExecContext(ctx,
+				`INSERT INTO run_capture_attempted (run_id, field) VALUES (?, ?)`, r.RunID, field); err != nil {
+				return fmt.Errorf("inserting capture.attempted %q: %w", field, err)
+			}
+		}
+	}
 
 	return tx.Commit()
+}
+
+// captureColumns maps a (possibly nil) *lineage.CaptureDeclaration to the
+// two scalar columns runs stores it in. capture_declared is what carries
+// "no declaration at all" (nil) as a state distinct from "declared, with an
+// empty client name" (non-nil, Client == "") -- collapsing the two the way
+// ADR 0011 collapses "" and absent for the scalar fields would erase the
+// exact distinction ADR 0016 exists to make available.
+func captureColumns(c *lineage.CaptureDeclaration) (declared bool, client string) {
+	if c == nil {
+		return false, ""
+	}
+	return true, c.Client
 }
 
 // Update applies a partial, provenance-only change to an already-recorded
@@ -320,11 +375,11 @@ func (d *DuckDB) Get(ctx context.Context, runID string) (lineage.Run, error) {
 }
 
 func (d *DuckDB) get(ctx context.Context, q queryer, runID string) (lineage.Run, error) {
-	r, err := scanRun(q.QueryRowContext(ctx, `
+	r, captureDeclared, captureClient, err := scanRun(q.QueryRowContext(ctx, `
 		SELECT run_id, project, git_commit, git_dirty, config_hash, dataset_version,
 			model_version, seed, fingerprint, fingerprint_version, host, device,
-			framework_version, submitter_claim, job_id, status, started_at_ns,
-			ended_at_ns, checkpoint_uri
+			framework_version, submitter_claim, job_id, capture_declared,
+			capture_client, status, started_at_ns, ended_at_ns, checkpoint_uri
 		FROM runs WHERE run_id = ?`, runID))
 	if err != nil {
 		return lineage.Run{}, err
@@ -337,24 +392,31 @@ func (d *DuckDB) get(ctx context.Context, q queryer, runID string) (lineage.Run,
 		return lineage.Run{}, err
 	}
 	r.Metrics = metricsRaw
+	if captureDeclared {
+		attempted, err := loadCaptureAttempted(ctx, q, runID)
+		if err != nil {
+			return lineage.Run{}, err
+		}
+		r.Capture = &lineage.CaptureDeclaration{Client: captureClient, Attempted: attempted}
+	}
 	return r, nil
 }
 
-func scanRun(row *sql.Row) (lineage.Run, error) {
-	var r lineage.Run
+func scanRun(row *sql.Row) (r lineage.Run, captureDeclared bool, captureClient string, err error) {
 	var status string
 	var startedAtNS int64
 	var endedAtNS sql.NullInt64
-	err := row.Scan(
+	err = row.Scan(
 		&r.RunID, &r.Project, &r.GitCommit, &r.GitDirty, &r.ConfigHash, &r.DatasetVersion,
 		&r.ModelVersion, &r.Seed, &r.Fingerprint, &r.FingerprintVersion, &r.Host, &r.Device,
-		&r.FrameworkVersion, &r.SubmitterClaim, &r.JobID, &status, &startedAtNS, &endedAtNS, &r.CheckpointURI,
+		&r.FrameworkVersion, &r.SubmitterClaim, &r.JobID, &captureDeclared, &captureClient,
+		&status, &startedAtNS, &endedAtNS, &r.CheckpointURI,
 	)
 	if err == sql.ErrNoRows {
-		return lineage.Run{}, ErrNotFound
+		return lineage.Run{}, false, "", ErrNotFound
 	}
 	if err != nil {
-		return lineage.Run{}, err
+		return lineage.Run{}, false, "", err
 	}
 	r.Status = lineage.Status(status)
 	r.StartedAt = nsToTime(startedAtNS)
@@ -362,7 +424,31 @@ func scanRun(row *sql.Row) (lineage.Run, error) {
 		endedAt := nsToTime(endedAtNS.Int64)
 		r.EndedAt = &endedAt
 	}
-	return r, nil
+	return r, captureDeclared, captureClient, nil
+}
+
+// loadCaptureAttempted returns runID's capture.attempted list in a
+// canonical (lexical) order -- ORDER BY, not left to whatever order the
+// side table happens to scan in, for exactly the reason NormalizeCapture's
+// doc comment gives: this value is compared against a freshly-decoded,
+// NormalizeCapture-sorted Run during Record's idempotency check, and the
+// two orders must agree or a legitimate retry could misread as a conflict.
+func loadCaptureAttempted(ctx context.Context, q queryer, runID string) ([]string, error) {
+	rows, err := q.QueryContext(ctx,
+		`SELECT field FROM run_capture_attempted WHERE run_id = ? ORDER BY field`, runID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var field string
+		if err := rows.Scan(&field); err != nil {
+			return nil, err
+		}
+		out = append(out, field)
+	}
+	return out, rows.Err()
 }
 
 func loadKV(ctx context.Context, q queryer, table, runID string) (map[string]string, error) {
@@ -422,6 +508,15 @@ func (d *DuckDB) List(ctx context.Context, query Query) (Page, error) {
 	add("device", query.Device)
 	add("submitter_claim", query.SubmitterClaim)
 	add("job_id", query.JobID)
+	if query.CaptureClient != "" {
+		// Not add(): a run with no declaration at all stores
+		// capture_client = '' (the same default a legacy row backfills to),
+		// so a bare "capture_client = ?" predicate already excludes it
+		// correctly without needing a separate capture_declared check --
+		// an undeclared run can never equal a non-empty filter value.
+		where = append(where, "capture_client = ?")
+		args = append(args, query.CaptureClient)
+	}
 	if !query.Since.IsZero() {
 		where = append(where, "started_at_ns >= ?")
 		args = append(args, query.Since.UnixNano())
@@ -441,8 +536,8 @@ func (d *DuckDB) List(ctx context.Context, query Query) (Page, error) {
 	sqlStr := `
 		SELECT run_id, project, git_commit, git_dirty, config_hash, dataset_version,
 			model_version, seed, fingerprint, fingerprint_version, host, device,
-			framework_version, submitter_claim, job_id, status, started_at_ns,
-			ended_at_ns, checkpoint_uri
+			framework_version, submitter_claim, job_id, capture_declared,
+			capture_client, status, started_at_ns, ended_at_ns, checkpoint_uri
 		FROM runs`
 	if len(where) > 0 {
 		sqlStr += " WHERE " + strings.Join(where, " AND ")
@@ -469,10 +564,13 @@ func (d *DuckDB) List(ctx context.Context, query Query) (Page, error) {
 		var status string
 		var startedAtNS int64
 		var endedAtNS sql.NullInt64
+		var captureDeclared bool
+		var captureClient string
 		if err := rows.Scan(
 			&r.RunID, &r.Project, &r.GitCommit, &r.GitDirty, &r.ConfigHash, &r.DatasetVersion,
 			&r.ModelVersion, &r.Seed, &r.Fingerprint, &r.FingerprintVersion, &r.Host, &r.Device,
-			&r.FrameworkVersion, &r.SubmitterClaim, &r.JobID, &status, &startedAtNS, &endedAtNS, &r.CheckpointURI,
+			&r.FrameworkVersion, &r.SubmitterClaim, &r.JobID, &captureDeclared, &captureClient,
+			&status, &startedAtNS, &endedAtNS, &r.CheckpointURI,
 		); err != nil {
 			rows.Close()
 			return Page{}, err
@@ -482,6 +580,12 @@ func (d *DuckDB) List(ctx context.Context, query Query) (Page, error) {
 		if endedAtNS.Valid {
 			endedAt := nsToTime(endedAtNS.Int64)
 			r.EndedAt = &endedAt
+		}
+		if captureDeclared {
+			// Attempted is filled in below by hydrateCaptureAttempted, in one
+			// batched query for the whole page rather than one per run --
+			// the same reasoning hydrate (params/metrics) already follows.
+			r.Capture = &lineage.CaptureDeclaration{Client: captureClient}
 		}
 		runs = append(runs, r)
 		runIDs = append(runIDs, r.RunID)
@@ -500,10 +604,14 @@ func (d *DuckDB) List(ctx context.Context, query Query) (Page, error) {
 		next = &Cursor{StartedAt: last.StartedAt, RunID: last.RunID}
 	}
 
-	// Hydrate params/metrics for the page in two batched queries rather than
-	// one round trip per run -- List answers "every run of this project",
-	// which is exactly the case with the most rows to hydrate.
+	// Hydrate params/metrics/capture.attempted for the page in batched
+	// queries rather than one round trip per run -- List answers "every run
+	// of this project", which is exactly the case with the most rows to
+	// hydrate.
 	if err := hydrate(ctx, d.db, runs, runIDs); err != nil {
+		return Page{}, err
+	}
+	if err := hydrateCaptureAttempted(ctx, d.db, runs, runIDs); err != nil {
 		return Page{}, err
 	}
 	return Page{Runs: runs, Next: next}, nil
@@ -570,6 +678,49 @@ func hydrate(ctx context.Context, q queryer, runs []lineage.Run, runIDs []string
 	}
 	mrows.Close()
 	return nil
+}
+
+// hydrateCaptureAttempted fills in Capture.Attempted for every run in the
+// page that has a capture declaration (Capture != nil, stamped by List's
+// row scan from capture_declared), the same batched-query shape hydrate
+// uses for params and metrics. ORDER BY field, for the reason
+// loadCaptureAttempted's doc comment gives: this must agree with
+// NormalizeCapture's canonical order.
+func hydrateCaptureAttempted(ctx context.Context, q queryer, runs []lineage.Run, runIDs []string) error {
+	if len(runIDs) == 0 {
+		return nil
+	}
+	byID := make(map[string]int, len(runs))
+	for i, r := range runs {
+		byID[r.RunID] = i
+	}
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(runIDs)), ",")
+	args := make([]any, len(runIDs))
+	for i, id := range runIDs {
+		args[i] = id
+	}
+
+	rows, err := q.QueryContext(ctx, fmt.Sprintf(
+		`SELECT run_id, field FROM run_capture_attempted WHERE run_id IN (%s) ORDER BY field`, placeholders), args...)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id, field string
+		if err := rows.Scan(&id, &field); err != nil {
+			return err
+		}
+		i := byID[id]
+		if runs[i].Capture == nil {
+			// Defensive only: Record never writes a run_capture_attempted
+			// row without also setting capture_declared, so this should be
+			// unreachable against data this backend itself wrote.
+			continue
+		}
+		runs[i].Capture.Attempted = append(runs[i].Capture.Attempted, field)
+	}
+	return rows.Err()
 }
 
 func (d *DuckDB) Close() error {

--- a/internal/store/duckdb_test.go
+++ b/internal/store/duckdb_test.go
@@ -215,6 +215,71 @@ func TestDuckDBLegacyRowsDefaultAttributionToEmptyString(t *testing.T) {
 	}
 }
 
+// TestDuckDBLegacyRowsHaveNoCaptureDeclaration exercises the ADR 0016
+// migration the same way the two tests above exercise ADR 0013's and ADR
+// 0015's: simulate a database that predates capture_declared/capture_client
+// (everything through the job_id migration, migrations[7], but no
+// further), insert a row directly, then open it through NewDuckDB and
+// confirm the row reads back with Capture == nil -- not a declaration that
+// merely happens to be empty. That distinction is the entire reason
+// capture_declared is a separate column rather than inferring "no
+// declaration" from capture_client == "": a pre-migration row and a
+// modern client that declares an empty capture must not become
+// indistinguishable, because examples/churn/completeness.py's
+// peer-comparison fallback depends on telling them apart (see
+// lineage.Run.Capture's doc comment and ADR 0016).
+func TestDuckDBLegacyRowsHaveNoCaptureDeclaration(t *testing.T) {
+	ctx := context.Background()
+	dsn := filepath.Join(t.TempDir(), "runs.duckdb")
+
+	preMigration, err := sql.Open("duckdb", dsn)
+	if err != nil {
+		t.Fatalf("opening pre-migration duckdb: %v", err)
+	}
+	if _, err := preMigration.ExecContext(ctx, `CREATE TABLE schema_migrations (version INTEGER PRIMARY KEY)`); err != nil {
+		t.Fatalf("creating schema_migrations: %v", err)
+	}
+	for _, i := range []int{0, 5, 6, 7} {
+		if _, err := preMigration.ExecContext(ctx, migrations[i]); err != nil {
+			t.Fatalf("applying migrations[%d]: %v", i, err)
+		}
+		if _, err := preMigration.ExecContext(ctx, `INSERT INTO schema_migrations (version) VALUES (?)`, i); err != nil {
+			t.Fatalf("recording migrations[%d] as applied: %v", i, err)
+		}
+	}
+	_, err = preMigration.ExecContext(ctx, `
+		INSERT INTO runs (
+			run_id, project, git_commit, git_dirty, config_hash, dataset_version,
+			model_version, seed, fingerprint, fingerprint_version, host, device,
+			framework_version, submitter_claim, job_id, status, started_at_ns,
+			ended_at_ns, checkpoint_uri
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		"legacy-run", "p", "c1", false, "cfg", "", "", 0,
+		"fp", lineage.CurrentFingerprintVersion, "", "", "", "", "",
+		string(lineage.StatusSucceeded), time.Now().UnixNano(), nil, "",
+	)
+	if err != nil {
+		t.Fatalf("inserting pre-migration row: %v", err)
+	}
+	if err := preMigration.Close(); err != nil {
+		t.Fatalf("closing pre-migration handle: %v", err)
+	}
+
+	s, err := NewDuckDB(dsn)
+	if err != nil {
+		t.Fatalf("NewDuckDB against a pre-migration database: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	got, err := s.Get(ctx, "legacy-run")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Capture != nil {
+		t.Fatalf("want a pre-migration row to read back with Capture == nil (no declaration, not an empty one), got %+v", got.Capture)
+	}
+}
+
 func TestDuckDBMigrateIsIdempotent(t *testing.T) {
 	dsn := filepath.Join(t.TempDir(), "runs.duckdb")
 	s, err := NewDuckDB(dsn)

--- a/internal/store/memory.go
+++ b/internal/store/memory.go
@@ -26,6 +26,13 @@ func (m *Memory) Record(_ context.Context, r lineage.Run) error {
 	if err := r.Validate(); err != nil {
 		return err
 	}
+	// See lineage.Run.NormalizeCapture's doc comment: Attempted is
+	// conceptually a set, but the idempotency check just below compares the
+	// whole struct with reflect.DeepEqual, which is order-sensitive for a
+	// slice. Without this, a retried request whose client happened to build
+	// Attempted in a different (but equal-as-a-set) order would be refused
+	// as a conflict for a reason that has nothing to do with what changed.
+	r.NormalizeCapture()
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if existing, ok := m.runs[r.RunID]; ok {
@@ -87,6 +94,9 @@ func (m *Memory) List(_ context.Context, q Query) (Page, error) {
 			continue
 		}
 		if q.JobID != "" && r.JobID != q.JobID {
+			continue
+		}
+		if q.CaptureClient != "" && (r.Capture == nil || r.Capture.Client != q.CaptureClient) {
 			continue
 		}
 		if !q.Since.IsZero() && r.StartedAt.Before(q.Since) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -67,6 +67,14 @@ type Query struct {
 	// asks for.
 	SubmitterClaim string
 	JobID          string
+	// CaptureClient filters to runs whose capture declaration names this
+	// exact client string (e.g. "runledger-py/0.1.0") -- the query ADR 0016
+	// names directly: "did capture regress in client X.Y" needs to isolate
+	// every run that client recorded, the same exact-match shape Device
+	// already has. A run with no capture declaration never matches a
+	// non-empty CaptureClient, the same way an unset Device never matches a
+	// non-empty filter.
+	CaptureClient string
 	// Limit caps the number of rows a single List call returns. Zero means
 	// unbounded — callers that page (the HTTP API's GET /runs) are expected
 	// to supply their own default and maximum; Store itself imposes none, so
@@ -144,6 +152,22 @@ type Patch struct {
 	SubmitterClaim *string
 	JobID          *string
 	Metrics        map[string]float64
+
+	// Capture (lineage.Run.Capture, ADR 0016) is deliberately not here, and
+	// that is a decision, not an oversight. Host, Device, and JobID are
+	// patchable because a run is often recorded before every fact about it
+	// is known -- a device only knowable once a job schedules onto specific
+	// hardware, a job id assigned by the scheduler after submission. A
+	// capture declaration has no such deferred-availability case: it
+	// describes what the recording client's own code tried to determine,
+	// which the client already knows in full at the moment it makes the
+	// very first request for a run (rlctl and the Python client both build
+	// it before sending anything). There is no legitimate "fill this in
+	// once known" scenario to support, and allowing one would raise a
+	// question patchability for the other fields never has to answer: whose
+	// declaration is it if a different call patches it in later? Leaving
+	// Capture out keeps it what it is by construction -- a fact about the
+	// request that created the run, fixed at that moment.
 }
 
 // Store is the persistence boundary.

--- a/python/runledger/_run.py
+++ b/python/runledger/_run.py
@@ -120,6 +120,14 @@ from .read import API_VERSION
 
 DEFAULT_SERVER = "http://localhost:8080"
 DEFAULT_TIMEOUT = 10.0
+# Reported as capture.client (ADR 0016): "did capture regress in client
+# X.Y" needs each run to say what its own client tried, and the version
+# string is how a reader finds every run one client version recorded.
+# Duplicated from runledger.__version__ rather than imported from it:
+# __init__.py imports this module (``from ._run import ...``) before it
+# assigns __version__, so importing it back here would reach into a
+# partially-initialized package and fail. Bump both together.
+_CLIENT_VERSION = "0.1.0"
 # Left unexpanded on purpose. Expanding at import time baked the building
 # machine's home directory into the default, which then rendered as an
 # absolute path in help(), IDE tooltips, and the published pdoc page -- and,
@@ -410,6 +418,20 @@ class Run:
             "host": socket.gethostname(),
             "device": _provenance.device_name(),
             "framework_version": _provenance.framework_version(),
+            # ADR 0016: a capture declaration records what this client
+            # *tried* to capture, not what it found -- the fact that
+            # distinguishes "asked and got nothing" from "never asked",
+            # which device_name()'s own "" return can't carry on its own
+            # (see its docstring, and #66). host/device/framework_version
+            # are unconditionally attempted, immediately above, every time
+            # this payload is built -- not sometimes, depending on flags or
+            # environment the way rlctl's --device/--dataset/etc. are -- so
+            # all three always belong in attempted, regardless of whether
+            # any of them actually came back empty.
+            "capture": {
+                "client": f"runledger-py/{_CLIENT_VERSION}",
+                "attempted": ["host", "device", "framework_version"],
+            },
         }
         if self.params:
             # The wire schema's Params is map[string]string (lineage.Run) --

--- a/python/tests/test_run.py
+++ b/python/tests/test_run.py
@@ -298,9 +298,53 @@ class RunRecordingTests(unittest.TestCase):
         self.assertEqual(finish_call["path"], "/v1/runs/fake-run-id")
         self.assertEqual(finish_call["payload"]["status"], "succeeded")
         self.assertEqual(finish_call["payload"]["metrics"], {"loss": 0.5, "acc": 0.8})
+
+    def test_start_payload_declares_capture(self):
+        # ADR 0016: the client reports what it attempted to capture, not
+        # just what it captured -- this pins the exact declaration
+        # runledger-py sends. host/device/framework_version are
+        # unconditionally attempted by this client (see
+        # _identity_and_provenance's comment), exactly the issue's own
+        # worked example.
+        with _clean_git(), _FakeLedger() as ledger:
+            with runledger.Run.start(project="demo", server=ledger.addr):
+                pass
+
+        self.assertEqual(len(ledger.received), 2)
+        start_call, finish_call = ledger.received
+        capture = start_call["payload"]["capture"]
+        self.assertEqual(capture["client"], f"runledger-py/{runledger.__version__}")
+        self.assertEqual(
+            sorted(capture["attempted"]), ["device", "framework_version", "host"]
+        )
+        # The terminal PATCH carries only what changed (status, ended_at,
+        # metrics) -- capture is not patchable (ADR 0016: the client already
+        # knows its own capture behaviour in full at record time, so there
+        # is no "fill this in later" case to support), and this client
+        # never tries to send it there.
+        self.assertNotIn("capture", finish_call["payload"])
         self.assertIn("ended_at", finish_call["payload"])
         self.assertNotIn(
             "project", finish_call["payload"], "PATCH only carries what changed"
+        )
+
+    def test_fallback_full_record_also_declares_capture(self):
+        # When the start-time POST never lands, _record_whole_run() sends
+        # one full POST built from the same _identity_and_provenance() --
+        # the fallback path must declare capture too, not just the common
+        # case.
+        with _clean_git(), _FakeLedger() as ledger:
+            with mock.patch.object(
+                run_module.Run, "_record_start", lambda self: None
+            ):
+                with runledger.Run.start(project="demo", server=ledger.addr):
+                    pass
+
+        self.assertEqual(len(ledger.received), 1, "no start-time POST landed, so one fallback POST")
+        capture = ledger.received[0]["payload"]["capture"]
+        self.assertEqual(capture["client"], f"runledger-py/{runledger.__version__}")
+        self.assertEqual(
+            sorted(capture["attempted"]), ["device", "framework_version", "host"]
         )
 
     def test_failure_records_failed_with_partial_metrics_and_reraises(self):


### PR DESCRIPTION
Fixes #68

## Summary

Adds `lineage.Run.Capture` (`*CaptureDeclaration{Client, Attempted}`), a
capture declaration recorded alongside the run and outside the fingerprint
-- never hashed by `Compute`. `device: ""` with `"device"` in `Attempted`
means the client looked and found nothing; `device: ""` with `"device"`
absent means the client never looks at all. Neither claim is expressible by
widening `Device` itself, which is why this is ADR 0016, not an edit to
ADR 0011.

**Framing note, per the issue's own reasoning:** issue #68 argues at length
that this should *not* be built yet -- none of its three named triggers (a
gate, fleet scale, cross-client-version attribution) has fired. ADR 0016
quotes that reasoning rather than skip past it. This PR exists because the
repository owner asked for it directly, having read that caution -- which
the issue itself treats as a legitimate way for "not yet" to become "now".
It is not a claim that the original caution was wrong.

## What changed

- **`internal/lineage`**: `Capture *CaptureDeclaration`, tagged
  `lineage:"provenance"`; `CaptureFields` whitelist; `Validate` rejects an
  unknown `attempted` name; `NormalizeCapture` canonicalizes `Attempted`'s
  order. The identity/provenance split in `run_property_test.go` is now
  *derived* from `lineage:"identity"|"provenance"` struct tags on `Run`
  via reflection, replacing a hand-duplicated whitelist -- an earlier pass
  wanted this and was scoped not to touch `run.go`; this one isn't.
- **`internal/compare`**: `capture.client` / `capture.attempted` reported
  as `KindProvenance` diffs; `attempted` is compared as a sorted set.
- **`internal/store`**: `Memory` and `DuckDB` both persist and round-trip
  declarations (`DuckDB`: `capture_declared`/`capture_client` columns +
  `run_capture_attempted` side table, migrations appended, `DEFAULT` not
  `NOT NULL`). New `conformance.go` subtests both backends pass. **Not**
  patchable -- see `store.Patch`'s doc comment for why.
- **`internal/api`** + **`docs/openapi.yaml`**: `GET /v1/runs?capture_client=`
  filter; `CaptureDeclaration` schema; `capture` on `Run`/`RunInput`, not
  `RunPatch`.
- **`rlctl`**: declares `Attempted: ["host"]` (the one field it
  auto-detects); `--capture-client` list filter.
- **Python client**: declares `Attempted: ["host", "device",
  "framework_version"]` on every write -- the issue's own worked example.
- **`examples/churn/completeness.py`**: a run with a declaration is never
  flagged by the peer-comparison heuristic (`odd_ones_out`) -- it states
  the fact the heuristic used to guess at. New `declared_blind_spots` is
  the ground-truth counterpart of the pipeline-level `blind_spots` signal.
  The heuristic itself is unchanged for runs with no declaration (most
  existing runs).
- **`docs/adr/0016-...md`**: full reasoning, including the "not yet"
  framing above.

## Decisions worth flagging

- **Not patchable.** A capture declaration describes what the client's own
  code tried, which it knows in full at record time -- no "fill this in
  later" case the way `host`/`device`/`job_id` have.
- **Filterable** by `capture_client` (exact match) -- the "did capture
  regress in client X.Y" query the issue names directly. **Not** wired
  into `spread.provenanceFields`: which client recorded a run isn't itself
  a plausible cause of a metric spread the way `device`/`framework_version`
  are.
- **`compare.Runs`** reports it as provenance, never identity.

## Testing

`go build ./... && go vet ./... && go test -race ./...`, `gofmt -l .`,
`python3 -m unittest discover -s python/tests`, `-s dashboard/tests`,
`-s examples/churn`, and `make example` all pass. No golden files
(`cmd/rlctl/testdata/*.golden`) changed -- `Capture` is `omitempty` and
none of the existing fixtures set it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
