### PR TITLE
ci: preserve Docker runner fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     # have a non-nested Docker daemon; a container-based runner fails here with
     # "make: docker: No such file or directory", which is a structural
     # incompatibility rather than a flake.
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.USE_SELF_HOSTED_RUNNER == 'true' && github.event.repository.private && '["self-hosted","Linux","wsl"]' || '["ubuntu-latest"]') }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -16,7 +16,7 @@ jobs:
     # GitHub-hosted; see ci.yml's `build` job for the reasoning. This job also
     # runs a real `docker build` (multi-arch, via buildx + QEMU), so whatever
     # runs it needs a non-nested Docker daemon.
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.USE_SELF_HOSTED_RUNNER == 'true' && github.event.repository.private && '["self-hosted","Linux","wsl"]' || '["ubuntu-latest"]') }}
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
Updates the two Docker-dependent jobs to use the documented WSL-pinned, private-repository-gated runner expression with an ubuntu-latest fallback.

- ci.yml: build job (make image)
- image.yml: publish job (Buildx/QEMU)
- Preserves permissions, triggers, comments, and all other workflow behavior.

Validation: actionlint; git diff --check.