### PR TITLE
Revert #87: the self-hosted runner expression is dead code on a public repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     # have a non-nested Docker daemon; a container-based runner fails here with
     # "make: docker: No such file or directory", which is a structural
     # incompatibility rather than a flake.
-    runs-on: ${{ fromJSON(vars.USE_SELF_HOSTED_RUNNER == 'true' && github.event.repository.private && '["self-hosted","Linux","wsl"]' || '["ubuntu-latest"]') }}
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -16,7 +16,7 @@ jobs:
     # GitHub-hosted; see ci.yml's `build` job for the reasoning. This job also
     # runs a real `docker build` (multi-arch, via buildx + QEMU), so whatever
     # runs it needs a non-nested Docker daemon.
-    runs-on: ${{ fromJSON(vars.USE_SELF_HOSTED_RUNNER == 'true' && github.event.repository.private && '["self-hosted","Linux","wsl"]' || '["ubuntu-latest"]') }}
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v5

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ docker compose up
 That builds the image from the `Dockerfile` and starts `runledger` on `:8080`
 with the durable DuckDB backend (`internal/store.DuckDB`), the database file
 on a persistent volume at `/data/runs.duckdb`. Published images land on
-`ghcr.io/lurking-walrus/run-ledger` on tagged releases; `make image` builds
+`ghcr.io/kornsour/run-ledger` on tagged releases; `make image` builds
 the same image locally for the host platform.
 
 Running `./bin/runledger` directly still defaults to the in-memory store --


### PR DESCRIPTION
Reverts the `runs-on` change from #87 and fixes a stale registry path in the
README. Both Docker-dependent jobs go back to a plain `ubuntu-latest`.

## The expression cannot select a self-hosted runner here

Two independent conditions make it dead:

- `github.event.repository.private` is **false** for a public repo, so the
  `&&` chain short-circuits and every evaluation yields `["ubuntu-latest"]`.
- `vars.USE_SELF_HOSTED_RUNNER` is an **org** variable that does not exist
  under this personal account, so the first term is false as well.

Either one alone is sufficient. #87 changed nothing about which machine runs
these jobs.

## What it did change is what the file implies

`5dde8dc` removed this expression two days before #87 restored it, on stated
security grounds:

> Keeping it implied the fleet was one config flip away from taking these
> jobs, which for a public repo it must never be — a fork PR would then
> execute on self-hosted hardware.

That reasoning did not stop holding. The repo is still public, and a fork's
`pull_request` still runs untrusted code.

#87 also left the expression sitting directly beneath the comment `5dde8dc`
wrote to replace it — which says GitHub-hosted is *"not negotiable while this
repo is public"*. The file asserted one thing in prose and configured another.

## Nothing is lost

#87's stated goal was a working Docker daemon for `make image` and the
multi-arch buildx publish. `ubuntu-latest` provides one unconditionally.

The comments explaining **why** a non-nested Docker daemon is a real
requirement of these jobs are untouched. That is the durable half of what #87
was protecting, and it holds independent of which label satisfies it.

## The README fix

`README.md` advertised published images at `ghcr.io/lurking-walrus/run-ledger`.
`image.yml` pushes to `ghcr.io/${{ github.repository }}` — i.e.
`ghcr.io/kornsour/run-ledger`. So the line was both factually wrong and still
pointing at the org this repo left. `5dde8dc` cleaned that pointer out of the
workflows and missed the README.

It was the only cross-org reference remaining anywhere in the tree.

## Checks

- `actionlint` clean on both workflows
- Both workflow files are **byte-identical** to their pre-#87 state (327ef68)
- Full sweep of the working tree *and* git history found no secrets, tokens,
  private keys, credentials, private IPs, internal hostnames, or leaked local
  paths — this repo went public recently, so history is exposed too

### If this is wrong

The one scenario where #87's expression does something is this repo going
**private** again. If that is planned, say so and this should not merge — but
note the expression would still need a repo-level `USE_SELF_HOSTED_RUNNER`
variable, since the org one is not reachable from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
